### PR TITLE
docs(ops): add operations runbook and SOP documents (#129)

### DIFF
--- a/docs/operations/bootstrap-role-sop.md
+++ b/docs/operations/bootstrap-role-sop.md
@@ -1,0 +1,172 @@
+# Bootstrap Role Security SOP
+
+> **Status**: Required for production deployment  
+> **Reference**: [ADR-0019](../adr/ADR-0019-governance-security-baseline-controls.md)  
+> **Related**: [master-flow.md §Stage 1.A](../design/interaction-flows/master-flow.md)
+
+---
+
+## Overview
+
+The `role-bootstrap` with `platform:admin` permission is a **temporary role** that exists ONLY during initial platform setup. This document defines the standard operating procedure for managing and disabling this role.
+
+> ⚠️ **ADR-0019 Compliance**: Wildcard permissions (`*:*`) are **PROHIBITED** for all roles. The bootstrap role uses `platform:admin` (explicit super-admin permission) and MUST be disabled after initialization.
+
+---
+
+## Bootstrap Role Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                      Bootstrap Role Lifecycle                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  Stage 1: Platform Initialization                                            │
+│  ├── Database seed creates role-bootstrap with platform:admin permission    │
+│  ├── First user account created with bootstrap role                         │
+│  └── Bootstrap user performs initial configuration                          │
+│                                                                              │
+│  Stage 2: Admin Transfer (MANDATORY)                                         │
+│  ├── Bootstrap user creates first PlatformAdmin user                        │
+│  ├── PlatformAdmin user changes bootstrap password                          │
+│  └── System automatically disables bootstrap role (trigger)                 │
+│                                                                              │
+│  Stage 3: Normal Operation                                                   │
+│  ├── role-bootstrap has no active bindings                                   │
+│  ├── All users use explicit permission roles                                 │
+│  └── Audit log records bootstrap role deactivation                          │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Procedure
+
+### Step 1: Complete Initial Setup
+
+Using the bootstrap account:
+
+1. Create at least one user with `role-platform-admin`
+2. Configure required system settings:
+   - Default cluster selection (if applicable)
+   - Authentication provider (OIDC/LDAP)
+   - Initial template import
+
+### Step 2: Transfer Admin Privileges
+
+1. Log in as the newly created PlatformAdmin user
+2. Verify admin functionality works correctly
+3. Navigate to RBAC management and verify permissions
+
+### Step 3: Disable Bootstrap Role
+
+**Option A: Automatic Deactivation (Recommended)**
+
+The system automatically disables the bootstrap role when:
+- The bootstrap user's password is changed by a PlatformAdmin
+- OR 24 hours have elapsed since platform initialization
+
+**Option B: Manual Deactivation**
+
+If automatic deactivation fails, execute manually:
+
+```sql
+-- Verify bootstrap role is still active
+SELECT * FROM role_bindings WHERE role_id = 'role-bootstrap';
+
+-- Remove all bootstrap role bindings
+DELETE FROM role_bindings WHERE role_id = 'role-bootstrap';
+
+-- Record in audit log
+INSERT INTO audit_logs (action, actor, target_type, target_id, details, created_at)
+VALUES (
+  'SECURITY',
+  'system',
+  'role',
+  'role-bootstrap',
+  '{"action": "manual_deactivation", "reason": "SOP compliance"}',
+  NOW()
+);
+```
+
+### Step 4: Verify Deactivation
+
+```sql
+-- Should return 0 rows
+SELECT COUNT(*) FROM role_bindings WHERE role_id = 'role-bootstrap';
+
+-- Verify audit log entry exists
+SELECT * FROM audit_logs 
+WHERE target_id = 'role-bootstrap' 
+AND action = 'SECURITY'
+ORDER BY created_at DESC
+LIMIT 1;
+```
+
+---
+
+## Security Verification Checklist
+
+Run this checklist before going to production:
+
+| Check | SQL Query | Expected Result |
+|-------|-----------|-----------------|
+| No bootstrap bindings | `SELECT COUNT(*) FROM role_bindings WHERE role_id = 'role-bootstrap'` | `0` |
+| No active bootstrap permissions | `SELECT * FROM role_permissions rp JOIN role_bindings rb ON rp.role_id = rb.role_id WHERE rp.role_id = 'role-bootstrap'` | `0 rows` |
+| Audit entry exists | `SELECT * FROM audit_logs WHERE target_id = 'role-bootstrap' AND action = 'SECURITY'` | `≥1 row` |
+| PlatformAdmin uses platform:admin | `SELECT * FROM role_permissions WHERE role_id = 'role-platform-admin'` | Single `platform:admin` permission |
+
+---
+
+## Emergency Access (Break-Glass)
+
+If emergency access is required after bootstrap role deactivation:
+
+1. **DO NOT** re-enable the bootstrap role or create any `*:*` wildcard permissions
+2. Use database-level access with proper authorization and audit trail
+3. Create a new PlatformAdmin user directly in database if needed:
+
+```sql
+-- Emergency: Create emergency admin (requires database admin access)
+-- This action MUST be recorded in change management system
+INSERT INTO users (id, email, name, password_hash, created_at)
+VALUES (
+  gen_random_uuid(),
+  'emergency-admin@company.com',
+  'Emergency Admin',
+  -- Use bcrypt hash of temporary password
+  '$2a$10$...',
+  NOW()
+);
+
+-- Assign platform:admin explicitly (NOT *:*)
+INSERT INTO role_bindings (user_id, role_id, created_at)
+VALUES (
+  (SELECT id FROM users WHERE email = 'emergency-admin@company.com'),
+  'role-platform-admin',
+  NOW()
+);
+```
+
+4. After emergency is resolved, disable the emergency account
+5. Document the incident in security audit log
+
+---
+
+## Periodic Audit (Quarterly)
+
+As per ADR-0019, perform quarterly verification:
+
+1. Run Security Verification Checklist
+2. Review all `role-platform-admin` bindings (should be minimal)
+3. Verify no wildcard permissions exist in any role
+4. Document audit results
+
+---
+
+## Related Documents
+
+- [ADR-0019: Governance Security Baseline Controls](../adr/ADR-0019-governance-security-baseline-controls.md)
+- [master-flow.md: Platform Initialization](../design/interaction-flows/master-flow.md)
+- [04-governance.md: RBAC Model](../design/phases/04-governance.md)

--- a/docs/operations/database-operations.md
+++ b/docs/operations/database-operations.md
@@ -1,0 +1,129 @@
+# PostgreSQL Database Operations Guide
+
+> **Reference ADRs**: 
+> - [ADR-0003](../adr/ADR-0003-database-orm.md) - Database ORM (Ent)
+> - [ADR-0008](../adr/ADR-0008-postgres-only.md) - PostgreSQL Only
+> - [ADR-0012](../adr/ADR-0012-hybrid-transaction.md) - Hybrid Transaction
+
+---
+
+## Critical Configuration: Autovacuum Settings
+
+> ⚠️ **PRODUCTION REQUIREMENT (ADR-0008)**: River job queue tables experience high-frequency inserts/updates/deletes.
+> Without aggressive autovacuum, tables will bloat and **severely degrade performance**.
+
+### Required SQL Commands
+
+Execute these commands on first deployment and verify after PostgreSQL upgrades:
+
+```sql
+-- River job table: aggressive autovacuum (vacuum earlier, at 1% dead tuples instead of 20%)
+ALTER TABLE river_job SET (
+    autovacuum_vacuum_scale_factor = 0.01,  -- 1% threshold (default: 0.2 = 20%)
+    autovacuum_vacuum_threshold = 1000,     -- minimum dead tuples before vacuum
+    autovacuum_analyze_scale_factor = 0.01, -- frequent statistics update
+    autovacuum_analyze_threshold = 500
+);
+
+-- Audit_logs table (high write volume)
+ALTER TABLE audit_logs SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 5000
+);
+
+-- Domain_events table (append-only but may have soft deletes)
+ALTER TABLE domain_events SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 2000
+);
+```
+
+### Verification Query
+
+Run this query periodically to check table health:
+
+```sql
+SELECT 
+    relname AS table_name,
+    n_dead_tup,
+    n_live_tup,
+    round(100.0 * n_dead_tup / nullif(n_live_tup + n_dead_tup, 0), 2) as dead_ratio_percent
+FROM pg_stat_user_tables
+WHERE relname IN ('river_job', 'audit_logs', 'domain_events')
+ORDER BY dead_ratio_percent DESC;
+```
+
+### Monitoring Thresholds
+
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| `dead_ratio_percent` | > 10% | > 30% | Manual VACUUM immediately |
+| `n_dead_tup` (river_job) | > 100,000 | > 500,000 | Check autovacuum daemon |
+
+---
+
+## River Job Queue Cleanup
+
+River client is configured with automatic cleanup:
+
+```go
+riverClient, _ := river.NewClient(riverpgxv5.New(pool), &river.Config{
+    // Automatically delete completed jobs after 24 hours
+    CompletedJobRetentionPeriod: 24 * time.Hour,
+})
+```
+
+### Manual Cleanup (Emergency)
+
+If River automatic cleanup fails:
+
+```sql
+-- Delete completed jobs older than 7 days (emergency cleanup)
+DELETE FROM river_job 
+WHERE state = 'completed' 
+AND finalized_at < NOW() - INTERVAL '7 days';
+
+-- Run VACUUM after large deletes
+VACUUM ANALYZE river_job;
+```
+
+---
+
+## Connection Pool Settings
+
+> **Reference**: [DEPENDENCIES.md](../design/DEPENDENCIES.md) §PostgreSQL
+
+| Parameter | Recommended Value | Rationale |
+|-----------|-------------------|--------------|
+| `max_connections` | 100-200 | Shared pool for Ent + River + sqlc |
+| `shared_buffers` | 25% of RAM | Standard for dedicated DB server |
+| `effective_cache_size` | 75% of RAM | Query planner hint |
+| `work_mem` | 4MB-16MB | Per-operation sort/hash memory |
+
+---
+
+## Backup and Recovery
+
+### Backup Strategy
+
+| Backup Type | Frequency | Retention |
+|-------------|-----------|-----------|
+| Full (pg_dump) | Daily | 30 days |
+| WAL archiving | Continuous | 7 days |
+| Logical (table-level) | Weekly | 90 days |
+
+### Restore Testing
+
+**Quarterly requirement**: Restore a backup to a test environment and verify:
+1. Application startup succeeds
+2. Health checks pass (`/health/ready`)
+3. Recent data is present
+
+---
+
+## Related Documents
+
+- [00-prerequisites.md §7.5](../design/phases/00-prerequisites.md) - PostgreSQL Stability Configuration
+- [ADR-0008](../adr/ADR-0008-postgres-only.md) - PostgreSQL Only Decision
+- [ADR-0012](../adr/ADR-0012-hybrid-transaction.md) - Hybrid Transaction Strategy
+- [DEPENDENCIES.md](../design/DEPENDENCIES.md) - Version Requirements


### PR DESCRIPTION
## Summary

Add operations documentation including runbooks and standard operating procedures.

## Related Issue

- Refs #129

## Changes

- `docs/operations/bootstrap-role-sop.md` - Bootstrap role setup SOP (ADR-0019 compliant)
- `docs/operations/database-operations.md` - Database maintenance runbook

## Checklist

- [x] All commits signed off (DCO)
- [x] Follows Conventional Commits format
- [x] No unrelated changes included