### PR TITLE
docs(adr): add ADR-0026 amendments to ADR-0015 and ADR-0018

### DIFF
--- a/docs/adr/ADR-0015-governance-model-v2.md
+++ b/docs/adr/ADR-0015-governance-model-v2.md
@@ -2277,4 +2277,10 @@ func ValidateIDToken(token *oidc.IDToken, expectedIssuer, expectedAudience strin
 > - **Naming**: All platform-managed names must validate against RFC 1035 rules plus `--` prohibition
 > - **Audit**: Logs must redact: passwords, tokens, secrets, personal identifiers (SSN, ID numbers)
 
+### ADR-0026: Auth Provider Naming (2026-01-30)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §22.6 IdP Configuration Schema (idp_config) | **AMENDED** | Canonical table name is `auth_providers`; `idp_configs` is treated as an alias in docs | [ADR-0026](./ADR-0026-idp-config-naming.md) |
+
 ---

--- a/docs/adr/ADR-0018-instance-size-abstraction.md
+++ b/docs/adr/ADR-0018-instance-size-abstraction.md
@@ -2302,6 +2302,12 @@ RUNNING/STOPPED → DELETING → DELETED (terminal)
 > The `platform:admin` is an explicit, named permission that grants full access through application logic,
 > not pattern matching.
 
+### ADR-0026: Auth Provider Naming (2026-01-30)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §Configuration Storage Strategy (auth_providers) | **AMENDED** | `auth_providers` is canonical; `idp_configs` references are aliases | [ADR-0026](./ADR-0026-idp-config-naming.md) |
+
 ---
 
 _End of ADR-0018_


### PR DESCRIPTION
## Summary

Add ADR-0026 amendment sections to ADR-0015 and ADR-0018 documenting the naming standardization.

## Changes

### ADR-0015
- Add amendment section for §22.6 IdP Configuration Schema
- Document that canonical table name is `auth_providers`

### ADR-0018
- Add amendment section for §Configuration Storage Strategy
- Document that `auth_providers` is canonical, `idp_configs` is treated as alias

## Related Issues

- Refs: #73 (ADR-0025)
- Refs: #74 (ADR-0026)

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] DCO sign-off included
- [x] Changes align with accepted ADR-0026