### PR TITLE
docs: sync ADR-0017/0018 acceptance status to design docs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,8 +26,8 @@
 | [ADR-0014](./ADR-0014-capability-detection.md) | KubeVirt Capability Detection | Accepted | - |
 | [ADR-0015](./ADR-0015-governance-model-v2.md) | Governance Model V2 | **Accepted** ² | - |
 | [ADR-0016](./ADR-0016-go-module-vanity-import.md) | Go Module Vanity Import | Accepted | - |
-| [ADR-0017](./ADR-0017-vm-request-flow-clarification.md) | VM Request and Approval Flow Clarification | **Proposed** | - |
-| [ADR-0018](./ADR-0018-instance-size-abstraction.md) | Instance Size Abstraction Layer | **Proposed** | - |
+| [ADR-0017](./ADR-0017-vm-request-flow-clarification.md) | VM Request and Approval Flow Clarification | **Accepted** | - |
+| [ADR-0018](./ADR-0018-instance-size-abstraction.md) | Instance Size Abstraction Layer | **Accepted** | - |
 | [ADR-0019](./ADR-0019-governance-security-baseline-controls.md) | Governance Security Baseline Controls | **Proposed** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -194,6 +194,8 @@ This project follows the architecture decisions documented in:
 | [ADR-0014](../../adr/ADR-0014-capability-detection.md) | Capability Detection | Accepted |
 | [ADR-0015](../../adr/ADR-0015-governance-model-v2.md) | Governance Model V2 | Accepted |
 | [ADR-0016](../../adr/ADR-0016-go-module-vanity-import.md) | Go Module Vanity Import | Accepted |
+| [ADR-0017](../../adr/ADR-0017-vm-request-flow-clarification.md) | VM Request and Approval Flow Clarification | Accepted |
+| [ADR-0018](../../adr/ADR-0018-instance-size-abstraction.md) | Instance Size Abstraction Layer | Accepted |
 
 ---
 

--- a/docs/design/checklist/phase-4-checklist.md
+++ b/docs/design/checklist/phase-4-checklist.md
@@ -23,8 +23,8 @@
   - [ ] `Cluster.environment` - Cluster environment type (test/prod)
   - [ ] `ent/schema/namespace_registry.go` - Namespace registry with explicit environment
     - [ ] Contains `name` field
-    - [ ] Contains `cluster_id` field
     - [ ] Contains `environment` field (test/prod) - **explicitly set by admin**
+    - [ ] Does NOT contain `cluster_id` field (ADR-0017)
   - [ ] ❌ **No `System.environment`** - System is decoupled from environment (ADR-0015 §1)
 - [ ] **Platform RBAC**:
   - [ ] `RoleBinding.allowed_environments` field
@@ -158,4 +158,3 @@
   - [ ] New approval request → all admins
   - [ ] Request approved/rejected → creator + maintainers
   - [ ] VM created/deleted → creator + maintainers
-

--- a/docs/design/interaction-flows/README.md
+++ b/docs/design/interaction-flows/README.md
@@ -1,6 +1,6 @@
 # Interaction Flows
 
-> **Status**: Draft (Pending ADR-0018 Acceptance)  
+> **Status**: Stable (ADR-0017, ADR-0018 Accepted)  
 > **Source of Truth**: This directory contains the canonical interaction flows for Shepherd platform.
 
 ---
@@ -101,6 +101,7 @@ This directory content is **extracted from** ADR-0018 Appendix.
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-01-28 | 1.0 | **STABLE**: ADR-0017 and ADR-0018 accepted |
 | 2026-01-26 | 0.1-draft | CNCF normalization: English as canonical, Chinese to i18n/ |
 | 2026-01-26 | 0.1-draft | Added: Stage 1.5 Bootstrap, Stage 2.E External Approval Systems |
 | 2026-01-26 | 0.1-draft | Updated: All runtime config via PostgreSQL (removed YAML config) |

--- a/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
+++ b/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
@@ -1,8 +1,8 @@
 # 规范交互流程 (Master Flow)
 
-> **Status**: Draft (待 ADR-0018 接受后生效)  
-> **版本**: 0.1-draft  
-> **日期**: 2026-01-26  
+> **Status**: Stable (ADR-0017, ADR-0018 Accepted)  
+> **版本**: 1.0  
+> **日期**: 2026-01-28  
 > **语言**: 中文 (翻译版本)  
 > **规范版本**: [English Canonical Version](../../../../design/interaction-flows/master-flow.md)
 
@@ -24,8 +24,8 @@
 
 ## 附录：规范交互流程（中文版）
 
-> **重要**: 本节是 `docs/design/interaction-flows/master-flow.md` 的草稿。
-> ADR 被接受后，本节内容将被提取为独立的规范交互流程文档，作为前后端和数据库开发的统一参考。
+> **重要**: 本节为 `docs/design/interaction-flows/master-flow.md` 的中文翻译版本。
+> 如有不一致，以英文规范版本为准。
 
 ### 文档结构
 
@@ -2179,4 +2179,3 @@ INSERT INTO external_approval_systems (
 | **回退机制** | 外部系统不可用时，自动回退到内置审批 |
 
 ---
-


### PR DESCRIPTION
## Summary

Synchronize design documentation to reflect the accepted status of ADR-0017 and ADR-0018.

## Related Issues

- Refs #16 (ADR-0017: VM Request and Approval Flow Clarification)
- Refs #17 (ADR-0018: Instance Size Abstraction Layer)

## Changes

### ADR Status Updates
- `docs/adr/README.md`: Update ADR-0017 and ADR-0018 status from "Proposed" to "Accepted"
- `docs/design/README.md`: Add ADR-0017 and ADR-0018 to the ADR reference table

### Design Document Alignment
- `docs/design/checklist/phase-4-checklist.md`: Align namespace registry design with ADR-0017 (no `cluster_id` field per ADR decision)
- `docs/design/interaction-flows/README.md`: Minor sync improvements
- `docs/i18n/zh-CN/design/interaction-flows/master-flow.md`: Sync Chinese translation

## Checklist

- [x] Documentation updated
- [x] ADR compliance verified
- [x] No unrelated changes included
- [x] Separated from ADR-0023 changes per workflow standards

## Review Notes

This is a documentation sync PR following the acceptance of ADR-0017 and ADR-0018. It ensures all design documents reference the correct ADR status.