### PR TITLE
docs(adr): ADR compliance updates for ADR-0018/0021/0029 (#131)

### DIFF
--- a/docs/adr/ADR-0018-instance-size-abstraction.md
+++ b/docs/adr/ADR-0018-instance-size-abstraction.md
@@ -2308,6 +2308,23 @@ RUNNING/STOPPED → DELETING → DELETED (terminal)
 |------------------|--------|-------------------|----------|
 | §Configuration Storage Strategy (auth_providers) | **AMENDED** | `auth_providers` is canonical; `idp_configs` references are aliases | [ADR-0026](./ADR-0026-idp-config-naming.md) |
 
+### ADR-0023: Schema Cache Management (2026-01-28) — Clarification
+
+| Original Section | Status | Clarification Details | See Also |
+|------------------|--------|----------------------|----------|
+| §Multi-Cluster Schema Compatibility Strategy | **CLARIFIED** | "No fallback" refers to **validation results** only. ADR-0023 extends schema **fetch** layer with graceful degradation. | [ADR-0023 §Graceful Degradation](./ADR-0023-schema-cache-and-api-standards.md#graceful-degradation-strategy) |
+
+> **Important Clarification**: This ADR's "No Degradation" principle (Line 1494) applies to **validation outcomes**:
+> - Incompatible InstanceSize configuration → **ERROR** (not a fallback/degraded acceptance)
+>
+> ADR-0023 supplements this with **schema fetch** layer resilience:
+> - Schema fetch fails → Use **embedded fallback schema** for validation
+> - This ensures system availability while maintaining strict validation
+>
+> **These two principles are complementary, not contradictory**:
+> - Schema acquisition: Graceful degradation (ADR-0023)
+> - Validation result: Strict pass/fail, no silent degradation (ADR-0018)
+
 ---
 
 _End of ADR-0018_


### PR DESCRIPTION
## Summary

ADR compliance updates addressing multiple ADR synchronization requirements:
- ADR-0018: Add ADR-0023 coordination clarification
- ADR-0021: Update toolchain per ADR-0029 (vacuum, libopenapi)
- CI scripts: Align with ADR-0029 toolchain

**Supersedes**: #148 (closed due to incorrect stash restoration)

## Related Issues

- Refs #131 (ADR compliance updates for ADR-0018)
- Refs #96 (ADR-0029 OpenAPI Toolchain Governance)

## Changes

### ADR-0018 Amendment
- Added ADR-0023 clarification to Amendments section
- Explanation: "no fallback" applies to **validation results** only (incompatible config → ERROR)
- ADR-0023 supplements schema **fetch** layer with graceful degradation (embedded fallback)
- These principles are **complementary, not contradictory**

### ADR-0021 Implementation Design (per ADR-0029)
| Section | Before | After |
|---------|--------|-------|
| Makefile `api-lint` | `spectral lint` | `vacuum lint` |
| Compat Overlay | `oas-patch` | `libopenapi overlay` |
| CI workflow | `spectral-cli` | `vacuum` + `libopenapi-validator` |
| Implementation Checklist | `.spectral.yaml` | `.vacuum.yaml` |
| References | Spectral (active) | ~~Spectral~~ + Vacuum + libopenapi |

### CI Script
- Updated `openapi-compat-generate.sh` to use `libopenapi` overlay support
- Replaced `oas-patch` with Go-native `libopenapi` (ADR-0029 compliance)

## Checklist

- [x] DCO signed commit
- [x] Follows Conventional Commits format
- [x] ADR compliance verified (ADR-0018, ADR-0021, ADR-0029)
- [x] No unrelated changes included
- [x] ✅ **Verified**: All file changes manually applied and diffs checked to ensure no accidental deletions.

## Review Notes

1. ADR-0018 amendment clarifies the schema loading strategy coordination
2. All toolchain updates align with accepted ADR-0029