### PR TITLE
docs: fix ADR-0028 status in DEPENDENCIES.md (#83)

### DIFF
--- a/docs/design/DEPENDENCIES.md
+++ b/docs/design/DEPENDENCIES.md
@@ -202,11 +202,11 @@ func (c *DatabaseClients) Close() {
 >
 > ⚠️ **ADR Status Notice**:
 > - **ADR-0021**: Accepted ✅
-> - **ADR-0028**: Proposed ⏳ (omitzero field strategy)
+> - **ADR-0028**: Accepted ✅ (omitzero field strategy)
 > - **ADR-0029**: Proposed ⏳ (toolchain governance)
 >
-> Specifications below that reference ADR-0028/ADR-0029 are **provisional** and may change upon ADR acceptance.
-> If these ADRs are rejected or modified, this document must be updated accordingly.
+> Specifications below that reference ADR-0029 are **provisional** and may change upon ADR acceptance.
+> If ADR-0029 is rejected or modified, this document must be updated accordingly.
 
 ### OpenAPI Specification Versions
 


### PR DESCRIPTION
## Summary

Fix ADR-0028 status in DEPENDENCIES.md to reflect its acceptance status.

## Related Issue

Refs #83

## Changes

Update ADR Status Notice section:
- ADR-0028: `Proposed ⏳` → `Accepted ✅`
- Update provisional specifications notice to only reference ADR-0029

## Context

ADR-0028 (oapi-codegen Optional Field Strategy with Go 1.25 omitzero) passed its 48-hour review period on 2026-02-04 and has been accepted. The ADR README already shows the correct status; this PR syncs DEPENDENCIES.md.

## Checklist

- [x] All commits signed off (DCO)
- [x] Follows Conventional Commits format
- [x] No unrelated changes included