### PR TITLE
docs(adr): fix ADR-0020 invalid reference and add ADR-0027 amendment

### DIFF
--- a/docs/adr/ADR-0020-frontend-technology-stack.md
+++ b/docs/adr/ADR-0020-frontend-technology-stack.md
@@ -803,7 +803,8 @@ const handleClick = () => setCount(prev => prev + 1)
 ### Documentation Reference
 
 For the complete performance optimization ruleset (57 rules across 8 categories), see:
-- `.agent/skills/vercel-react-best-practices/AGENTS.md`
+- [Vercel Engineering: How We Optimized Package Imports](https://vercel.com/blog/how-we-optimized-package-imports-in-next-js)
+- [Next.js Performance Best Practices](https://nextjs.org/docs/pages/building-your-application/optimizing)
 
 ---
 
@@ -891,3 +892,16 @@ Upon acceptance, perform the following:
 ---
 
 _End of ADR-0020_
+
+---
+
+## Amendments by Subsequent ADRs
+
+> ⚠️ **Notice**: The following sections have been amended by subsequent ADRs.
+> The original decisions above remain **unchanged for historical reference**.
+
+### ADR-0027: Monorepo Repository Structure with web/ (2026-01-31)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §Repository Structure | **SUPERSEDED** | Repository structure decision updated to Monorepo with `web/` frontend directory. | [ADR-0027](./ADR-0027-repository-structure-monorepo.md) |


### PR DESCRIPTION
## Summary

Fix invalid documentation reference in ADR-0020 and add ADR-0027 amendment section.

## Changes

### Fix Invalid Reference
- Replace invalid internal path reference with official Vercel and Next.js documentation links
- The previous reference pointed to a non-existent path

### Add ADR-0027 Amendment
- Add "Amendments by Subsequent ADRs" section
- Document that ADR-0027 supersedes the repository structure decision

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] DCO sign-off included
- [x] No breaking changes