### PR TITLE
docs(adr): clarify ADR-0029 Go-native scope and add Documents section (#96)

### DIFF
--- a/docs/adr/ADR-0029-openapi-toolchain-governance.md
+++ b/docs/adr/ADR-0029-openapi-toolchain-governance.md
@@ -27,7 +27,7 @@ We need a unified, Go-native toolchain that provides **strict contract enforceme
 
 ## Decision Drivers
 
-* **Go-native tooling**: Align with project's primary language, reduce external dependencies
+* **Go-native backend tooling**: Align backend validation/linting with project's primary language; TypeScript generation remains Node.js-based per ADR-0021
 * **Strict validation**: Catch undeclared fields, schema violations at CI stage
 * **Performance**: Fast feedback in CI pipelines
 * **Governance-first**: Tools should enforce constraints, not just report them
@@ -69,11 +69,12 @@ All gates are **blocking** (fail CI if violated):
 
 ### Consequences
 
-* ✅ Good, because all tooling is Go-native (no Node.js/Python in CI)
+* ✅ Good, because **backend** tooling is Go-native (no Node.js/Python for validation/linting)
 * ✅ Good, because strict mode catches undeclared fields automatically
 * ✅ Good, because vacuum is 10x faster than spectral in CI
 * ✅ Good, because oapi-codegen integration preserved (ADR-0021 compliance)
 * 🟡 Neutral, because adds libopenapi-validator as new dependency
+* 🟡 Neutral, because TypeScript type generation (`openapi-typescript`) still requires Node.js per ADR-0021
 * ❌ Bad, because existing spectral rulesets may need minor adaptation for vacuum
 
 ### Confirmation
@@ -107,6 +108,21 @@ All gates are **blocking** (fail CI if violated):
 * ✅ Good, because complete ecosystem consistency
 * ❌ Bad, because replacing oapi-codegen violates ADR-0021
 * ❌ Bad, because libopenapi code generation less mature
+
+---
+
+## Documents Requiring Updates
+
+Upon acceptance, the following documents require updates:
+
+| Document | Action | Description |
+|----------|--------|-------------|
+| `docs/design/DEPENDENCIES.md` | UPDATE | Add libopenapi, libopenapi-validator; mark spectral/oas-patch as replaced |
+| `Makefile` | ADD | Add `api-lint`, `api-validate`, `api-check` targets |
+| `.github/workflows/api-contract.yaml` | UPDATE | Add vacuum lint gate, libopenapi-validator gate |
+| `internal/api/middleware/openapi_validator.go` | CREATE | Implement StrictMode validation middleware |
+| `api/.vacuum.yaml` | CREATE | Vacuum ruleset configuration |
+| `go.mod` | UPDATE | Add `github.com/pb33f/libopenapi`, `github.com/pb33f/libopenapi-validator` |
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses review feedback on ADR-0029 OpenAPI Toolchain Governance to resolve identified issues and improve ADR template compliance.

## Related Issue

- Refs #96

## Changes

### 1. Clarified "Go-native" Scope (Decision Drivers)

**Before:**
> Go-native tooling: Align with project's primary language, reduce external dependencies

**After:**
> Go-native **backend** tooling: Align backend validation/linting with project's primary language; TypeScript generation remains Node.js-based per ADR-0021

### 2. Fixed Consequences Section

**Before:**
> ✅ Good, because all tooling is Go-native (no Node.js/Python in CI)

**After:**
> ✅ Good, because **backend** tooling is Go-native (no Node.js/Python for validation/linting)
> 🟡 Neutral, because TypeScript type generation (`openapi-typescript`) still requires Node.js per ADR-0021

**Rationale:** `openapi-typescript` is the industry-standard tool for TypeScript type generation from OpenAPI specs. No mature Go-native alternative exists as of 2026. This was an ADR-0021 decision that ADR-0029 does not change.

### 3. Added "Documents Requiring Updates" Section (MANDATORY for Proposed ADRs)

New section listing all documents that require updates upon ADR acceptance:
- `docs/design/DEPENDENCIES.md`
- `Makefile`
- `.github/workflows/api-contract.yaml`
- `internal/api/middleware/openapi_validator.go`
- `api/.vacuum.yaml`
- `go.mod`

## Checklist

- [x] Commits signed off (`-s`)
- [x] Follows Conventional Commits format
- [x] Single issue addressed
- [x] No unrelated changes included

## Review Notes

This PR resolves the "Node.js contradiction" and "missing Documents Requiring Updates" issues identified during ADR review. The review period for ADR-0029 remains until 2026-02-05.