### PR TITLE
docs(adr-0018): sync design documents with Instance Size Abstraction

### DIFF
--- a/docs/design/examples/domain/instance_size.go
+++ b/docs/design/examples/domain/instance_size.go
@@ -1,0 +1,115 @@
+// Package domain provides example domain entities for KubeVirt Shepherd.
+//
+// This file defines the InstanceSize entity per ADR-0018.
+// InstanceSize abstracts KubeVirt VM resource configuration.
+//
+// Reference: docs/adr/ADR-0018-instance-size-abstraction.md
+
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+// InstanceSize represents a predefined VM resource configuration.
+// Admin-managed entity that defines CPU, Memory, and optional overcommit settings.
+//
+// Key Design Decisions (ADR-0018):
+// - Name is globally unique (index.Fields("name").Unique())
+// - spec_overrides stores KubeVirt-specific configuration as JSONB
+// - Immutability: VMs snapshot InstanceSize at approval time (changes don't affect existing VMs)
+type InstanceSize struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"` // Globally unique, e.g., "small", "medium-gpu"
+	Description string `json:"description,omitempty"`
+
+	// Core scheduling fields (indexed for query performance)
+	CPU         int `json:"cpu"`       // Logical CPUs
+	MemoryMB    int `json:"memory_mb"` // Memory in MB
+	GPUCount    int `json:"gpu_count,omitempty"`
+	HugepagesGB int `json:"hugepages_gb,omitempty"`
+
+	// Overcommit settings (ADR-0018 §5)
+	CPUOvercommit float64 `json:"cpu_overcommit,omitempty"` // e.g., 0.5 = 50% of limit
+	MemOvercommit float64 `json:"mem_overcommit,omitempty"` // e.g., 0.8 = 80% of limit
+
+	// KubeVirt-specific configuration (JSONB in backend)
+	// Contains: dedicatedCpuPlacement, isolateEmulatorThread, ioThreadsPolicy, etc.
+	SpecOverrides map[string]interface{} `json:"spec_overrides,omitempty"`
+
+	// Metadata
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// OvercommitConfig defines overcommit settings that can be used
+// in both InstanceSize and ApprovalTicket (admin override).
+type OvercommitConfig struct {
+	// CPURatio: request = limit * CPURatio (e.g., 0.5 = 50%)
+	// 1.0 = Guaranteed QoS (no overcommit)
+	// <1.0 = Burstable QoS
+	CPURatio float64 `json:"cpu_ratio,omitempty"`
+
+	// MemRatio: request = limit * MemRatio (e.g., 0.8 = 80%)
+	// 1.0 = Guaranteed QoS (no overcommit)
+	// <1.0 = Burstable QoS
+	MemRatio float64 `json:"mem_ratio,omitempty"`
+}
+
+// IsGuaranteedQoS returns true if this config results in Guaranteed QoS.
+// Guaranteed QoS requires: request == limit (ratio = 1.0 for both CPU and Memory)
+func (c *OvercommitConfig) IsGuaranteedQoS() bool {
+	return c.CPURatio >= 1.0 && c.MemRatio >= 1.0
+}
+
+// ValidateWithDedicatedCPU checks if overcommit is compatible with dedicated CPU.
+// Per KubeVirt documentation, dedicatedCpuPlacement requires Guaranteed QoS.
+//
+// Returns error if:
+// - Dedicated CPU is enabled AND overcommit < 1.0 (Burstable QoS)
+func (c *OvercommitConfig) ValidateWithDedicatedCPU(dedicatedCPU bool) error {
+	if dedicatedCPU && !c.IsGuaranteedQoS() {
+		return ErrDedicatedCPURequiresGuaranteedQoS
+	}
+	return nil
+}
+
+// InstanceSizeSnapshot represents a snapshot of InstanceSize configuration
+// at the time of VM approval. This ensures that modifying an InstanceSize
+// does NOT affect existing VMs (ADR-0018 §Immutability).
+type InstanceSizeSnapshot struct {
+	Name          string                 `json:"name"`
+	CPU           int                    `json:"cpu"`
+	MemoryMB      int                    `json:"memory_mb"`
+	GPUCount      int                    `json:"gpu_count,omitempty"`
+	HugepagesGB   int                    `json:"hugepages_gb,omitempty"`
+	CPUOvercommit float64                `json:"cpu_overcommit,omitempty"`
+	MemOvercommit float64                `json:"mem_overcommit,omitempty"`
+	SpecOverrides map[string]interface{} `json:"spec_overrides,omitempty"`
+	SnapshotAt    time.Time              `json:"snapshot_at"`
+}
+
+// ToSnapshot creates an immutable snapshot of this InstanceSize.
+func (i *InstanceSize) ToSnapshot() *InstanceSizeSnapshot {
+	return &InstanceSizeSnapshot{
+		Name:          i.Name,
+		CPU:           i.CPU,
+		MemoryMB:      i.MemoryMB,
+		GPUCount:      i.GPUCount,
+		HugepagesGB:   i.HugepagesGB,
+		CPUOvercommit: i.CPUOvercommit,
+		MemOvercommit: i.MemOvercommit,
+		SpecOverrides: i.SpecOverrides,
+		SnapshotAt:    time.Now(),
+	}
+}
+
+// Errors
+
+var (
+	// ErrDedicatedCPURequiresGuaranteedQoS is returned when attempting to
+	// use overcommit with dedicated CPU placement.
+	// Per KubeVirt documentation, dedicatedCpuPlacement requires Guaranteed QoS.
+	ErrDedicatedCPURequiresGuaranteedQoS = errors.New("dedicated CPU requires Guaranteed QoS (overcommit must be 1.0)")
+)

