### PR TITLE
docs(ci): implement API Contract-First CI/CD pipeline (#85, #96)

### DIFF
--- a/docs/design/ci/api-templates/oapi-codegen.yaml
+++ b/docs/design/ci/api-templates/oapi-codegen.yaml
@@ -6,5 +6,10 @@ generate:
   - models
   - spec
   - embedded-spec
+output-options:
+  # Go 1.24+ omitzero support (ADR-0028)
+  # Eliminates "Pointer Hell" for optional fields
+  # See: docs/design/DEPENDENCIES.md §API Contract-First Tooling
+  prefer-skip-optional-pointer-with-omitzero: true
 import-mapping:
   # Add specific mappings here if needed

--- a/docs/design/ci/scripts/check_river_job_args.go
+++ b/docs/design/ci/scripts/check_river_job_args.go
@@ -1,0 +1,154 @@
+// scripts/ci/check_river_job_args.go
+
+/*
+River Job Arguments Claim Check 验证 (ADR-0009)
+
+规则：
+1. River Job Args 结构体只应包含 EventID 字段
+2. 禁止在 Job Args 中传递 vm_id, ticket_id 或其他业务 ID
+3. Worker 通过 EventID 查询 DomainEvent 获取完整数据
+
+误报处理：
+- 某些 Job 可能有合理理由包含其他字段（如 batch_id）
+- 使用 //nolint:river-claim-check 注释跳过检查
+*/
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// 禁止在 Job Args 中出现的字段名
+var forbiddenJobArgFields = map[string]bool{
+	"VMID":       true,
+	"VmID":       true,
+	"VMId":       true,
+	"vm_id":      true,
+	"TicketID":   true,
+	"ticket_id":  true,
+	"ServiceID":  true,
+	"service_id": true,
+	"SystemID":   true,
+	"system_id":  true,
+	"ClusterID":  true,
+	"cluster_id": true,
+}
+
+// 允许的字段名
+var allowedJobArgFields = map[string]bool{
+	"EventID":  true,
+	"event_id": true,
+	"BatchID":  true, // For batch operations
+	"batch_id": true,
+	"Metadata": true, // Generic metadata allowed
+	"TraceID":  true, // Observability
+	"trace_id": true,
+}
+
+type jobArgsVisitor struct {
+	fset       *token.FileSet
+	path       string
+	violations []string
+}
+
+func (v *jobArgsVisitor) Visit(n ast.Node) ast.Visitor {
+	// 查找以 "JobArgs" 或 "Args" 结尾的结构体定义
+	ts, ok := n.(*ast.TypeSpec)
+	if !ok {
+		return v
+	}
+
+	name := ts.Name.Name
+	if !strings.HasSuffix(name, "JobArgs") && !strings.HasSuffix(name, "Args") {
+		return v
+	}
+
+	st, ok := ts.Type.(*ast.StructType)
+	if !ok || st.Fields == nil {
+		return v
+	}
+
+	// 检查结构体字段
+	for _, field := range st.Fields.List {
+		for _, ident := range field.Names {
+			fieldName := ident.Name
+			if forbiddenJobArgFields[fieldName] {
+				pos := v.fset.Position(field.Pos())
+				v.violations = append(v.violations, fmt.Sprintf(
+					"%s:%d: River Job Args %s 包含禁止的字段 '%s' (ADR-0009 Claim Check 要求只传递 EventID)",
+					v.path, pos.Line, name, fieldName,
+				))
+			}
+		}
+	}
+
+	return v
+}
+
+func main() {
+	var violations []string
+
+	// 扫描 usecase 和 worker 目录
+	for _, dir := range []string{"internal/usecase", "internal/worker", "internal/jobs"} {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
+
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			// 检查是否有 nolint 注释
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			if strings.Contains(string(content), "//nolint:river-claim-check") {
+				return nil
+			}
+
+			fset := token.NewFileSet()
+			node, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				return nil
+			}
+
+			visitor := &jobArgsVisitor{
+				fset: fset,
+				path: path,
+			}
+			ast.Walk(visitor, node)
+			violations = append(violations, visitor.violations...)
+
+			return nil
+		})
+
+		if err != nil {
+			fmt.Printf("❌ 遍历目录 %s 失败: %v\n", dir, err)
+		}
+	}
+
+	if len(violations) > 0 {
+		fmt.Println("❌ River Job Args Claim Check 检查失败:")
+		for _, v := range violations {
+			fmt.Printf("  %s\n", v)
+		}
+		fmt.Println("\n📋 规则 (ADR-0009): River Job Args 只应包含 EventID")
+		fmt.Println("📋 正确做法: Worker 通过 EventID 查询 DomainEvent 获取完整数据")
+		fmt.Println("📋 跳过检查: 使用 //nolint:river-claim-check 注释")
+		os.Exit(1)
+	} else {
+		fmt.Println("✅ River Job Args Claim Check 检查通过")
+	}
+}

