### PR TITLE
docs(adr): update ADR README with ADR-0019 through ADR-0027

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,8 +28,15 @@
 | [ADR-0016](./ADR-0016-go-module-vanity-import.md) | Go Module Vanity Import | Accepted | - |
 | [ADR-0017](./ADR-0017-vm-request-flow-clarification.md) | VM Request and Approval Flow Clarification | **Accepted** | - |
 | [ADR-0018](./ADR-0018-instance-size-abstraction.md) | Instance Size Abstraction Layer | **Accepted** | - |
-| [ADR-0019](./ADR-0019-governance-security-baseline-controls.md) | Governance Security Baseline Controls | **Proposed** | - |
-| [ADR-0027](./ADR-0027-repository-structure-monorepo.md) | Monorepo Repository Structure with web/ | **Proposed** | - |
+| [ADR-0019](./ADR-0019-governance-security-baseline-controls.md) | Governance Security Baseline Controls | **Accepted** | - |
+| [ADR-0020](./ADR-0020-frontend-technology-stack.md) | Frontend Technology Stack | **Accepted** | - |
+| [ADR-0021](./ADR-0021-api-contract-first.md) | API Contract-First Design | **Accepted** | - |
+| [ADR-0022](./ADR-0022-modular-provider-pattern.md) | Modular Provider Pattern | **Accepted** | - |
+| [ADR-0023](./ADR-0023-schema-cache-management.md) | Schema Cache Management and API Standardization | **Accepted** | - |
+| [ADR-0024](./ADR-0024-provider-capability-composition.md) | Provider Interface Capability Composition | **Accepted** | - |
+| [ADR-0025](./ADR-0025-secret-bootstrap.md) | Bootstrap Secrets Auto-Generation and Persistence | **Accepted** | - |
+| [ADR-0026](./ADR-0026-idp-config-naming.md) | Auth Provider Naming and Standardized Provider Output | **Accepted** | - |
+| [ADR-0027](./ADR-0027-repository-structure-monorepo.md) | Monorepo Repository Structure with web/ | **Accepted** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:
 >


### PR DESCRIPTION
## Summary

Update ADR README index to reflect current ADR status after review periods have ended.

## Changes

| ADR | Status | Review Period Ended |
|-----|--------|---------------------|
| ADR-0019 | Accepted | - |
| ADR-0020 | Accepted | - |
| ADR-0021 | Accepted | - |
| ADR-0022 | Accepted | - |
| ADR-0023 | Accepted | - |
| ADR-0024 | **Accepted** | 2026-02-01 |
| ADR-0025 | **Accepted** | 2026-02-01 |
| ADR-0026 | **Accepted** | 2026-02-01 |
| ADR-0027 | **Accepted** | 2026-02-02 |

> Note: ADR-0028 review period ends 2026-02-04, remains Proposed.

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] DCO sign-off included
- [x] No breaking changes