--- a/docs/design/examples/domain/resource_role_binding.go
+++ b/docs/design/examples/domain/resource_role_binding.go
@@ -1,0 +1,74 @@
+// Package domain provides example domain entities for KubeVirt Shepherd.
+//
+// This file defines resource-level RBAC entities per ADR-0018 §Stage 2.A+, §Stage 4.A+.
+// Dual-layer permission model: Global RBAC + Resource-level RBAC.
+//
+// Reference: docs/adr/ADR-0018-instance-size-abstraction.md
+
+package domain
+
+import "time"
+
+// ResourceRoleBinding represents a resource-level permission grant.
+// This supplements the global RBAC (RoleBinding) with fine-grained resource permissions.
+//
+// Example Use Cases:
+// - User A can only manage VMs in System "shop"
+// - User B can only view (not modify) Service "redis"
+// - Team lead grants VM access to team members
+//
+// Permission Inheritance:
+// - System permission → inherits to all Services and VMs under it
+// - Service permission → inherits to all VMs under it
+type ResourceRoleBinding struct {
+	ID           string     `json:"id"`
+	UserID       string     `json:"user_id"`       // Target user
+	Role         string     `json:"role"`          // viewer, editor, admin
+	ResourceType string     `json:"resource_type"` // system, service, vm, namespace
+	ResourceID   string     `json:"resource_id"`   // The specific resource ID
+	GrantedBy    string     `json:"granted_by"`    // Who granted this permission
+	CreatedAt    time.Time  `json:"created_at"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"` // Optional expiration
+}
+
+// ResourceRole defines the available roles for resource-level RBAC.
+type ResourceRole string
+
+const (
+	ResourceRoleViewer ResourceRole = "viewer" // Read-only access
+	ResourceRoleEditor ResourceRole = "editor" // Read + Modify (no delete)
+	ResourceRoleAdmin  ResourceRole = "admin"  // Full access including grant permissions
+)
+
+// ResourceType defines the resource types that support resource-level RBAC.
+type ResourceType string
+
+const (
+	ResourceTypeSystem       ResourceType = "system"
+	ResourceTypeService      ResourceType = "service"
+	ResourceTypeVM           ResourceType = "vm"
+	ResourceTypeNamespace    ResourceType = "namespace"
+	ResourceTypeTemplate     ResourceType = "template"
+	ResourceTypeInstanceSize ResourceType = "instance_size"
+)
+
+// Permission represents a permission check result.
+type Permission struct {
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason,omitempty"` // Why allowed/denied
+	Source  string `json:"source,omitempty"` // global_rbac, resource_rbac, inheritance
+}
+
+// PermissionChecker interface for checking permissions.
+// Implementation should check both global RBAC and resource-level RBAC.
+type PermissionChecker interface {
+	// CheckPermission checks if user has specified permission on resource.
+	// Returns Permission with allowed=true if:
+	// 1. Global RBAC grants the permission, OR
+	// 2. Resource-level RBAC grants the permission (direct or inherited)
+	CheckPermission(userID, action, resourceType, resourceID string) (*Permission, error)
+
+	// CanGrant checks if user can grant the specified role to another user.
+	// Only users with "admin" role on the resource can grant permissions.
+	CanGrant(granterID, resourceType, resourceID, role string) (bool, error)
+}