--- a/docs/design/ci/vacuum/.vacuum.yaml
+++ b/docs/design/ci/vacuum/.vacuum.yaml
@@ -1,0 +1,65 @@
+# api/.vacuum.yaml
+# Vacuum configuration with Spectral-compatible rules (ADR-0029)
+# 
+# This ruleset replaces the previous .spectral.yaml configuration.
+# Vacuum is fully compatible with Spectral rulesets and provides:
+# - 10x faster linting performance (Go-native)
+# - Same rule syntax and severity levels
+# - Additional vacuum-specific features (e.g., runOnChange)
+#
+# Reference: https://quobix.com/vacuum/rulesets/
+
+extends: [[spectral:oas, recommended]]
+
+rules:
+  # Enforce operationId for code generation
+  operation-operationId:
+    severity: error
+    description: "Operations must have operationId for code generation"
+  
+  # Enforce summary for documentation
+  operation-summary:
+    severity: warn
+    description: "Operations should have a summary"
+  
+  # Enforce descriptions
+  operation-description:
+    severity: warn
+    description: "Operations should have a description"
+  
+  # Tag enforcement
+  operation-tag-defined:
+    severity: error
+    description: "Operations must be tagged"
+    
+  # Enforce unique operationIds
+  operation-operationId-unique:
+    severity: error
+    description: "operationIds must be unique across all operations"
+    
+  # Schema property descriptions
+  oas3-schema:
+    severity: warn
+    description: "Schemas should follow OAS3 best practices"
+
+  # Security definitions
+  oas3-operation-security-defined:
+    severity: warn
+    description: "Operations should define security requirements"
+    
+  # Undeclared properties check (critical for StrictMode validation)
+  # This ensures all response fields are explicitly defined in schema
+  oas3-valid-schema-example:
+    severity: error
+    description: "Schema examples must be valid against the schema"
+
+# Vacuum-specific configuration
+settings:
+  # Only run on changed files in CI (performance optimization)
+  runOnChange: true
+  
+  # Fail CI on warnings and above
+  failSeverity: warn
+  
+  # Enable spectral compatibility mode
+  spectralCompatibility: true

--- a/docs/design/ci/workflows/api-contract.yaml
+++ b/docs/design/ci/workflows/api-contract.yaml
@@ -1,7 +1,13 @@
-# API Contract-First Enforcement (ADR-0021)
+# API Contract-First Enforcement (ADR-0021, ADR-0029)
 # This workflow ensures OpenAPI spec remains the single source of truth
 # by validating spec quality, detecting breaking changes, and verifying
 # that generated code stays in sync with the specification.
+#
+# Security Notes (ADR-0029):
+# - All third-party actions pinned to specific commit SHAs
+# - Runner version pinned (ubuntu-22.04, not ubuntu-latest)
+# - Minimal permissions following least privilege principle
+# - Dependabot configured for automated updates
 
 name: API Contract Validation
 
@@ -11,21 +17,28 @@ on:
       - 'api/**'
       - 'internal/api/**'
       - 'web/src/types/api.gen.ts'
-      - '.spectral.yaml'
+      - '.vacuum.yaml'  # ADR-0029: vacuum replaces spectral
   push:
     branches: [main]
     paths:
       - 'api/**'
 
+# Principle of Least Privilege (ADR-0029)
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   # ─────────────────────────────────────────────────────────────────
-  # Stage 1: Validate OpenAPI Specification
+  # Stage 1: Validate OpenAPI Specification (ADR-0029: vacuum)
   # ─────────────────────────────────────────────────────────────────
   lint-spec:
     name: Lint OpenAPI Spec
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Pin runner version
+    timeout-minutes: 10    # Prevent stuck workflows
     steps:
-      - uses: actions/checkout@v4
+      # Pin to specific commit SHA for security
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Check if spec exists
         id: check_file
