### PR TITLE
docs: propose ADR-0025, ADR-0026 and RFC-0016

### DIFF
--- a/docs/adr/ADR-0025-secret-bootstrap.md
+++ b/docs/adr/ADR-0025-secret-bootstrap.md
@@ -1,0 +1,110 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-01-30
+deciders: []
+consulted: []
+informed: []
+---
+
+# ADR-0025: Bootstrap Secrets Auto-Generation and Persistence
+
+> **Review Period**: Until 2026-02-01
+> **Discussion**: [Issue #69](https://github.com/kv-shepherd/shepherd/issues/69)
+> **Amends**: [ADR-0018](./ADR-0018-instance-size-abstraction.md) (bootstrap config guidance)
+
+---
+
+## Context and Problem Statement
+
+Deployment-time secrets (`ENCRYPTION_KEY`, `SESSION_SECRET`) are security-critical but create
+operational friction when required before first boot. For V1, we prioritize usability and
+define a safe default that avoids blocking initial startup. Key rotation is explicitly
+deferred to a future RFC. Secrets are stored in PostgreSQL with minimal access privileges.
+
+## Decision Drivers
+
+* Strong security defaults with encrypted-at-rest secrets
+* Zero-friction first boot for users
+* Defer rotation complexity to a later RFC
+* Keep secrets accessible to the application without restart
+* Avoid ephemeral in-memory secrets
+
+## Considered Options
+
+* **Option 1**: Require operators to provide all secrets before startup
+* **Option 2**: Allow missing secrets; run with ephemeral in-memory keys
+* **Option 3**: Auto-generate secrets on first boot and persist (no rotation in V1)
+
+## Decision Outcome
+
+**Chosen option**: "Auto-generate secrets on first boot and persist (no rotation in V1)",
+because it balances security with usability and avoids unsafe ephemeral keys.
+
+### Consequences
+
+* ✅ Good, because first boot succeeds without pre-provisioned secrets
+* ✅ Good, because secrets are durable and available across restarts
+* 🟡 Neutral, because bootstrap needs a storage location for generated secrets
+* ❌ Bad, because rotation is deferred (mitigation: RFC-0016)
+
+### Confirmation
+
+* Unit tests: secrets generated only when missing, persisted once
+* Integration tests: boot with missing secrets produces stable persisted keys
+* Security checks: secrets never logged; encryption works with generated keys
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Require operators to provide all secrets
+
+* ✅ Good, because key management is explicit
+* ❌ Bad, because increases setup friction and delays first boot
+
+### Option 2: Allow missing secrets (ephemeral in-memory)
+
+* ✅ Good, because easiest to start
+* ❌ Bad, because secrets rotate on restart and break encrypted data and sessions
+
+### Option 3: Auto-generate and persist (no rotation in V1)
+
+* ✅ Good, because secure by default with low friction
+* ❌ Bad, because rotation is deferred
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0018](./ADR-0018-instance-size-abstraction.md) - Deployment-time config overview
+* [ADR-0019](./ADR-0019-governance-security-baseline-controls.md) - Secrets handling baseline
+* [RFC-0016](../rfc/RFC-0016-key-rotation.md) - Key rotation (future work)
+
+### References
+
+* RFC 7518 (JWA) key length guidance: https://www.rfc-editor.org/rfc/rfc7518
+* OWASP Secrets Management: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+### Implementation Notes
+
+* Generate 32-byte random keys using a CSPRNG
+* Persist generated secrets in PostgreSQL on first boot
+* Load secrets from DB into memory on startup; do not auto-rotate in V1
+* Precedence: external key (KMS/secret manager) > env vars > DB-generated
+* If an external/env key is introduced later, require an explicit re-encryption step
+* Store secrets in `system_secrets` table (single row or per key)
+* Access control: only application DB role can read/write; no admin UI/API exposure
+
+**Proposed table shape** (non-normative):
+- `id`, `key_name`, `key_value`, `source`, `created_at`, `updated_at`
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-01-30 | @jindyzhao | Initial draft |

