### PR TITLE
docs(adr): accept ADR-0024, ADR-0025, ADR-0026, and ADR-0027

### DIFF
--- a/docs/adr/ADR-0024-provider-interface-capability-composition.md
+++ b/docs/adr/ADR-0024-provider-interface-capability-composition.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+status: "accepted"  # proposed | accepted | deprecated | superseded by ADR-XXXX
 date: 2026-01-29
 deciders: []  # GitHub usernames of decision makers
 consulted: []  # Subject-matter experts consulted (two-way communication)

--- a/docs/adr/ADR-0025-secret-bootstrap.md
+++ b/docs/adr/ADR-0025-secret-bootstrap.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-01-30
 deciders: []
 consulted: []

--- a/docs/adr/ADR-0026-idp-config-naming.md
+++ b/docs/adr/ADR-0026-idp-config-naming.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-01-30
 deciders: []
 consulted: []

--- a/docs/adr/ADR-0027-repository-structure-monorepo.md
+++ b/docs/adr/ADR-0027-repository-structure-monorepo.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-01-31
 deciders: []
 consulted: []


### PR DESCRIPTION
## Summary

Accept ADR-0024, ADR-0025, ADR-0026, and ADR-0027 after their 48-hour review periods have ended with no objections.

## ADRs Accepted

| ADR | Title | Review Period |
|-----|-------|---------------|
| ADR-0024 | Provider Interface Capability Composition | Until 2026-02-01 |
| ADR-0025 | Bootstrap Secrets Auto-Generation and Persistence | Until 2026-02-01 |
| ADR-0026 | Auth Provider Naming and Standardized Provider Output | Until 2026-02-01 |
| ADR-0027 | Monorepo Repository Structure with web/ | Until 2026-02-02 |

## Checklist

- [x] Review periods (48+ hours) have ended
- [x] No objections raised during review
- [x] DCO sign-off included