### PR TITLE
docs(adr): add pre-written amendment block for ADR-0017

### DIFF
--- a/docs/adr/ADR-0017-vm-request-flow-clarification.md
+++ b/docs/adr/ADR-0017-vm-request-flow-clarification.md
@@ -166,6 +166,30 @@ Admin can:
 | `01-contracts.md` | VM creation flow | Document correct request structure |
 | `04-governance.md` | Approval workflow | Document admin cluster selection |
 
+> **ADR Immutability Principle**: Upon acceptance of ADR-0017, append the following block to ADR-0015 (do NOT modify original content).
+
+**Amendment Block to Append** (at end of ADR-0015):
+
+```markdown
+---
+
+## Amendments by Subsequent ADRs
+
+> ⚠️ **Notice**: The following sections of this ADR have been amended by subsequent ADRs.
+> The original decisions above remain **unchanged for historical reference**.
+> When implementing, please refer to the amending ADRs for current design.
+
+### ADR-0017: VM Request Flow Clarification (2026-01-22)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §4. VMCreateRequest: `ClusterID string binding:"required"` | **REMOVED** | User does NOT provide ClusterID. Admin selects target cluster during approval workflow. | [ADR-0017](./ADR-0017-vm-request-flow-clarification.md) |
+
+> **Rationale**: Separation of concerns - Users submit business requests (service, template, namespace); Administrators determine infrastructure decisions (cluster, storage class).
+
+---
+```
+
 ### API Changes
 
 | Endpoint | Change |
@@ -190,3 +214,4 @@ Admin can:
 |------|--------|
 | 2026-01-22 | Initial draft, amending ADR-0015 §4 |
 | 2026-01-26 | Submitted as formal proposal with 48-hour review period (Issue #15) |
+| 2026-01-26 | Added: Pre-written "Amendments by Subsequent ADRs" block for ADR-0015 (to be appended upon ADR-0017 acceptance) |


### PR DESCRIPTION
## Summary

This PR adds the pre-written amendment block for **ADR-0017: VM Request Flow Clarification**.

Follows the ADR Immutability Principle established in project governance.

## Changes

### ADR-0017: Pre-written Amendment Block

Added the "Amendments by Subsequent ADRs" block that will be appended to ADR-0015 upon ADR-0017 acceptance:

| Original Section | Status | Amendment Details |
|------------------|--------|-------------------|
| §4. VMCreateRequest: `ClusterID` | **REMOVED** | User does NOT provide ClusterID. Admin selects target cluster during approval workflow. |

**Rationale**: Separation of concerns - Users submit business requests (service, template, namespace); Administrators determine infrastructure decisions (cluster, storage class).

## Related Issue

Refs #15

## Type of Change

- [x] 📚 Documentation update

## Checklist

### Documentation
- [x] I have updated relevant documentation
- [x] Breaking changes are documented with migration guides

### Architecture
- [x] My changes comply with existing [ADRs](docs/adr/)
- [x] ADR Immutability Principle followed (append-only amendments)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.