### PR TITLE
docs: fix ADR compliance issues in design notes (#131)

### DIFF
--- a/docs/design/notes/ADR-0026-idp-config-naming.md
+++ b/docs/design/notes/ADR-0026-idp-config-naming.md
@@ -1,6 +1,6 @@
 # ADR-0026 Design Notes: Auth Provider Naming Unification
 
-> **Status**: Active (ADR-0026 accepted 2026-01-30)
+> **Status**: Active (ADR-0026 **Accepted** ✅ 2026-01-30)
 
 ## Summary
 
@@ -30,5 +30,5 @@ Adapters normalize to:
 
 ## References
 
-- ADR-0026 (proposed)
+- ADR-0026 (Accepted)
 - ADR-0015 §22.6 (IdP config schema, amended by ADR-0026)

--- a/docs/design/phases/02-providers.md
+++ b/docs/design/phases/02-providers.md
@@ -26,6 +26,17 @@ Implement infrastructure providers:
 - Cluster health checking
 - Capability detection (ADR-0014)
 
+> **⚠️ Interface Composition Constraint (ADR-0004, ADR-0024)**:
+>
+> Provider implementations MUST use **interface composition** pattern defined in [examples/provider/interface.go](../examples/provider/interface.go).
+>
+> | ADR | Requirement |
+> |-----|-------------|
+> | ADR-0004 | Provider interfaces must be composable (single responsibility per interface) |
+> | ADR-0024 | Capability-based interface selection (providers expose only supported interfaces) |
+>
+> **Example**: `KubeVirtProvider` embeds `VMOperator + SnapshotOperator + MigrationOperator` based on cluster capabilities.
+
 > **📖 Document Hierarchy (Prevents Content Drift)**:
 >
 > | Document | Authority | Scope |


### PR DESCRIPTION
## Summary

Fix ADR compliance issues in design notes and phase documents.

## Related Issue

- Refs #131

## Changes

- **ADR-0026-idp-config-naming.md**: Fix status capitalization
  - `accepted` → `Accepted` (consistent with ADR README format)
  - `(proposed)` → `(Accepted)` in reference text
- **02-providers.md**: Add Interface Composition Constraint note
  - Reference ADR-0004 (Provider Interface) and ADR-0024 (Composable Interfaces)
  - Clarify that provider implementations must follow interface composition principles

## Checklist

- [x] Commits signed off (DCO)
- [x] Documentation updated
- [x] ADR compliance verified
- [x] No unrelated changes included