### PR TITLE
docs(governance): establish design notes workflow (#51)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,18 @@ See [docs/design/ci/README.md](docs/design/ci/README.md) for the complete list.
 - ADR changes require discussion and approval
 - Keep examples in `docs/design/examples/` synchronized with actual patterns
 
+### Decision Documents (ADR + Design Notes)
+
+When an ADR is **Proposed**, do not change normative design specs yet.
+Use a Design Note to describe the concrete changes and impact:
+
+1. Create `docs/design/notes/ADR-XXXX-title.md`
+2. Document impacted APIs, schemas, migrations, and behavioral changes
+3. Optionally add a short **Pending Changes** block in the affected design docs
+
+After the ADR is **Accepted**, merge the Design Note into the design specs
+and remove any Pending Changes blocks.
+
 ## Testing
 
 ### Unit Tests

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ System (Business Line) → Service (Application) → VM Instance
 | **Async by Default** | All write operations return `202 Accepted` and execute asynchronously. |
 | **Platform RBAC** | RBAC managed in PostgreSQL, not Kubernetes. Permission queries isolated from cluster control plane. |
 
+## Decision Documents
+
+- **ADRs** record accepted architectural decisions
+- **Design Notes** capture proposed changes before ADR acceptance
+- Normative design specs are updated only after ADRs are accepted
+
 ## Project Status
 
 > ⚠️ **Pre-Alpha**: Planning and design phase.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -115,6 +115,18 @@ For newcomers, we recommend reading ADRs in this order:
 4. Submit for review with a GitHub Issue
 5. After 48-hour review period, update status to `Accepted` or `Rejected`
 
+### Proposed ADRs and Pending Changes
+
+When an ADR is **Proposed**, do NOT edit normative design specs.
+Instead:
+
+1. Create a Design Note in `docs/design/notes/` (e.g., `ADR-XXXX-title.md`)
+2. Capture concrete implementation impacts there (fields, APIs, migrations)
+3. Optionally add a short **Pending Changes** block in affected design docs
+
+Once the ADR is **Accepted**, merge Design Note changes into the design specs
+and remove the Pending Changes block.
+
 ### Amending Accepted ADRs
 
 Accepted ADRs are **immutable**. To change a decision:

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -196,6 +196,16 @@ This project follows the architecture decisions documented in:
 | [ADR-0016](../../adr/ADR-0016-go-module-vanity-import.md) | Go Module Vanity Import | Accepted |
 | [ADR-0017](../../adr/ADR-0017-vm-request-flow-clarification.md) | VM Request and Approval Flow Clarification | Accepted |
 | [ADR-0018](../../adr/ADR-0018-instance-size-abstraction.md) | Instance Size Abstraction Layer | Accepted |
+<<<<<<< HEAD
+=======
+
+---
+
+### Proposed Changes (Pre-ADR)
+
+Proposed changes are documented in `docs/design/notes/` until the ADR is accepted.
+Do not update normative specs until acceptance.
+>>>>>>> 4476316 (docs(governance): establish design notes workflow)
 
 ---
 

--- a/docs/design/notes/README.md
+++ b/docs/design/notes/README.md
@@ -1,0 +1,65 @@
+# Design Notes
+
+Design Notes document **proposed changes** that are not yet accepted as ADRs.
+They allow teams to share implementation impact without changing normative specs.
+
+## When to Use
+
+Create a Design Note when:
+- An ADR is **Proposed** and not yet accepted
+- You need to communicate concrete changes to design or implementation
+- You must avoid updating normative design docs until a decision is accepted
+
+## Naming
+
+Use one of:
+- `ADR-XXXX-title.md` (recommended when tied to an ADR)
+- `NOTE-YYYYMMDD-short-title.md` (for exploratory notes)
+
+## Template (Minimal)
+
+```
+# Design Note: <Title>
+
+> Status: Proposed
+> Related ADR: ADR-XXXX
+> Owner: @name
+> Date: YYYY-MM-DD
+
+## Summary
+One paragraph summary of what is changing and why.
+
+## Scope
+- In scope: ...
+- Out of scope: ...
+
+## Pending Changes (Not Yet Normative)
+- Affected docs: ...
+- Affected components: ...
+- Behavior changes: ...
+
+## Migration / Rollout
+- Data migration (if any)
+- Compatibility notes
+
+## Open Questions
+- ...
+```
+
+## Lifecycle
+
+1. **Proposed**: Design Note exists; no normative docs changed.
+2. **Accepted**: ADR accepted; incorporate changes into design docs.
+3. **Archived**: If ADR rejected or superseded.
+
+## Pending Changes Blocks
+
+If you must surface proposed changes inside a design doc, add a short block:
+
+```
+> ⚠ Pending Changes (Proposed, not yet accepted)
+> - See docs/design/notes/ADR-XXXX-title.md
+```
+
+Keep it short and do not alter normative sections until acceptance.
+


### PR DESCRIPTION
## Summary
Establish a formal workflow for handling "Proposed" ADR design impacts without modifying normative specifications prematurely.

## Related Issue
- Closes #51

## Changes
- **New Directory**: `docs/design/notes/` for holding `ADR-XXXX-title.md` design notes.
- **Workflow Update**: Update `CONTRIBUTING.md` and `docs/adr/README.md` to define this process.
- **Pending Changes Sections**: Allow "Pending Changes" blocks in design docs that reference these notes.

## Checklist
- [x] Documentation updated
- [x] No unrelated changes included
- [x] Adheres to project governance standards