### PR TITLE
docs(design): add web/ directory to project structure (#81)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -295,7 +295,17 @@ internal/
 │   └── sqlc/         # sqlc queries (limited scope)
 ├── service/          # Business services
 └── usecase/          # Atomic transaction orchestration
+
+web/                  # Frontend (ADR-0027: Monorepo with web/)
+├── src/
+│   ├── components/   # React components
+│   ├── pages/        # Next.js pages
+│   └── types/
+│       └── api.gen.ts  # Generated from OpenAPI (ADR-0021)
+├── public/
+└── package.json
 ```
+
 
 ---
 


### PR DESCRIPTION
## Summary

Sync design README with ADR-0027 monorepo decision by adding the `web/` directory to the target directory structure section.

## Related Issue

- Refs #81 (ADR-0027: Monorepo Repository Structure - closed)

## Changes

- Add `web/` directory structure to the project structure section
- Include frontend subdirectories (components, pages, types) per ADR-0027

## Checklist

- [x] Documentation updated
- [x] ADR compliance verified
- [x] No unrelated changes included