### PR TITLE
docs(impl): update ADR-0029 tool versions for Overlay and validation (#96)

### DIFF
--- a/docs/design/notes/ADR-0029-openapi-toolchain-implementation.md
+++ b/docs/design/notes/ADR-0029-openapi-toolchain-implementation.md
@@ -18,9 +18,9 @@ This document provides detailed implementation specifications for the OpenAPI to
 | Tool | Version | Install Method | Notes |
 |------|---------|---------------|-------|
 | `vacuum` | `>= v0.14.0` | Go binary / Docker | World's fastest OpenAPI linter |
-| `github.com/pb33f/libopenapi` | `>= v0.21.0` | Go module | Lossless OpenAPI parsing |
-| `github.com/pb33f/libopenapi-validator` | `>= v0.2.0` | Go module | Strict mode validation |
-| `oapi-codegen` | `>= v2.4.0` | Go module | ADR-0021 selection |
+| `github.com/pb33f/libopenapi` | `>= v0.31.0` | Go module | Lossless OpenAPI parsing, **Overlay support** (v0.31.0+) |
+| `github.com/pb33f/libopenapi-validator` | `>= v0.6.0` | Go module | StrictMode, **version-aware validation** (3.0 vs 3.1) |
+| `oapi-codegen` | `>= v2.4.1` | Go module | ADR-0021 selection, pin exact version in CI |
 | `openapi-typescript` | `>= v7.0.0` | npm | TypeScript type generation |
 
 ---
@@ -98,7 +98,7 @@ jobs:
           go-version: '1.25'
       
       - name: Install oapi-codegen
-        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
       
       - name: Generate and verify Go code
         run: |


### PR DESCRIPTION
## Summary

Updates tool versions in ADR-0029 implementation details based on feature requirements verified via web search.

## Related Issue

- Refs #96

## Changes

### Version Updates

| Tool | Previous | Updated | Reason |
|------|----------|---------|--------|
| `libopenapi` | `>= v0.21.0` | `>= v0.31.0` | **Overlay support** was introduced in v0.31.0 (2025-12-23) |
| `libopenapi-validator` | `>= v0.2.0` | `>= v0.6.0` | **Version-aware validation** (OpenAPI 3.0 vs 3.1) introduced in v0.6.0 |
| `oapi-codegen` | `@latest` | `@v2.4.1` | **Reproducible builds** - avoid non-deterministic CI behavior |

### Technical Details

1. **libopenapi Overlay**: The ADR specifies using `libopenapi` to replace `oas-patch` for Overlay processing. This feature requires v0.31.0+.

2. **Version-aware Validation**: `libopenapi-validator` v0.6.0 correctly handles OpenAPI version differences:
   - OpenAPI 3.0: Processes `nullable` keyword correctly
   - OpenAPI 3.1+: Enforces strict JSON Schema compliance

3. **Reproducible CI**: Using `@latest` with `go install` can cause different builds to use different tool versions, leading to inconsistent generated code.

## Verification

Version requirements verified via:
- [pb33f.io changelog](https://pb33f.io) - Overlay support in v0.31.0
- [libopenapi-validator docs](https://pb33f.io/libopenapi-validator/) - Version-aware validation in v0.6.0

## Checklist

- [x] Commits signed off (`-s`)
- [x] Follows Conventional Commits format
- [x] Single issue addressed
- [x] Version requirements verified via web search