--- a/docs/adr/ADR-0026-idp-config-naming.md
+++ b/docs/adr/ADR-0026-idp-config-naming.md
@@ -1,0 +1,120 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-01-30
+deciders: []
+consulted: []
+informed: []
+---
+
+# ADR-0026: Auth Provider Naming and Standardized Provider Output
+
+> **Review Period**: Until 2026-02-01
+> **Discussion**: [Issue #70](https://github.com/kv-shepherd/shepherd/issues/70)
+> **Amends**: [ADR-0018](./ADR-0018-instance-size-abstraction.md) (naming alignment)
+
+---
+
+## Context and Problem Statement
+
+Design docs currently use both `auth_providers` and `idp_configs` to represent
+OIDC/LDAP provider configuration. The platform intent is to standardize provider
+output across OIDC, LDAP, enterprise SSO, Feishu, DingTalk, WeCom, etc., so that
+only the adapter/plugin layer changes while core logic remains stable.
+
+## Decision Drivers
+
+* Standardized provider output across many auth backends
+* Minimal change to core auth/rbac logic when adding providers
+* Consistent naming across UI/API/DB
+* Alignment with existing V1 design in ADR-0018
+
+## Considered Options
+
+* **Option 1**: Use `auth_providers` as canonical name
+* **Option 2**: Use `idp_configs` as canonical name
+* **Option 3**: Keep both with compatibility layer
+
+## Decision Outcome
+
+**Chosen option**: "Use `auth_providers` as canonical name", because it aligns with
+V1 design intent for a standardized provider abstraction and avoids long-term
+naming drift.
+
+### Consequences
+
+* ✅ Good, because core auth logic depends on a single standardized provider model
+* ✅ Good, because adding new auth backends is adapter-only
+* 🟡 Neutral, because existing references to `idp_configs` must be reconciled
+* ❌ Bad, because any prior `idp_configs` references in docs must be amended
+
+### Confirmation
+
+* Schema definitions include `auth_providers` with OIDC/LDAP fields
+* API endpoints and UI labels use "Auth Provider" terminology
+* Any `idp_configs` mentions are amended/aliased in design docs
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Use `auth_providers`
+
+* ✅ Good, because matches standardized provider abstraction intent
+* ✅ Good, because aligns with ADR-0018 table naming
+* ❌ Bad, because ADR-0015 uses `idp_config` naming and needs amendment
+
+### Option 2: Use `idp_configs`
+
+* ✅ Good, because matches IdP terminology in ADR-0015
+* ❌ Bad, because conflicts with standardized provider abstraction naming
+
+### Option 3: Keep both with compatibility layer
+
+* ✅ Good, because avoids immediate renames
+* ❌ Bad, because doubles complexity and invites drift
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0015](./ADR-0015-governance-model-v2.md) - IdP schema naming (amended by this ADR)
+* [ADR-0018](./ADR-0018-instance-size-abstraction.md) - `auth_providers` table design
+
+### References
+
+* OpenID Connect Discovery: https://openid.net/specs/openid-connect-discovery-1_0.html
+* OpenID Connect Core: https://openid.net/specs/openid-connect-core-1_0.html
+
+### Implementation Notes
+
+* Rename remaining docs and examples to `auth_providers`
+* Adapter/plugin layer maps external systems to standardized provider output
+
+### Standard Provider Output (Contract)
+
+Adapters MUST normalize all external providers into a common output payload:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider_id` | string | `auth_providers.id` |
+| `auth_type` | string | `oidc` / `ldap` / `sso` / `wecom` / `feishu` / `dingtalk` |
+| `external_id` | string | Stable subject identifier from provider |
+| `email` | string | User email (may be empty if provider lacks) |
+| `display_name` | string | Human-readable name |
+| `groups` | string[] | Normalized group list for RBAC mapping |
+| `raw_claims` | json | Raw provider claims/attributes (optional, for audit/debug) |
+
+**Rules**:
+- Core auth/RBAC logic consumes only this normalized output.
+- Provider-specific fields must be mapped in the adapter layer.
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-01-30 | @jindyzhao | Initial draft |

--- a/docs/design/notes/ADR-0025-secret-bootstrap.md
+++ b/docs/design/notes/ADR-0025-secret-bootstrap.md
@@ -1,0 +1,39 @@
+# ADR-0025 Design Notes: Bootstrap Secrets Auto-Generation (V1)
+
+> **Status**: Pending ADR-0025 acceptance
+
+## Summary
+
+- V1: If `ENCRYPTION_KEY` or `SESSION_SECRET` is missing at startup, generate strong random keys.
+- Persist generated keys in PostgreSQL.
+- Load keys into memory on startup; no automatic rotation in V1.
+- External secret manager or env vars override DB values.
+
+## Schema Proposal (DB Storage)
+
+**Table**: `system_secrets`
+
+| Column | Type | Notes |
+|--------|------|------|
+| `id` | string | Primary key (single row or named keys) |
+| `key_name` | string | `ENCRYPTION_KEY` / `SESSION_SECRET` |
+| `key_value` | string | Base64-encoded secret; encrypted at rest at DB level | 
+| `source` | string | `db_generated` / `env` / `external` |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update |
+
+**Usage**:
+- On startup: check external/env → else DB → else generate+persist in DB.
+- Only one active value per `key_name`.
+
+## Access Control (Minimum Privilege)
+
+- Only the application service DB role can `SELECT/INSERT/UPDATE` this table.
+- No admin UI exposure; no API returns key values.
+- Audit any changes to `system_secrets` metadata (not values).
+- Logs must never include `key_value`.
+
+## References
+
+- ADR-0025 (proposed)
+- RFC-0016 Key Rotation

--- a/docs/design/notes/ADR-0026-idp-config-naming.md
+++ b/docs/design/notes/ADR-0026-idp-config-naming.md
@@ -1,0 +1,34 @@
+# ADR-0026 Design Notes: Auth Provider Naming Unification
+
+> **Status**: Pending ADR-0026 acceptance
+
+## Summary
+
+- Canonical table name is `auth_providers`.
+- Replace references to `idp_configs` in design docs and schemas.
+- Adapter/plugin layer maps external providers (OIDC/LDAP/SSO/WeCom/Feishu/DingTalk) to standard output fields.
+
+## Design Impact
+
+- Schema: `auth_providers` includes issuer, client_id, client_secret_encrypted, claims_mapping, defaults.
+- API/UI labels use Auth Provider terminology.
+- Migration plan required if `idp_configs` ever implemented.
+
+## Standard Provider Output (Contract)
+
+Adapters normalize to:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider_id` | string | `auth_providers.id` |
+| `auth_type` | string | `oidc` / `ldap` / `sso` / `wecom` / `feishu` / `dingtalk` |
+| `external_id` | string | Stable subject identifier |
+| `email` | string | May be empty |
+| `display_name` | string | Human-readable name |
+| `groups` | string[] | Normalized group list |
+| `raw_claims` | json | Optional raw attributes |
+
+## References
+
+- ADR-0026 (proposed)
+- ADR-0015 §22.6 (IdP config schema, amended by ADR-0026)

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -25,6 +25,7 @@
 | [RFC-0013](./RFC-0013-vm-snapshot.md) | VM Snapshot ³ | Deferred | P2 | Backup/Restore needed |
 | [RFC-0014](./RFC-0014-vm-clone.md) | VM Clone ³ | Deferred | P2 | Rapid VM duplication |
 | [RFC-0015](./RFC-0015-per-cluster-concurrency.md) | Per-Cluster Concurrency | Deferred | P3 | Distributed semaphore needed |