@@ -36,22 +49,25 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Run Spectral Linting
+      # ADR-0029: Use vacuum instead of spectral (Go-native, 10x faster)
+      - name: Run Vacuum Linting
         if: steps.check_file.outputs.exists == 'true'
-        uses: stoplightio/spectral-action@latest
+        uses: pb33f/vacuum-action@v2
         with:
-          file_glob: 'api/openapi.yaml'
-          spectral_ruleset: 'api/.spectral.yaml'
+          spec: api/openapi.yaml
+          fail_severity: warn
+          ruleset: api/.vacuum.yaml
 
   # ─────────────────────────────────────────────────────────────────
   # Stage 2: Detect Breaking Changes
   # ─────────────────────────────────────────────────────────────────
   breaking-changes:
     name: Detect Breaking Changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -96,20 +112,26 @@ jobs:
   # ─────────────────────────────────────────────────────────────────
   generated-code-sync:
     name: Verify Generated Code Sync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: lint-spec
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
 
+      # Pin oapi-codegen to exact version for reproducibility
+      - name: Install oapi-codegen
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
+
       - name: Setup Node.js (for TypeScript generation)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'web/package-lock.json'
 
@@ -154,9 +176,9 @@ jobs:
   # ─────────────────────────────────────────────────────────────────
   # contract-test:
   #   name: Contract Testing
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   needs: [lint-spec, generated-code-sync]
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Run Dredd contract tests
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+  #     - name: Run contract tests with libopenapi-validator
   #       run: make api-contract-test

--- a/docs/design/notes/ADR-0021-api-contract-first-implementation.md
+++ b/docs/design/notes/ADR-0021-api-contract-first-implementation.md
@@ -597,3 +597,24 @@ additional-imports:
 - [kin-openapi documentation](https://github.com/getkin/kin-openapi)
 - [Spectral CLI](https://github.com/stoplightio/spectral)
 - [go-playground/validator](https://github.com/go-playground/validator)
+- [Vacuum](https://github.com/daveshanley/vacuum) - Go-native OpenAPI linter
+
+---
+
+## Addendum: ADR-0029 Toolchain Migration (2026-02-03)
+
+> **Note**: This document was written before ADR-0029 (OpenAPI Toolchain Governance).
+>
+> Per ADR-0029, the following toolchain changes apply:
+>
+> | This Document | ADR-0029 Replacement |
+> |---------------|----------------------|
+> | `spectral lint` | `vacuum lint` (Go-native, 10x faster, Spectral-rule compatible) |
+> | `kin-openapi` validation | `libopenapi-validator` (StrictMode) |
+> | `oas-patch` | `libopenapi` overlay support |
+>
+> **Spectral rulesets remain compatible** with Vacuum. No rule file changes required.
+>
+> See [ADR-0029](../../adr/ADR-0029-openapi-toolchain-governance.md) and
+> [ADR-0029 Implementation Details](./ADR-0029-openapi-toolchain-implementation.md) for current toolchain.
+


### PR DESCRIPTION
## Summary

Phase 1 implementation of API Contract-First CI/CD pipeline, combining ADR-0021 and ADR-0029 requirements.

## Related Issues

- Refs #85 - API Contract-First CI/CD Pipeline
- Refs #96 - ADR-0029 OpenAPI Toolchain Governance

## Changes

### ADR-0029 vacuum Integration
- Add `.vacuum.yaml` configuration for Go-native OpenAPI linting
- Replace spectral with vacuum for 10x faster linting in CI

### ADR-0021 CI Implementation
- Add `check_river_job_args.go` validation script for River Queue compliance
- Update `oapi-codegen.yaml` template with Go 1.25 omitzero support
- Update `api-contract.yaml` CI workflow with contract validation gates
- Update `api.mk` makefile targets

### Documentation Updates
- Update `docs/design/ci/README.md` with vacuum toolchain reference
- Update `docs/design/phases/01-contracts.md` with CI requirements
- Update `ADR-0021-api-contract-first-implementation.md` with vacuum integration

## Checklist

- [x] All commits signed off (DCO)
- [x] Follows Conventional Commits format
- [x] ADR compliance verified
- [x] No unrelated changes included

## Review Notes

This PR combines two related issues (#85 and #96) because:
1. Both involve CI tooling for API contract enforcement
2. The files overlap significantly (ci/ directory)
3. vacuum is the Go-native replacement specified in ADR-0029 for ADR-0021's linting needs