### PR TITLE
docs(adr): propose ADR-0025 secret bootstrap (#73)

### DIFF
--- a/docs/adr/ADR-0025-secret-bootstrap.md
+++ b/docs/adr/ADR-0025-secret-bootstrap.md
@@ -1,0 +1,109 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-01-30
+deciders: []
+consulted: []
+informed: []
+---
+
+# ADR-0025: Bootstrap Secrets Auto-Generation and Persistence
+
+> **Review Period**: Until 2026-02-01
+> **Discussion**: [Issue #XX](https://github.com/kv-shepherd/shepherd/issues/XX)
+> **Amends**: [ADR-0018](./ADR-0018-instance-size-abstraction.md) (bootstrap config guidance)
+
+---
+
+## Context and Problem Statement
+
+Deployment-time secrets (`ENCRYPTION_KEY`, `SESSION_SECRET`) are security-critical but create
+operational friction when required before first boot. For V1, we prioritize usability and
+define a safe default that avoids blocking initial startup. Key rotation is explicitly
+deferred to a future RFC. Secrets are stored in PostgreSQL with minimal access privileges.
+
+## Decision Drivers
+
+* Strong security defaults with encrypted-at-rest secrets
+* Zero-friction first boot for users
+* Defer rotation complexity to a later RFC
+* Keep secrets accessible to the application without restart
+
+## Considered Options
+
+* **Option 1**: Require operators to provide all secrets before startup
+* **Option 2**: Allow missing secrets; run with ephemeral in-memory keys
+* **Option 3**: Auto-generate secrets on first boot and persist (no rotation in V1)
+
+## Decision Outcome
+
+**Chosen option**: "Auto-generate secrets on first boot and persist (no rotation in V1)",
+because it balances security with usability and avoids unsafe ephemeral keys.
+
+### Consequences
+
+* ✅ Good, because first boot succeeds without pre-provisioned secrets
+* ✅ Good, because secrets are durable and available across restarts
+* 🟡 Neutral, because bootstrap needs a storage location for generated secrets
+* ❌ Bad, because rotation is deferred (mitigation: RFC-0016)
+
+### Confirmation
+
+* Unit tests: secrets generated only when missing, persisted once
+* Integration tests: boot with missing secrets produces stable persisted keys
+* Security checks: secrets never logged; encryption works with generated keys
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Require operators to provide all secrets
+
+* ✅ Good, because key management is explicit
+* ❌ Bad, because increases setup friction and delays first boot
+
+### Option 2: Allow missing secrets (ephemeral in-memory)
+
+* ✅ Good, because easiest to start
+* ❌ Bad, because secrets rotate on restart and break encrypted data and sessions
+
+### Option 3: Auto-generate and persist (no rotation in V1)
+
+* ✅ Good, because secure by default with low friction
+* ❌ Bad, because rotation is deferred
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0018](./ADR-0018-instance-size-abstraction.md) - Deployment-time config overview
+* [ADR-0019](./ADR-0019-governance-security-baseline-controls.md) - Secrets handling baseline
+* [RFC-0016](../rfc/RFC-0016-key-rotation.md) - Key rotation (future work)
+
+### References
+
+* RFC 7518 (JWA) key length guidance: https://www.rfc-editor.org/rfc/rfc7518
+* OWASP Secrets Management: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+
+### Implementation Notes
+
+* Generate 32-byte random keys using a CSPRNG
+* Persist generated secrets in PostgreSQL on first boot
+* Load secrets from DB into memory on startup; do not auto-rotate in V1
+* Precedence: external key (KMS/secret manager) > env vars > DB-generated
+* If an external/env key is introduced later, require an explicit re-encryption step
+* Store secrets in `system_secrets` table (single row or per key)
+* Access control: only application DB role can read/write; no admin UI/API exposure
+
+**Proposed table shape** (non-normative):
+- `id`, `key_name`, `key_value`, `source`, `created_at`, `updated_at`
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-01-30 | @codex | Initial draft |

--- a/docs/design/notes/ADR-0025-secret-bootstrap.md
+++ b/docs/design/notes/ADR-0025-secret-bootstrap.md
@@ -1,0 +1,39 @@
+# ADR-0025 Design Notes: Bootstrap Secrets Auto-Generation (V1)
+
+> **Status**: Pending ADR-0025 acceptance
+
+## Summary
+
+- V1: If `ENCRYPTION_KEY` or `SESSION_SECRET` is missing at startup, generate strong random keys.
+- Persist generated keys in PostgreSQL.
+- Load keys into memory on startup; no automatic rotation in V1.
+- External secret manager or env vars override DB values.
+
+## Schema Proposal (DB Storage)
+
+**Table**: `system_secrets`
+
+| Column | Type | Notes |
+|--------|------|------|
+| `id` | string | Primary key (single row or named keys) |
+| `key_name` | string | `ENCRYPTION_KEY` / `SESSION_SECRET` |
+| `key_value` | string | Base64-encoded secret; encrypted at rest by DB | 
+| `source` | string | `db_generated` / `env` / `external` |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update |
+
+**Usage**:
+- On startup: check external/env → else DB → else generate+persist in DB.
+- Only one active value per `key_name`.
+
+## Access Control (Minimum Privilege)
+
+- Only the application service DB role can `SELECT/INSERT/UPDATE` this table.
+- No admin UI exposure; no API returns key values.
+- Audit any changes to `system_secrets` metadata (not values).
+- Logs must never include `key_value`.
+
+## References
+
+- ADR-0025 (proposed)
+- RFC-0016 Key Rotation


### PR DESCRIPTION
## Summary
Propose ADR-0025 to enable auto-generation of deployment secrets on first boot, improving developer experience and removing setup friction.

## Related Issue
- Refs #73

## Changes
- Add `docs/adr/ADR-0025-secret-bootstrap.md`
- Add `docs/design/notes/ADR-0025-secret-bootstrap.md` (Design Note)

## Checklist
- [x] Documentation updated
- [x] ADR compliance verified
