### PR TITLE
docs: enhance contribution guidelines with industry best practices (#47)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,76 @@
+# CODEOWNERS for KubeVirt Shepherd
+#
+# These owners will be automatically requested for review when a PR modifies
+# matching file paths. Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# CODEOWNERS syntax:
+#   [path pattern] [owner1] [owner2] ...
+#   Owners can be @username, @org/team, or email@example.com
+
+# Global default owners (required for all PRs)
+*                                   @jindyzhao
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Core Areas
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Architecture Decision Records (critical - require maintainer review)
+/docs/adr/                          @jindyzhao
+
+# Database schemas and migrations
+/ent/                               @jindyzhao
+/migrations/                        @jindyzhao
+
+# API layer
+/internal/api/                      @jindyzhao
+/api/                               @jindyzhao
+
+# Provider implementations (KubeVirt integration)
+/internal/provider/                 @jindyzhao
+
+# Job queue and workers
+/internal/jobs/                     @jindyzhao
+
+# Governance (System/Service/RBAC)
+/internal/governance/               @jindyzhao
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Configuration and CI
+# ──────────────────────────────────────────────────────────────────────────────
+
+# GitHub configuration
+/.github/                           @jindyzhao
+
+# CI/CD pipelines
+/.github/workflows/                 @jindyzhao
+
+# Project configuration files
+/go.mod                             @jindyzhao
+/go.sum                             @jindyzhao
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Documentation
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Project-level documentation
+/*.md                               @jindyzhao
+/docs/                              @jindyzhao
+
+# AI Agent configuration
+/.agent/                            @jindyzhao
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Security-sensitive files
+# ──────────────────────────────────────────────────────────────────────────────
+
+SECURITY.md                         @jindyzhao
+/internal/auth/                     @jindyzhao
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Note: As the project grows, add more granular ownership:
+#
+# Example for future SIG structure:
+# /internal/vm/       @kv-shepherd/sig-vm
+# /internal/storage/  @kv-shepherd/sig-storage
+# /docs/i18n/zh-CN/   @kv-shepherd/localization-zh
+# ──────────────────────────────────────────────────────────────────────────────

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,14 @@
 
 ## Related Issue
 
-<!-- Link to the issue this PR addresses (if applicable) -->
-Fixes #
+<!-- Link to the issue this PR addresses -->
+<!-- Use "Refs #N" for partial work, "Closes #N" ONLY when fully resolved -->
+
+- Refs #<!--issue number-->
+
+<!-- Uncomment ONLY if this PR fully resolves the issue:
+- Closes #
+-->
 
 ## Type of Change
 
@@ -46,10 +52,19 @@ Fixes #
 
 <!-- Add screenshots to help explain your changes -->
 
+## Labels
+
+<!-- Check applicable labels -->
+- [ ] `kind/feature` | `kind/bug` | `kind/documentation` | `kind/cleanup`
+- [ ] `area/core` | `area/api` | `area/provider`
+- [ ] `priority/high` | `priority/medium` | `priority/low`
+
 ## Additional Notes
 
 <!-- Add any additional notes for reviewers -->
 
 ---
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+By submitting this pull request, I confirm that:
+- My contribution is made under the Apache 2.0 license
+- All commits are signed off (DCO)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,24 +32,56 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Commit Message Guidelines
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+Follow [Conventional Commits](https://www.conventionalcommits.org/) with the **50/72 rule**:
 
 ```
-<type>(<scope>): <description>
-
-[optional body]
-
-[optional footer(s)]
+<type>(<scope>): <description>     ← 50 chars max, imperative, no period
+                                    ← blank line
+[body: explain what and why]        ← wrap at 72 chars
+                                    ← blank line
+[footer: issue refs, sign-off]      ← Refs #N or Closes #N
+Signed-off-by: Your Name <email>
 ```
 
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+### Commit Message Rules
 
-Example:
+| Rule | Requirement |
+|------|-------------|
+| Subject line | ≤50 characters, imperative mood, no period |
+| Blank line | Required between subject and body |
+| Body | Wrap at 72 characters, explain *what* and *why* |
+| Footer | Issue references, DCO sign-off |
+
+### Types
+
+`feat` | `fix` | `docs` | `style` | `refactor` | `test` | `chore` | `perf` | `ci`
+
+### Issue Reference Keywords
+
+| Keyword | Effect | When to Use |
+|---------|--------|-------------|
+| `Refs #N` | Links only | Partial work, ongoing discussion |
+| `Part of #N` | Links only | Multi-PR issue |
+| `Closes #N` | **Closes on merge** | Only when PR fully resolves issue |
+| `Fixes #N` | **Closes on merge** | Bug fixes that fully resolve |
+
+> ⚠️ **IMPORTANT**: Use `Refs #N` for work-in-progress. Only use `Closes/Fixes` when the PR **completely** resolves the issue.
+
+### Example
+
 ```
 feat(provider): add KubeVirt snapshot support
 
-Implements VM snapshot functionality using KubeVirt VolumeSnapshot API.
+Implements VM snapshot functionality using the KubeVirt VolumeSnapshot
+API. This enables point-in-time recovery for VirtualMachine instances.
+
+Key changes:
+- Add SnapshotProvider interface
+- Implement KubeVirt VolumeSnapshot adapter
+- Add snapshot lifecycle management
+
 Closes #123
+Signed-off-by: Your Name <email@example.com>
 ```
 
 ## Development Setup
@@ -162,6 +194,45 @@ Aim for ≥60% test coverage on new code.
 2. CI checks must pass
 3. Documentation must be updated if applicable
 4. Breaking changes require ADR update
+5. All review comments must be resolved before merge
+
+### Labels
+
+Use labels to categorize your PR:
+
+| Label | Description |
+|-------|-------------|
+| `kind/feature` | New feature |
+| `kind/bug` | Bug fix |
+| `kind/documentation` | Documentation update |
+| `kind/cleanup` | Code cleanup or refactoring |
+| `area/core` | Core functionality |
+| `area/api` | API changes |
+| `area/provider` | KubeVirt provider |
+| `good first issue` | Suitable for new contributors |
+
+### Draft PRs
+
+Open a **Draft PR** early to:
+- Get early feedback on your approach
+- Allow others to track your progress
+- Prevent duplicate work
+
+Mark as "Ready for Review" when complete.
+
+### Handling Review Feedback
+
+When addressing review comments:
+
+```bash
+# Make changes, then use fixup commits
+git commit --fixup=<commit-hash>
+
+# Before final merge, squash fixups
+git rebase --autosquash -i main
+```
+
+> 💡 Avoid commit messages like "Address review comments" - squash them into meaningful commits before merge.
 
 ## Getting Help
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@ This file lists the maintainers of the KubeVirt Shepherd project.
 
 | Name | GitHub | Affiliation | Focus Area |
 |------|--------|-------------|------------|
-| *To be announced* | - | - | Core |
+| Jindy Zhao | [@jindyzhao](https://github.com/jindyzhao) | Independent | Core, Architecture |
 
 > **Note**: As a new project, the maintainer list will be populated as the community grows. See [GOVERNANCE.md](GOVERNANCE.md) for the process of becoming a maintainer.
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,17 @@
 # OWNERS file for KubeVirt Shepherd
 #
 # Defines who can approve and review pull requests.
+# See: https://www.kubernetes.dev/docs/guide/owners/
 
-# Approvers can approve PRs for merge
+# Approvers can approve PRs for merge (LGTM + approve)
 approvers:
-  - kv-shepherd/maintainers
+  - jindyzhao
+  # Future: - kv-shepherd/maintainers
 
-# Reviewers can review PRs and provide feedback
+# Reviewers can review PRs and provide feedback (LGTM only)
 reviewers:
-  - kv-shepherd/reviewers
+  - jindyzhao
+  # Future: - kv-shepherd/reviewers
 
 # Labels to apply to issues/PRs in this directory
 labels:


### PR DESCRIPTION
## Summary

Enhances project contribution documentation to align with industry-standard open-source practices.

## Related Issue

- Refs #47

## Changes

### 1. Added `.github/CODEOWNERS`
- Automatic reviewer assignment for all code areas
- Currently all paths owned by @jindyzhao (sole maintainer)
- Structured for future team expansion

### 2. Enhanced `CONTRIBUTING.md`
- **50/72 Rule**: Commit message subject ≤50 chars, body wrapped at 72 chars
- **Issue Keywords**: Clear distinction between `Refs #N` (links only) and `Closes #N` (closes on merge)
- **Labels Section**: Added kind/, area/, priority/ label categories
- **Draft PRs**: Guidance on opening Draft PRs for early feedback
- **Review Feedback**: Fixup commits and rebase workflow for clean commit history

### 3. Updated `MAINTAINERS.md`
- Added @jindyzhao as initial maintainer

### 4. Updated `OWNERS`
- Added concrete approvers and reviewers (jindyzhao)
- Added reference to Kubernetes OWNERS documentation

### 5. Improved `.github/PULL_REQUEST_TEMPLATE.md`
- Changed default from `Fixes #` to `Refs #` with guidance
- Added labels checklist
- Added DCO reminder to confirmation statement

## Checklist

- [x] Documentation updated
- [x] No code changes
- [x] ADR compliance verified

## Review Notes

These changes bring the project's contribution workflow in line with widely-adopted open-source practices, making it easier for new contributors to follow established patterns.