### PR TITLE
chore: add ADR proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr_proposal.md
+++ b/.github/ISSUE_TEMPLATE/adr_proposal.md
@@ -1,0 +1,50 @@
+---
+name: ADR Proposal
+about: Propose an Architecture Decision Record for architectural changes
+title: "[ADR] "
+labels: kind/documentation, area/architecture
+assignees: ''
+---
+
+## Context and Problem Statement
+
+<!-- Describe the context and problem that requires an architectural decision. -->
+<!-- Why is this decision needed now? What triggered this proposal? -->
+
+## Decision Drivers
+
+<!-- List the forces, concerns, or constraints that influence this decision -->
+
+- 
+- 
+- 
+
+## Proposed Solution
+
+<!-- Briefly describe the proposed solution or direction -->
+
+## Alternatives Considered
+
+<!-- List any alternatives you've considered (details will be in the ADR) -->
+
+- **Option A**: 
+- **Option B**: 
+
+## Related ADRs
+
+<!-- List any existing ADRs that this proposal relates to, amends, or supersedes -->
+
+- Related: [ADR-XXXX](../../docs/adr/ADR-XXXX-xxx.md) - 
+- Amends: *(if applicable)*
+- Supersedes: *(if applicable)*
+
+## Additional Context
+
+<!-- Any other context, links, or references that help explain the proposal -->
+
+## Checklist
+
+- [ ] I have searched existing issues and ADRs to ensure this is not a duplicate
+- [ ] I have reviewed the [ADR template](../../docs/adr/TEMPLATE.md)
+- [ ] I have read the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines
+- [ ] I understand the 48-hour minimum review period for ADRs


### PR DESCRIPTION
## Description

Add a dedicated GitHub issue template for Architecture Decision Record (ADR) proposals.

## Motivation

The project has existing templates for `bug_report` and `feature_request`, but lacks a standardized template for ADR proposals. This leads to inconsistent ADR issue submissions.

## Changes

### New File: `.github/ISSUE_TEMPLATE/adr_proposal.md`

Provides structured sections for:
- Context and problem statement
- Decision drivers
- Proposed solution and alternatives
- Related ADRs and references
- Acceptance checklist

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🔧 Chore/Improvement
- [ ] 🧪 Test update

## Checklist

- [x] Template follows MADR 4.0 structure
- [x] All required sections included
- [x] Labels pre-configured (`kind/documentation`)
- [x] All commits are signed off (DCO)