+| [RFC-0016](./RFC-0016-key-rotation.md) | Secret Key Rotation | Proposed | P2 | Compliance or operator request |
 
 > **Notes**:
 > - ¹ Soft archiving (`archived_at` field) is implemented in Phase 4; this RFC covers physical archiving to separate tables

--- a/docs/rfc/RFC-0016-key-rotation.md
+++ b/docs/rfc/RFC-0016-key-rotation.md
@@ -1,0 +1,46 @@
+# RFC-0016: Secret Key Rotation
+
+> **Status**: Proposed  
+> **Priority**: P2  
+> **Trigger**: Compliance requirement or operator request for periodic key rotation
+
+## Problem
+
+V1 defers key rotation to reduce complexity. As deployments mature, operators will
+require periodic rotation of `ENCRYPTION_KEY` and `SESSION_SECRET` without downtime
+or data loss.
+
+## Proposed Solution
+
+Introduce a keyring model with versioned keys:
+
+- Store a list of key versions in DB (`active`, `retired`) with creation timestamps
+- Encrypt new data with `active` key
+- Decrypt by trying `active` then `retired` keys
+- Provide a rotation workflow that:
+  1. Generates a new key version
+  2. Marks it active
+  3. Re-encrypts existing sensitive fields in background
+  4. Retires old keys after migration
+
+## Trade-offs
+
+### Pros
+- No downtime rotation
+- Backward compatibility during migration
+- Clear auditability of key changes
+
+### Cons
+- Additional complexity in crypto handling
+- Requires background migration job
+
+## Implementation Notes
+
+- Add `key_version` metadata to encrypted fields or store in an encryption envelope
+- Ensure secrets are never logged
+- Provide an admin-only rotation endpoint or CLI
+
+## References
+
+- ADR-0025: Bootstrap Secrets Auto-Generation and Persistence
+- OWASP Secrets Management: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html


### PR DESCRIPTION
## Summary
Propose new Architecture Decision Records (ADR) and Request for Comments (RFC) related to secret management and authentication provider naming conventions.

## Proposals
- **ADR-0025**: Automates secret generation on first boot to reduce operational friction.
- **ADR-0026**: Standardizes naming around `auth_providers` and defines a common output contract for various authentication methods.
- **RFC-0016**: Outlines a future strategy for zero-downtime secret key rotation.

## Implementation Details
Includes Design Notes for ADR-0025 and ADR-0026 to capture implementation impacts without modifying normative specs.

## Linking
Refs #69, #70, #71