### PR TITLE
docs(design): clarify notification interface design (ADR-0015 §20) (#104)

### DIFF
--- a/docs/design/interaction-flows/master-flow.md
+++ b/docs/design/interaction-flows/master-flow.md
@@ -1471,7 +1471,9 @@ Target: vm-001 (svc-redis → sys-shop)
 │  │      NOW()                                                                        │       │
 │  │  );                                                                                │       │
 │  │                                                                                    │       │
-│  │  -- 4. Notify admins (optional, config-driven)                                     │       │
+│  │  -- 4. Notify admins via NotificationSender interface (ADR-0015 §20)               │       │
+│  │  --    V1: InboxNotificationSender (platform-internal inbox)                        │       │
+│  │  --    V2+: External adapters (Email, Webhook, Slack) via plugin layer              │       │
 │  │  INSERT INTO notifications (                                                      │       │
 │  │      id, recipient_role, type, title, content, related_ticket_id, created_at      │       │
 │  │  ) VALUES (                                                                        │       │

--- a/docs/design/phases/04-governance.md
+++ b/docs/design/phases/04-governance.md
@@ -200,6 +200,9 @@ internal/governance/
 
 ### Status Flow
 
+> **ADR-0005 Phase Extension**: ADR-0005 defines the **approval decision flow** (`PENDING → APPROVED/REJECTED`).
+> This section extends it with **execution tracking phases** (`APPROVED → EXECUTING → SUCCESS/FAILED`) to support River Queue integration and provide complete ticket lifecycle visibility.
+
 > **Ticket Status** (ApprovalTicket table):
 >
 > ```
@@ -952,11 +955,12 @@ If >50% of resources detected as ghosts, halt and alert.
 | §13 Delete Cascade | Section 6.1 | Hierarchical delete |
 | §18 VNC Permissions | Section 6.2 | Token-based access |
 | §19 Batch Operations | ⚠️ **Pending** | Bulk approval/power ops |
-| §20 Notification System | ⚠️ **Pending** | In-app + email alerts |
+| §20 Notification System | ✅ **V1 Inbox** | Platform-internal inbox; decoupled `NotificationSender` interface for V2+ adapters |
 | §22 Authentication (IdP) | ✅ **V1 Scope** | Section 8 - OIDC + LDAP |
-| External Approval Systems | ⚠️ **V1 Interface Only** | Section 9 - API defined, V2 implementation |
+| External Approval Systems | ⚠️ **V1 Interface Only** | Standard data interface; external adapters via plugin layer |
 
-> **Pending items** will be addressed in future iterations. See ADR-0015 for full specification.
+> **Interface-First Design**: Notification and Approval systems use **standard data interfaces** (ADR-0015 §20, §9).
+> V1 implements simple built-in solutions. External integrations (Slack, ServiceNow, Jira) are handled by plugin adapters without core interface changes.
 
 ---
 

--- a/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
+++ b/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
@@ -1474,7 +1474,9 @@
 │  │      NOW()                                                                        │       │
 │  │  );                                                                                │       │
 │  │                                                                                    │       │
-│  │  -- 4. 发送通知到管理员 (可选, 根据配置)                                             │       │
+│  │  -- 4. 通过 NotificationSender 接口通知管理员 (ADR-0015 §20)                        │       │
+│  │  --    V1: InboxNotificationSender (平台内置信箱)                                   │       │
+│  │  --    V2+: 外部适配器 (Email, Webhook, Slack) 通过插件层实现                       │       │
 │  │  INSERT INTO notifications (                                                      │       │
 │  │      id, recipient_role, type, title, content, related_ticket_id, created_at      │       │
 │  │  ) VALUES (                                                                        │       │


### PR DESCRIPTION
## Summary

Update design documents to clarify ADR-0015 §20 notification system design and ADR-0005 status extension.

## Related Issue

- Refs #104

## Changes

- Add `NotificationSender` interface reference in `master-flow.md` notification INSERT
- Clarify V1 (InboxNotificationSender) vs V2+ external adapters (Email, Webhook, Slack)
- Add ADR-0005 Phase Extension clarification in `04-governance.md`
- Update notification/approval coverage index in `04-governance.md`
- Sync Chinese translation of `master-flow.md`

## Checklist

- [x] Documentation updated
- [x] ADR compliance verified
- [x] No unrelated changes included
- [x] i18n sync completed