### PR TITLE
docs: sync master-flow with ADR-0006 notification exception (#125)

### DIFF
--- a/docs/adr/ADR-0006-unified-async-model.md
+++ b/docs/adr/ADR-0006-unified-async-model.md
@@ -149,6 +149,24 @@ River built-in states mapping to business semantics:
 
 ---
 
+## Notification Exception
+
+> **V1 In-app notifications are synchronous writes**
+>
+> Platform-internal notifications (inserted into `notifications` table) are **synchronous** writes within the same DB transaction as business operations. This is an intentional design decision:
+>
+> | Channel | V1 Handling | Rationale |
+> |---------|-------------|-----------|
+> | **In-app inbox** | Sync (same transaction) | Ensures atomicity with business operation; no external I/O overhead |
+> | **V2+ External channels** (Email/Webhook/Slack) | Async (River Job) | External I/O requires fault tolerance and retry semantics |
+>
+> **Why synchronous notifications don't violate ADR-0006**:
+> - ADR-0006's async mandate addresses **K8s API calls** and **external I/O** that may timeout or fail
+> - In-app notifications are **internal DB writes** with negligible latency
+> - Same-transaction semantics ensure "business success = notification visible" atomicity
+>
+> See [04-governance.md §6.3](../design/phases/04-governance.md#63-notification-system-adr-0015-20) for implementation details.
+
 ## Stability Prerequisites
 
 All-in-PG strategy **must** be combined with the following measures for stability:

--- a/docs/design/FRONTEND.md
+++ b/docs/design/FRONTEND.md
@@ -9,6 +9,7 @@
 
 | Component | Technology | Version | Notes |
 |-----------|------------|---------|-------|
+| Core Library | React | 19.x | Required by Next.js 15 |
 | Framework | Next.js | 15.x | App Router (server components) |
 | Language | TypeScript | 5.8+ | Strict mode |
 | UI Library | Ant Design | 5.x | Enterprise UI components |

--- a/docs/design/interaction-flows/master-flow.md
+++ b/docs/design/interaction-flows/master-flow.md
@@ -55,10 +55,12 @@ database development.
 
 | ADR | Constraint | Scope |
 |-----|------------|-------|
-| **ADR-0006** | All write operations use **unified async model** (request → 202 → River Queue) | All state-changing operations |
+| **ADR-0006** | All write operations use **unified async model** (request → 202 → River Queue) | All state-changing operations ¹ |
 | **ADR-0009** | River Jobs carry **EventID only** (Claim Check); DomainEvent payload is **immutable** | All River Jobs |
 | **ADR-0012** | Atomic transactions: Ent for ORM, **sqlc for core transactions only** | All DB operations |
 
+> ¹ **Exception**: V1 in-app notifications are synchronous (same DB transaction). See [ADR-0006 §Notification Exception](../../adr/ADR-0006-unified-async-model.md#notification-exception).
+>
 > **CI Enforcement**: These constraints are enforced by CI checks. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for validation scripts.
 
 ---

--- a/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
+++ b/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
@@ -54,10 +54,12 @@
 
 | ADR | 约束 | 适用范围 |
 |-----|------|---------|
-| **ADR-0006** | 所有写操作使用**统一异步模型**（请求 → 202 → River 队列） | 所有状态变更操作 |
+| **ADR-0006** | 所有写操作使用**统一异步模型**（请求 → 202 → River 队列） | 所有状态变更操作 ¹ |
 | **ADR-0009** | River Job 仅携带 **EventID**（Claim Check）；DomainEvent payload **不可变** | 所有 River Job |
 | **ADR-0012** | 原子事务：Ent 用于 ORM，**sqlc 仅用于核心事务** | 所有数据库操作 |
 
+> ¹ **例外**: V1 应用内通知为同步写入（与业务操作同一数据库事务）。详见 [ADR-0006 §Notification Exception](../../../../adr/ADR-0006-unified-async-model.md#notification-exception)。
+>
 > **CI 强制执行**: 这些约束由 CI 检查强制执行。参见 [CONTRIBUTING.md](../../../CONTRIBUTING.md) 了解验证脚本。
 
 ---


### PR DESCRIPTION
## Summary

Synchronize master-flow documentation with ADR-0006 notification exception clarification.

## Related Issue

- Refs #125

## Changes

- **ADR-0006**: Add "Notification Exception" section clarifying that V1 in-app notifications are synchronous writes (within the same DB transaction as business operations), NOT via River Queue
- **master-flow.md**: Add footnote ¹ to ADR-0006 constraint referencing the notification exception
- **master-flow.md (zh-CN)**: Sync Chinese translation with English version
- **FRONTEND.md**: Add React 19.x to technology stack table (aligns with master-flow.md)

## Rationale

The global constraint table in master-flow.md states "All write operations use unified async model". However, V1 in-app notifications are intentionally synchronous (§5.F explicitly states this).

This PR:
1. Documents the exception officially in ADR-0006
2. Adds a footnote to master-flow.md so readers understand the exception exists
3. Creates a clear documentation chain: constraint → exception → rationale

## Checklist

- [x] Commits signed off (DCO)
- [x] Documentation updated (EN + CN)
- [x] ADR compliance verified
- [x] No unrelated changes included