### PR TITLE
docs(rfc): add V1.5 in-process caching alternative to RFC-0007

### DIFF
--- a/docs/rfc/RFC-0007-redis-cache.md
+++ b/docs/rfc/RFC-0007-redis-cache.md
@@ -26,6 +26,70 @@ In V1.0 architecture simplification, Redis dependency was completely removed:
 | Task queue | River Queue | PostgreSQL native |
 | Cluster state cache | Ent local query + sync.Map | Low-frequency access |
 
+### V1.5 Alternative: In-Process Cache (Before Redis)
+
+If performance bottlenecks emerge but do not yet justify Redis complexity, consider **in-process caching** as an intermediate step:
+
+| Library | Best For | GC Impact | Features |
+|---------|----------|-----------|----------|
+| **ristretto** | High hit-ratio scenarios | Low | Cost-based eviction, TinyLFU admission |
+| **bigcache** | Large data volumes | Minimal | Custom memory management, sharding |
+| **go-cache** | Simple use cases | Standard | TTL support, easy API |
+
+**Recommended: ristretto** for Shepherd due to:
+- Cost-based eviction (larger items can have higher cost)
+- High hit ratio with TinyLFU algorithm
+- Generics support (v2.x)
+
+**Implementation Pattern:**
+
+```go
+// internal/cache/cached_repository.go
+
+type CachedInstanceSizeRepo struct {
+    next  repository.InstanceSizeRepository
+    cache *ristretto.Cache[string, *ent.InstanceSize]
+    ttl   time.Duration
+}
+
+func NewCachedInstanceSizeRepo(next repository.InstanceSizeRepository) *CachedInstanceSizeRepo {
+    cache, _ := ristretto.NewCache(&ristretto.Config[string, *ent.InstanceSize]{
+        NumCounters: 1e4,     // 10,000 keys to track
+        MaxCost:     1 << 20, // 1MB max
+        BufferItems: 64,
+    })
+    return &CachedInstanceSizeRepo{next: next, cache: cache, ttl: 5 * time.Minute}
+}
+
+func (r *CachedInstanceSizeRepo) GetByName(ctx context.Context, name string) (*ent.InstanceSize, error) {
+    if cached, found := r.cache.Get(name); found {
+        return cached, nil
+    }
+    
+    is, err := r.next.GetByName(ctx, name)
+    if err != nil {
+        return nil, err
+    }
+    
+    r.cache.SetWithTTL(name, is, 1, r.ttl)
+    return is, nil
+}
+
+// Invalidation hook - call on write operations
+func (r *CachedInstanceSizeRepo) Invalidate(name string) {
+    r.cache.Del(name)
+}
+```
+
+**When to Use In-Process Cache:**
+- Single replica deployment OR cache-miss is acceptable during rolling updates
+- Data changes infrequently (InstanceSize list, KubeVirt schema)
+- QPS < 1000 per resource (above this, consider Redis)
+
+**When NOT to Use:**
+- Multi-replica deployment with strict consistency requirements
+- Data changes frequently and must be immediately consistent across pods
+
 ---
 
 ## Trigger Conditions


### PR DESCRIPTION
## Summary

This PR updates **RFC-0007: Redis Cache** with a V1.5 in-process caching alternative before adopting Redis.

## Context

RFC-0007 is currently in "Deferred" status. This update adds an intermediate solution when performance bottlenecks emerge but don't yet justify Redis complexity.

## Changes

Added "V1.5 Alternative: In-Process Cache" section:

| Library | Best For | GC Impact | Features |
|---------|----------|-----------|----------|
| **ristretto** | High hit-ratio scenarios | Low | Cost-based eviction, TinyLFU admission |
| **bigcache** | Large data volumes | Minimal | Custom memory management, sharding |
| **go-cache** | Simple use cases | Standard | TTL support, easy API |

## Recommendation

**ristretto** is recommended for Shepherd due to:
- Cost-based eviction (larger items = higher cost)
- High hit ratio with TinyLFU algorithm
- Generics support (v2.x)

## Implementation Pattern

Includes a `CachedRepository` decorator pattern example for wrapping existing repositories.

## Trigger Conditions

- ✅ **Use when**: Single replica, low-frequency changes, QPS < 1000
- ❌ **Don't use when**: Multi-replica with strict consistency, frequent updates

---

**Author**: @jindyzhao