### PR TITLE
docs(rfc): add RFC-0018 external notification channels (#127)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -13,7 +13,7 @@
 | [RFC-0001](./RFC-0001-pg-partman.md) | PostgreSQL Table Partitioning | Deferred | P2 | Daily jobs > 10M |
 | [RFC-0002](./RFC-0002-temporal.md) | Temporal Workflow Integration | Deferred | P3 | Multi-level approval needed |
 | [RFC-0003](./RFC-0003-helm-export.md) | Helm Chart Export | Deferred | P2 | User request |
-| [RFC-0004](./RFC-0004-external-approval.md) | External Approval Systems | **Proposed** | **P1** | V1+ optional feature |
+| [RFC-0004](./RFC-0004-external-approval.md) | External Approval Systems | **Accepted** | **P1** | V1+ optional feature |
 | [RFC-0005](./RFC-0005-event-archiving.md) | Physical Event Archiving ¹ | Deferred | P2 | DomainEvent table too large |
 | [RFC-0006](./RFC-0006-hot-reload.md) | Configuration Admin API ² | Deferred | P2 | Dynamic config via API |
 | [RFC-0007](./RFC-0007-redis-cache.md) | Redis Cache Support | Deferred | P3 | Cache miss causing bottleneck |
@@ -27,6 +27,7 @@
 | [RFC-0015](./RFC-0015-per-cluster-concurrency.md) | Per-Cluster Concurrency | Deferred | P3 | Distributed semaphore needed |
 | [RFC-0016](./RFC-0016-key-rotation.md) | Secret Key Rotation | Proposed | P2 | Compliance or operator request |
 | [RFC-0017](./RFC-0017-external-secret-provider.md) | External Secret Provider | Deferred | P2 | Enterprise KMS/Vault requirement |
+| [RFC-0018](./RFC-0018-external-notification.md) | External Notification Channels | Deferred | P2 | V1 complete; Email/Webhook/Slack requested |
 
 > **Notes**:
 > - ¹ Soft archiving (`archived_at` field) is implemented in Phase 4; this RFC covers physical archiving to separate tables

--- a/docs/rfc/RFC-0004-external-approval.md
+++ b/docs/rfc/RFC-0004-external-approval.md
@@ -1,6 +1,6 @@
 # RFC-0004: External Approval Systems Integration
 
-> **Status**: Proposed  
+> **Status**: Accepted  
 > **Priority**: P1 (V1+)  
 > **Source**: ADR-0005  
 > **Design**: [Master Flow Stage 2.E](../design/interaction-flows/master-flow.md#stage-2-e)  

--- a/docs/rfc/RFC-0018-external-notification.md
+++ b/docs/rfc/RFC-0018-external-notification.md
@@ -1,0 +1,212 @@
+# RFC-0018: External Notification Channels
+
+> **Status**: Deferred  
+> **Priority**: P2  
+> **Trigger**: V1 completed; user/enterprise request for Email/Webhook/Slack notifications  
+> **Related**: [ADR-0015 §20](../adr/ADR-0015-governance-model-v2.md), [04-governance.md §6.3](../design/phases/04-governance.md#63-notification-system-adr-0015-20)
+
+---
+
+## Problem
+
+V1 implements platform-internal inbox only (PostgreSQL-backed). Users have no way to receive real-time notifications outside the platform UI:
+
+| Limitation | Impact |
+|------------|--------|
+| No email notifications | Users must repeatedly check the platform for updates |
+| No webhook integration | Cannot trigger external automation (ChatOps, ServiceNow) |
+| No mobile push | No real-time alerts for critical events |
+
+Enterprise environments typically require integration with existing communication infrastructure (corporate email, Slack/Teams, PagerDuty-style alerting).
+
+---
+
+## V1 Foundation
+
+V1 establishes the foundation for external notifications:
+
+```go
+// V1: Decoupled NotificationSender interface
+type NotificationSender interface {
+    Send(ctx context.Context, notification *Notification) error
+    SendBatch(ctx context.Context, notifications []*Notification) error
+}
+
+// V1: InboxSender (stores to PostgreSQL)
+type InboxSender struct {
+    db *ent.Client
+}
+```
+
+> **Key Design Decision (ADR-0006 Compliance)**:
+> 
+> - **Internal Inbox** (V1): Synchronous writes within business transaction
+> - **External Channels** (V2+): Async via River Queue for retry resilience
+
+---
+
+## Proposed Solution
+
+### Channel Architecture
+
+```
+                              ┌─────────────────────┐
+                              │  NotificationRouter │
+                              │  (Fanout to channels)│
+                              └─────────┬───────────┘
+                                        │
+          ┌─────────────────────────────┼─────────────────────────────┐
+          │                             │                             │
+          ▼                             ▼                             ▼
+┌──────────────────┐      ┌──────────────────┐      ┌──────────────────┐
+│   InboxSender    │      │   EmailSender    │      │  WebhookSender   │
+│ (Sync, same TX)  │      │ (Async, River)   │      │ (Async, River)   │
+└──────────────────┘      └──────────────────┘      └──────────────────┘
+        │                         │                         │
+        ▼                         ▼                         ▼
+   PostgreSQL               SMTP Server             External System
+  (notifications)         (via template)          (JSON payload)
+```
+
+### River Queue Integration
+
+External channel sends use River Queue for:
+- **Retry on failure**: SMTP server down, webhook timeout
+- **Rate limiting**: Prevent email spam, respect external API limits
+- **Observability**: Track delivery status and failure reasons
+
+```go
+// internal/jobs/external_notification_job.go
+type ExternalNotificationJobArgs struct {
+    NotificationID string `json:"notification_id"`
+    Channel        string `json:"channel"` // "email", "webhook", "slack"
+    Attempt        int    `json:"attempt"`
+}
+
+func (ExternalNotificationJobArgs) Kind() string {
+    return "external_notification_job"
+}
+
+// Worker with retry logic
+func (w *ExternalNotificationWorker) Work(ctx context.Context, job *river.Job[ExternalNotificationJobArgs]) error {
+    notification, err := w.notificationRepo.Get(ctx, job.Args.NotificationID)
+    if err != nil {
+        return river.JobCancel(err) // Not found, don't retry
+    }
+    
+    sender := w.getSender(job.Args.Channel)
+    if err := sender.Send(ctx, notification); err != nil {
+        if isRetryable(err) {
+            return err // River will retry
+        }
+        return river.JobCancel(err) // Non-retryable, mark failed
+    }
+    
+    return nil
+}
+```
+
+### Supported Channels
+
+| Channel | Priority | Configuration | Use Case |
+|---------|----------|---------------|----------|
+| **Email** | P1 | SMTP settings | Approval notifications to team |
+| **Webhook** | P1 | URL + secret | ChatOps, ServiceNow integration |
+| **Slack** | P2 | Webhook URL or OAuth | Team channels |
+| **Microsoft Teams** | P3 | Incoming Webhook | Enterprise Teams integration |
+| **PagerDuty** | P3 | API integration | On-call alerting |
+
+### User Preferences
+
+Users can configure their notification preferences:
+
+```go
+// ent/schema/notification_preference.go
+func (NotificationPreference) Fields() []ent.Field {
+    return []ent.Field{
+        field.String("id").Unique().Immutable(),
+        field.String("user_id").NotEmpty(),
+        field.Enum("channel").Values("inbox", "email", "slack", "webhook"),
+        field.Bool("enabled").Default(true),
+        field.Strings("event_types").Optional(), // Filter which events
+        field.JSON("config", map[string]interface{}{}), // Channel-specific config
+    }
+}
+```
+
+### Admin Configuration
+
+Platform-wide notification settings:
+
+| Setting | Description |
+|---------|-------------|
+| Default channels | Which channels are enabled by default |
+| Email templates | Customizable email templates per event type |
+| Webhook retry policy | Max attempts, backoff strategy |
+| Rate limits | Max emails per user per hour |
+
+---
+
+## Trade-offs
+
+### Pros
+
+- **User experience**: Real-time notifications without platform polling
+- **Enterprise integration**: Works with existing communication tools
+- **Automation**: Webhook enables ChatOps and external workflows
+- **River Queue**: Built on existing async infrastructure
+
+### Cons
+
+- **Complexity**: Additional configuration and maintenance burden
+- **External dependencies**: SMTP server, Slack API availability
+- **Security**: Webhook secrets, email content sensitivity
+- **Cost**: External service usage (Slack API limits, email delivery services)
+
+---
+
+## Implementation Notes
+
+### Phase 1: Email + Webhook (P1)
+
+1. Add `NotificationRouter` to fanout to multiple senders
+2. Implement `EmailSender` with SMTP configuration
+3. Implement `WebhookSender` with HMAC signature
+4. Add River job for async external notification
+5. Create admin UI for channel configuration
+
+### Phase 2: Rich Integrations (P2+)
+
+1. Native Slack integration (OAuth flow)
+2. Microsoft Teams connector
+3. User preference UI
+4. Notification templating engine
+
+### Security Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Email content exposure | Use templates, redact sensitive data |
+| Webhook secret management | Encrypt at rest (ADR-0019) |
+| Rate limiting | Per-channel, per-user limits |
+| Audit logging | Log all external notification attempts |
+
+---
+
+## Migration Path
+
+No breaking changes. V1 inbox continues to work. External channels are additive:
+
+```
+V1: InboxSender only (synchronous)
+V2: InboxSender + EmailSender + WebhookSender (parallel fanout)
+```
+
+---
+
+## References
+
+- [ADR-0015 §20 Notification System](../adr/ADR-0015-governance-model-v2.md)
+- [ADR-0006 Unified Async Model](../adr/ADR-0006-unified-async-model.md)
+- [04-governance.md §6.3](../design/phases/04-governance.md#63-notification-system-adr-0015-20)
+- [River Queue Documentation](https://riverqueue.com/docs)


### PR DESCRIPTION
## Summary

Add RFC-0018 for external notification channel integration.

## Related Issue

- Refs #127

## Changes

- Create `docs/rfc/RFC-0018-external-notification.md`
  - Email, Webhook, Slack channels via River Queue
  - V1 synchronous notification strategy
  - V2+ asynchronous external channels
- Update `docs/rfc/RFC-0004-external-approval.md` status to Accepted
- Update `docs/rfc/README.md` index

## Checklist

- [x] All commits signed off (DCO)
- [x] Follows Conventional Commits format
- [x] No unrelated changes included