### PR TITLE
docs: fix legacy path references in ADR-0001 and RFC-0006 (#139)

### DIFF
--- a/docs/adr/ADR-0001-kubevirt-client.md
+++ b/docs/adr/ADR-0001-kubevirt-client.md
@@ -13,7 +13,7 @@ Use the official KubeVirt `kubevirt.io/client-go` client library.
 |------|-------|
 | Package | `kubevirt.io/client-go` |
 | API Definitions | `kubevirt.io/api` |
-| Version | See [DEPENDENCIES.md](../projects/core-go/DEPENDENCIES.md) (single source of truth) |
+| Version | See [DEPENDENCIES.md](../design/DEPENDENCIES.md) (single source of truth) |
 
 ---
 

--- a/docs/rfc/RFC-0006-hot-reload.md
+++ b/docs/rfc/RFC-0006-hot-reload.md
@@ -57,4 +57,4 @@ NOTIFY config_changed, 'v1.2.3';
 
 ## References
 
-- [Phase 00: Prerequisites](../projects/core-go/phases/00-prerequisites.md)
+- [Phase 00: Prerequisites](../design/phases/00-prerequisites.md)


### PR DESCRIPTION
## Summary

Fix broken path references in legacy ADR and RFC documents that still point to the old `projects/core-go/` directory structure.

## Related Issue

- Closes #139

## Changes

| File | Old Path | New Path |
|------|----------|----------|
| `docs/adr/ADR-0001-kubevirt-client.md` | `../projects/core-go/design/` | `../design/` |
| `docs/rfc/RFC-0006-hot-reload.md` | `../projects/core-go/design/` | `../design/` |

## Checklist

- [x] All commits signed off (DCO)
- [x] Follows Conventional Commits format
- [x] Documentation-only change
- [x] No unrelated changes included
- [x] Links verified to work correctly

## Review Notes

This is a simple path fix PR. The repository underwent a directory restructuring where `projects/core-go/design/` was moved to `docs/design/`.