### PR TITLE
docs(adr): add context propagation rule to ADR-0031

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,13 +32,16 @@
 | [ADR-0020](./ADR-0020-frontend-technology-stack.md) | Frontend Technology Stack | **Accepted** | - |
 | [ADR-0021](./ADR-0021-api-contract-first.md) | API Contract-First Design | **Accepted** | - |
 | [ADR-0022](./ADR-0022-modular-provider-pattern.md) | Modular Provider Pattern | **Accepted** | - |
-| [ADR-0023](./ADR-0023-schema-cache-management.md) | Schema Cache Management and API Standardization | **Accepted** | - |
+| [ADR-0023](./ADR-0023-schema-cache-and-api-standards.md) | Schema Cache Management and API Standardization | **Accepted** | - |
 | [ADR-0024](./ADR-0024-provider-interface-capability-composition.md) | Provider Interface Capability Composition | **Accepted** | - |
 | [ADR-0025](./ADR-0025-secret-bootstrap.md) | Bootstrap Secrets Auto-Generation and Persistence | **Accepted** | - |
 | [ADR-0026](./ADR-0026-idp-config-naming.md) | Auth Provider Naming and Standardized Provider Output | **Accepted** | - |
 | [ADR-0027](./ADR-0027-repository-structure-monorepo.md) | Monorepo Repository Structure with web/ | **Accepted** | - |
 | [ADR-0028](./ADR-0028-oapi-codegen-optional-field-strategy.md) | oapi-codegen Optional Field Strategy | **Accepted** | - |
-| [ADR-0029](./ADR-0029-openapi-toolchain-governance.md) | OpenAPI Toolchain Governance | **Proposed** | - |
+| [ADR-0029](./ADR-0029-openapi-toolchain-governance.md) | OpenAPI Toolchain Governance | **Accepted** | - |
+| [ADR-0030](./ADR-0030-design-documentation-layering-and-fullstack-governance.md) | Design Documentation Layering and Full-Stack Governance | **Accepted** | - |
+| [ADR-0031](./ADR-0031-concurrency-and-worker-pool-standard.md) | Concurrency Safety and Worker Pool Standard | **Proposed** | - |
+| [ADR-0032](./ADR-0032-master-flow-traceability-manifest.md) | Master-Flow Traceability Manifest and Drift Enforcement | **Proposed** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:
 >
@@ -106,7 +109,7 @@ For newcomers, we recommend reading ADRs in this order:
 
 > **📋 Template**: Use the official [TEMPLATE.md](./TEMPLATE.md) file for new ADRs.
 
-### Best Practices (CNCF Guidelines)
+### Best Practices
 
 | Guideline | Description |
 |-----------|-------------|


### PR DESCRIPTION
## Summary

Add **Rule 2: Context Propagation** to ADR-0031 based on review feedback.

## Problem Addressed

The original ADR-0031 only addressed:
- Rule 1: No naked `go` statements
- Rule 2 (now 3): No Worker Pool nested in River
- Rule 3 (now 4): Semaphore leak-safe usage

Missing: **No constraint on cancellation and timeout propagation**, leaving governance gaps:
- Requests cancelled but tasks continue executing
- Inconsistent timeout handling
- Uncontrollable task tailing during graceful shutdown

## New Rule 2: Context Propagation

```markdown
2. **Worker Pool API must support context propagation**
   - The submission method (e.g., `Submit(ctx, func(ctx))`) MUST accept `context.Context`.
   - The implementation MUST respect context cancellation/timeout for graceful shutdown.
   - **Request-scoped tasks** MUST pass the upstream request context; check `ctx.Done()` at blocking points.
   - **Detached background tasks** MUST use a service-lifecycle context with explicit "detached" semantics.
```

## Justification

| Aspect | Rationale |
|--------|-----------|
| **Architecture Consistency** | CHECKLIST.md already requires "Context correctly passed in all async operations" |
| **Stability Priority** | Without context, Worker Pool cannot respond to graceful shutdown signals |
| **Rule Completeness** | Original Rule 1 only forbids naked goroutines but doesn't constrain the replacement API |
| **Best Practices** | Web search confirms `context.Context` is mandatory for Go concurrency in 2025/2026 |

## Also Included

- Update `docs/adr/README.md` index:
  - Add ADR-0030, ADR-0031, ADR-0032 entries
  - Fix ADR-0023 filename reference
  - Update ADR-0029 status to Accepted

## Review Notes

⏳ This PR extends the review period discussions for ADR-0031. The ADR remains in **Proposed** status.

---

Refs #151