--- a/docs/design/interaction-flows/master-flow.md
+++ b/docs/design/interaction-flows/master-flow.md
@@ -1,8 +1,8 @@
 # Master Interaction Flow
 
-> **Status**: Draft (Pending ADR-0018 Acceptance)  
-> **Version**: 0.1-draft  
-> **Date**: 2026-01-26  
+> **Status**: Stable (ADR-0017, ADR-0018 Accepted)  
+> **Version**: 1.0  
+> **Date**: 2026-01-28  
 > **Language**: English (Canonical Version)  
 > **Source**: Extracted from ADR-0018 Appendix
 
@@ -312,7 +312,11 @@ This document is the **canonical reference** for all Shepherd platform interacti
 │  - Target cluster (based on namespace environment, capacity, policy)        │
 │  - Final template version                                                   │
 │  - Storage class                                                            │
-│  - Any parameter overrides                                                  │
+│  - Any parameter overrides (CPU, Memory, etc.)                              │
+│                                                                              │
+│  Admin CANNOT modify (Security - prevents permission escalation):           │
+│  - Namespace (user-provided and immutable after submission) [ADR-0017]      │
+│  - ServiceID (determines ownership and inheritance)                         │
 │                                                                              │
 │  Approval decisions:                                                         │
 │  - APPROVE → VM creation proceeds                                           │
@@ -417,6 +421,9 @@ CREATE TABLE resource_role_bindings (
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-01-28 | 1.0 | **STABLE**: ADR-0017 and ADR-0018 accepted |
+| 2026-01-28 | 1.0 | Added: Stage 5.B Namespace immutability constraint (Admin CANNOT modify Namespace) |
+| 2026-01-28 | 1.0 | Verified: roles, role_bindings, resource_role_bindings tables match ADR-0018 §7 |
 | 2026-01-26 | 0.1-draft | Updated: Support both config.yaml and env vars for infrastructure config |
 | 2026-01-26 | 0.1-draft | Added: Configuration Storage Strategy - PostgreSQL-first design |
 | 2026-01-26 | 0.1-draft | Added: First Deployment Bootstrap flow (admin/admin + force password change) |


### PR DESCRIPTION
## Summary

Synchronizes design documents with **ADR-0018: Instance Size Abstraction Layer** decisions.

**ADR-0018 status has been changed to `accepted`.** This PR will close the related issue upon merge.

## Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `docs/adr/ADR-0018-instance-size-abstraction.md` | Modified | ADR updates and refinements |
| `docs/design/interaction-flows/master-flow.md` | Modified | Flow diagram alignment with ApprovalTicket-based cluster selection |
| `docs/design/examples/domain/instance_size.go` | **New** | InstanceSize domain model with capability requirements |
| `docs/design/examples/domain/resource_role_binding.go` | **New** | Dual-layer RBAC example code |

## Key Synchronizations

### 1. InstanceSize Domain Model

```go
type InstanceSize struct {
    RequiredFeatures  []string // ["gpu", "sriov", "hugepages"]
    RequiredHardware  []string // Hardware capability markers
    // ...
}
```

### 2. Dual-layer RBAC

| Layer | Scope | Example |
|-------|-------|---------|
| GlobalRoleBinding | Platform-wide | `user:alice` → `system-admin` |
| ResourceRoleBinding | Resource-specific | `user:bob` → `service:123` → `viewer` |

### 3. Master Flow Alignment

- Cluster selection moved to ApprovalTicket (Admin decision)
- InstanceSize capability matching with Cluster capabilities

## Closes

Closes #17

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] DCO sign-off included
- [x] Design docs synchronized with ADR decisions
- [x] Example code provided for new domain models