### PR TITLE
docs(design): sync ADR-0025/0026/0027 to design docs (#73, #74, #81)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -201,6 +201,9 @@ This project follows the architecture decisions documented in:
 | [ADR-0021](../../adr/ADR-0021-api-contract-first.md) | API Contract-First Design | Accepted |
 | [ADR-0022](../../adr/ADR-0022-modular-provider-pattern.md) | Modular Provider Pattern | Accepted |
 | [ADR-0023](../../adr/ADR-0023-schema-cache-and-api-standards.md) | Schema Cache and API Standards | Accepted |
+| [ADR-0025](../../adr/ADR-0025-secret-bootstrap.md) | Bootstrap Secrets Auto-Generation and Persistence | Accepted |
+| [ADR-0026](../../adr/ADR-0026-idp-config-naming.md) | Auth Provider Naming and Standardized Provider Output | Accepted |
+| [ADR-0027](../../adr/ADR-0027-repository-structure-monorepo.md) | Monorepo Repository Structure with web/ | Accepted |
 
 ---
 

--- a/docs/design/interaction-flows/README.md
+++ b/docs/design/interaction-flows/README.md
@@ -90,8 +90,8 @@ These are **infrastructure** settings required before the application can start:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DATABASE_URL` | ✅ | PostgreSQL connection string |
-| `ENCRYPTION_KEY` | ✅ | AES-256-GCM key for sensitive data |
-| `SESSION_SECRET` | ✅ | JWT signing secret |
+| `ENCRYPTION_KEY` | ❌ | AES-256-GCM key for sensitive data (auto-generated if missing) |
+| `SESSION_SECRET` | ❌ | JWT signing secret (auto-generated if missing) |
 | `SERVER_PORT` | ❌ | HTTP port (default: 8080) |
 | `LOG_LEVEL` | ❌ | Logging level (default: info) |
 
@@ -101,7 +101,7 @@ These are **infrastructure** settings required before the application can start:
 
 | Configuration Type | Table | Management |
 |--------------------|-------|------------|
-| Auth Providers (OIDC/LDAP) | `idp_configs` | Web UI |
+| Auth Providers (OIDC/LDAP) | `auth_providers` | Web UI |
 | External Approval Systems | `external_approval_systems` | Web UI |
 | Clusters | `clusters` | Web UI |
 | InstanceSizes, Templates | `instance_sizes`, `templates` | Web UI |

--- a/docs/design/phases/04-governance.md
+++ b/docs/design/phases/04-governance.md
@@ -716,7 +716,7 @@ func (v *TokenValidator) Validate(ctx context.Context, rawToken string) (*Claims
 
 | Table | Purpose |
 |-------|---------|
-| `idp_configs` | OIDC/LDAP provider configuration |
+| `auth_providers` | OIDC/LDAP provider configuration |
 | `idp_synced_groups` | Groups discovered from IdP |
 | `idp_group_mappings` | IdP group → Shepherd role mapping |
 
@@ -934,7 +934,8 @@ If >50% of resources detected as ghosts, halt and alert.
 - [ADR-0017](../../adr/ADR-0017-vm-request-flow-clarification.md) - VM Request Flow
 - [ADR-0018](../../adr/ADR-0018-instance-size-abstraction.md) - Instance Size Abstraction
 - [ADR-0019](../../adr/ADR-0019-governance-security-baseline-controls.md) - Governance Security Baseline
-- [ADR-0020](../../adr/ADR-0020-frontend-technology-stack.md) - Frontend Technology Stack (separate repo)
+- [ADR-0020](../../adr/ADR-0020-frontend-technology-stack.md) - Frontend Technology Stack
+- [ADR-0027](../../adr/ADR-0027-repository-structure-monorepo.md) - Repository Structure (monorepo with `web/`)
 
 ---
 
@@ -973,4 +974,3 @@ If >50% of resources detected as ghosts, halt and alert.
 # CI validation: scripts/check-sqlc-usage.sh
 # Fails build if sqlc imported outside whitelist
 ```
-


### PR DESCRIPTION
## Summary

Sync accepted ADR decisions (ADR-0025, ADR-0026, ADR-0027) to design documentation.

## Related Issues

- Refs #73 (ADR-0025: Bootstrap Secrets)
- Refs #74 (ADR-0026: IdP Config Naming)
- Refs #81 (ADR-0027: Monorepo Structure)

## Changes

| File | Change |
|------|--------|
| `docs/design/README.md` | Add ADR-0025/0026/0027 to ADR index |
| `docs/design/interaction-flows/README.md` | Update `idp_configs` → `auth_providers`, mark secrets as auto-generated |
| `docs/design/phases/04-governance.md` | Update `idp_configs` → `auth_providers`, add ADR-0027 reference |

## ADR Summary

| ADR | Decision | Design Doc Update |
|-----|----------|-------------------|
| ADR-0025 | Secrets auto-generated on first boot | `ENCRYPTION_KEY`, `SESSION_SECRET` marked optional |
| ADR-0026 | Canonical table name `auth_providers` | All references updated |
| ADR-0027 | Monorepo with `web/` directory | ADR-0020 note updated |

## Checklist

- [x] DCO signed off
- [x] Follows Conventional Commits format
- [x] References closed issues correctly (Refs, not Closes)