### PR TITLE
docs(adr): update ADR-0020/0021/0022 status to accepted

### DIFF
--- a/docs/adr/ADR-0020-frontend-technology-stack.md
+++ b/docs/adr/ADR-0020-frontend-technology-stack.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+status: "accepted"  # proposed | accepted | deprecated | superseded by ADR-XXXX
 date: 2026-01-27
 deciders: []  # GitHub usernames of decision makers
 consulted: []  # Subject-matter experts consulted (two-way communication)

--- a/docs/adr/ADR-0021-api-contract-first.md
+++ b/docs/adr/ADR-0021-api-contract-first.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+status: "accepted"  # proposed | accepted | deprecated | superseded by ADR-XXXX
 date: 2026-01-27
 deciders: []  # GitHub usernames of decision makers
 consulted: []  # Subject-matter experts consulted (two-way communication)

--- a/docs/adr/ADR-0022-modular-provider-pattern.md
+++ b/docs/adr/ADR-0022-modular-provider-pattern.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+status: "accepted"  # proposed | accepted | deprecated | superseded by ADR-XXXX
 date: 2026-01-27
 deciders: []  # GitHub usernames of decision makers
 consulted: []  # Subject-matter experts consulted (two-way communication)


### PR DESCRIPTION
## Summary

Updates ADR-0020, ADR-0021, and ADR-0022 status from `proposed` to `accepted` after review period completion.

## Related Issues

- Refs #30 (ADR-0020)
- Refs #31 (ADR-0021)
- Refs #32 (ADR-0022)

## Changes

| ADR | Title | Status Update |
|-----|-------|---------------|
| ADR-0020 | Frontend Technology Stack | proposed → **accepted** |
| ADR-0021 | API Contract-First Design | proposed → **accepted** |
| ADR-0022 | Modular Provider Pattern | proposed → **accepted** |

## Review Period

All three ADRs were submitted on 2026-01-27, with a 48-hour minimum review period that has now passed.

## Checklist

- [x] 48-hour review period completed
- [x] No objections raised in issue discussions
- [x] Related issues referenced (not closed)