### PR TITLE
docs: sync ADR-0028/0029 acceptance status (#96, #83)

### DIFF
--- a/docs/adr/ADR-0029-openapi-toolchain-governance.md
+++ b/docs/adr/ADR-0029-openapi-toolchain-governance.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+status: "accepted"  # proposed | accepted | deprecated | superseded by ADR-XXXX
 date: 2026-02-03
 deciders: []  # GitHub usernames of decision makers
 consulted: []  # Subject-matter experts consulted (two-way communication)
@@ -9,7 +9,7 @@ informed: []  # Stakeholders kept up-to-date (one-way communication)
 
 # ADR-0029: OpenAPI Toolchain Governance
 
-> **Review Period**: Until 2026-02-05 (48-hour minimum)  
+> **Accepted**: 2026-02-05 (48-hour review period completed)  
 > **Discussion**: [Issue #96](https://github.com/kv-shepherd/shepherd/issues/96)  
 > **Amends**: [ADR-0021 §Technology Stack](./ADR-0021-api-contract-first.md)
 

--- a/docs/design/DEPENDENCIES.md
+++ b/docs/design/DEPENDENCIES.md
@@ -203,10 +203,7 @@ func (c *DatabaseClients) Close() {
 > ⚠️ **ADR Status Notice**:
 > - **ADR-0021**: Accepted ✅
 > - **ADR-0028**: Accepted ✅ (omitzero field strategy)
-> - **ADR-0029**: Proposed ⏳ (toolchain governance)
->
-> Specifications below that reference ADR-0029 are **provisional** and may change upon ADR acceptance.
-> If ADR-0029 is rejected or modified, this document must be updated accordingly.
+> - **ADR-0029**: Accepted ✅ (toolchain governance)
 
 ### OpenAPI Specification Versions
 

--- a/docs/design/checklist/phase-1-checklist.md
+++ b/docs/design/checklist/phase-1-checklist.md
@@ -119,7 +119,7 @@
 ## Optional Field Strategy (ADR-0028)
 
 > **Purpose**: Ensure generated Go types use `omitzero` tag to eliminate pointer hell.    
-> **Note**: ADR-0028 is Proposed; checklist items are provisional until acceptance.
+> **Note**: ADR-0028 is Accepted. See [ADR-0028](../../adr/ADR-0028-oapi-codegen-optional-field-strategy.md).
 
 - [ ] `go.mod` requires Go 1.25+ (enables `omitzero` support)
 - [ ] `api/oapi-codegen.yaml` contains:

--- a/docs/design/notes/ADR-0029-openapi-toolchain-implementation.md
+++ b/docs/design/notes/ADR-0029-openapi-toolchain-implementation.md
@@ -1,7 +1,7 @@
 # ADR-0029 Implementation Details: OpenAPI Toolchain Governance
 
 > **Parent ADR**: [ADR-0029](../../adr/ADR-0029-openapi-toolchain-governance.md)  
-> **Status**: Implementation specification for ADR-0029 (parent ADR status: **proposed**)
+> **Status**: Implementation specification for ADR-0029 (parent ADR status: **accepted**)
 
 ---
 


### PR DESCRIPTION
## Summary

Synchronize documentation to reflect ADR-0028 and ADR-0029 acceptance status after 48-hour review period completion.

## Related Issue

- Refs #96 (ADR-0029 OpenAPI Toolchain Governance)
- Refs #83 (ADR-0028 oapi-codegen optional field strategy)

## Changes

| File | Change |
|------|--------|
| `docs/adr/ADR-0029-openapi-toolchain-governance.md` | `proposed` → `accepted` |
| `docs/design/notes/ADR-0029-openapi-toolchain-implementation.md` | Sync parent ADR status |
| `docs/design/DEPENDENCIES.md` | Remove provisional warning for ADR-0029 |
| `docs/design/checklist/phase-1-checklist.md` | Update ADR-0028 to Accepted |

## Checklist

- [x] All commits signed off (DCO)
- [x] Follows Conventional Commits format
- [x] Documentation-only change
- [x] No unrelated changes included
- [x] PR addresses related issues atomically

## Review Notes

This is a documentation sync PR following ADR acceptance. The 48-hour review period for both ADRs has been completed.