### PR TITLE
docs(design): add ADR-0030 documentation layering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ System (Business Line) → Service (Application) → VM Instance
 - **Design Notes** capture proposed changes before ADR acceptance
 - Normative design specs are updated only after ADRs are accepted
 
+## Documentation Map
+
+- [docs/README.md](docs/README.md) - documentation index
+- [docs/adr/README.md](docs/adr/README.md) - ADR catalog and reading order
+- [docs/design/interaction-flows/master-flow.md](docs/design/interaction-flows/master-flow.md) - canonical interaction flow
+- [docs/design/README.md](docs/design/README.md) - implementation design index
+- [docs/design/frontend/README.md](docs/design/frontend/README.md) - frontend design layer
+- [docs/design/database/README.md](docs/design/database/README.md) - database design layer
+- [docs/design/ci/README.md](docs/design/ci/README.md) - CI/governance checks
+
 ## Project Status
 
 > ⚠️ **Pre-Alpha**: Planning and design phase.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,17 @@ docs/
 ├── adr/                      # Architecture Decision Records
 │   ├── README.md             # ADR index with status table
 │   ├── GLOSSARY.md           # Technical terminology
-│   └── ADR-0001 ~ ADR-0014   # Individual ADRs (superseded ones remain here)
+│   └── ADR-0001 ~ ADR-0030   # Individual ADRs (superseded ones remain here)
 │
 ├── rfc/                      # Request for Comments (Future Features)
 │   ├── README.md             # RFC index with priorities
-│   └── RFC-0001 ~ RFC-0015   # Individual RFCs
+│   └── RFC-0001 ~ RFC-0018   # Individual RFCs
 │
 └── design/                   # Implementation Design
     ├── README.md             # Core Go Refactor Project overview
+    ├── interaction-flows/    # Canonical interaction outcomes
+    │   ├── README.md
+    │   └── master-flow.md
     ├── DEPENDENCIES.md       # Version pinning (single source of truth)
     ├── CHECKLIST.md          # Acceptance criteria (dashboard)
     ├── phases/               # Implementation phase specifications
@@ -36,16 +39,28 @@ docs/
     │   ├── phase-3-checklist.md
     │   └── phase-4-checklist.md
     ├── examples/             # Reference implementations
-    │   ├── config/           # Configuration management
-    │   ├── domain/           # Domain models, events
-    │   ├── infrastructure/   # Database connection pool
-    │   ├── handlers/         # HTTP handlers
-    │   ├── provider/         # Provider interfaces
-    │   ├── usecase/          # Atomic transaction examples
-    │   └── worker/           # Worker pool pattern
+    │   ├── README.md
+    │   ├── config/
+    │   ├── domain/
+    │   ├── infrastructure/
+    │   ├── handlers/
+    │   ├── provider/
+    │   ├── usecase/
+    │   └── worker/
+    ├── database/             # Database reference layer
+    │   └── README.md
+    ├── frontend/             # Frontend specification layer
+    │   └── README.md
+    ├── notes/                # Design notes (pre-ADR)
+    │   └── README.md
+    ├── traceability/         # Machine-readable traceability manifest (ADR-0032)
+    │   └── master-flow.json
     └── ci/                   # CI check scripts
         ├── README.md         # Script index
         └── scripts/          # Check scripts
+│
+├── i18n/                     # Translation docs mirror
+│   └── README.md
 ```
 
 ---
@@ -56,7 +71,7 @@ docs/
 
 > **New to this project?** Read these 3 sections first (~5 min total):
 >
-> 1. **[design/DEPENDENCIES.md](./design/DEPENDENCIES.md)** lines 1-70 (core dependencies)
+> 1. **[design/interaction-flows/master-flow.md](./design/interaction-flows/master-flow.md)** (product interaction source of truth)
 > 2. **[design/README.md → Architecture Overview](./design/README.md#architecture-overview)** (request flow diagram)
 > 3. **[adr/README.md → Reading Order](./adr/README.md#reading-order)** (which ADRs to read)
 >
@@ -67,25 +82,25 @@ docs/
 **Recommended reading order for implementing this project:**
 
 1. **[design/DEPENDENCIES.md](./design/DEPENDENCIES.md)** - Understand version constraints FIRST (single source of truth)
-2. **[adr/README.md](./adr/)** - Follow the "Reading Order" section for architectural decisions
+2. **[adr/README.md](./adr/README.md)** - Follow the "Reading Order" section for architectural decisions
 3. **[design/README.md](./design/README.md)** - Project overview and structure
-4. **[design/phases/](./design/phases/)** - Sequential implementation (00 → 01 → 02 → 03 → 04)
-5. **[design/examples/](./design/examples/)** - Reference implementations
-6. **[design/checklist/](./design/checklist/)** - Verification criteria for each phase
+4. **[design/README.md → Implementation Phases](./design/README.md#implementation-phases)** - Sequential implementation (00 → 01 → 02 → 03 → 04)
+5. **[design/examples/README.md](./design/examples/README.md)** - Reference implementations
+6. **[design/checklist/README.md](./design/checklist/README.md)** - Verification criteria for each phase
 
 ### For Architects
 
-Start with [ADRs](./adr/) to understand the architectural decisions:
+Start with [ADRs](./adr/README.md) to understand the architectural decisions:
 1. [ADR-0003: Database ORM](./adr/ADR-0003-database-orm.md) - Core data persistence
 2. [ADR-0006: Unified Async Model](./adr/ADR-0006-unified-async-model.md) - All writes are async
 3. [ADR-0012: Hybrid Transaction](./adr/ADR-0012-hybrid-transaction.md) - Ent + sqlc atomicity
 
 ### For Developers
 
-Start with the [Design](./design/) directory:
-1. [README.md](./design/README.md) - Project overview
+Start with the [Design](./design/README.md) directory:
+1. [design/README.md](./design/README.md) - Project overview
 2. [Phase 00](./design/phases/00-prerequisites.md) - Project setup
-3. [Examples](./design/examples/) - Reference implementations
+3. [Examples](./design/examples/README.md) - Reference implementations
 
 ### For Future Planning
 

--- a/docs/adr/ADR-0023-schema-cache-and-api-standards.md
+++ b/docs/adr/ADR-0023-schema-cache-and-api-standards.md
@@ -487,9 +487,8 @@ The Schema-Driven UI pattern creates a critical dependency on Schema Cache avail
 | Updating | Background fetch in progress | Loading indicator |
 | Degraded | No schema available | Basic fields only + error alert |
 
-> **Detailed Implementation**: See [FRONTEND.md §Schema Cache Degradation Strategy](../design/FRONTEND.md#schema-cache-degradation-strategy-adr-0023) for code examples, i18n keys, and UI component patterns.
+> **Detailed Implementation**: See [frontend/FRONTEND.md §Schema Cache Degradation Strategy](../design/frontend/FRONTEND.md#schema-cache-degradation-strategy-adr-0023) for code examples, i18n keys, and UI component patterns.
 
 ---
 
 _End of ADR-0023_
-

--- a/docs/adr/ADR-0030-design-documentation-layering-and-fullstack-governance.md
+++ b/docs/adr/ADR-0030-design-documentation-layering-and-fullstack-governance.md
@@ -1,0 +1,132 @@
+---
+status: "accepted"
+date: 2026-02-06
+deciders: []
+consulted: []
+informed: []
+---
+
+# ADR-0030: Design Documentation Layering and Full-Stack Governance
+
+> **Accepted**: 2026-02-06  
+> **Amends**: [ADR-0020 §Frontend Engineering Scope](./ADR-0020-frontend-technology-stack.md), [ADR-0027 §Repository Structure](./ADR-0027-repository-structure-monorepo.md)  
+> **Related**: [ADR-0015](./ADR-0015-governance-model-v2.md), [ADR-0021](./ADR-0021-api-contract-first.md), [ADR-0029](./ADR-0029-openapi-toolchain-governance.md)
+
+---
+
+## Context and Problem Statement
+
+Frontend design guidance existed mainly in a single `docs/design/FRONTEND.md` file. As backend design expanded into phased documents, frontend concerns became easy to miss, and cross-doc links drifted. We need a documentation structure and CI governance model that keeps frontend and backend design equally visible and consistently reviewed.
+
+## Decision Drivers
+
+* Prevent frontend/backend documentation drift in a monorepo workflow
+* Keep interaction flow (`master-flow.md`) and implementation specs aligned
+* Enforce full-stack acceptance through one global checklist standard
+* Add CI guardrails for design-document path/link/governance consistency
+
+## Considered Options
+
+* **Option 1**: Keep single-file frontend spec (`docs/design/FRONTEND.md`)
+* **Option 2**: Frontend docs under `docs/design/frontend/` with layered subdirectories
+* **Option 3**: Split frontend docs into a separate repository
+
+## Decision Outcome
+
+**Chosen option**: "Option 2", because it preserves monorepo atomicity while giving frontend design first-class structure and explicit governance hooks.
+
+### Normative Decisions
+
+1. **Frontend docs location**
+   - Move canonical frontend spec to `docs/design/frontend/FRONTEND.md`.
+   - `docs/design/FRONTEND.md` is retired.
+
+2. **Frontend documentation layering**
+   - `docs/design/frontend/` must contain structured subdirectories by concern:
+     - `architecture/`
+     - `features/`
+     - `contracts/`
+     - `testing/`
+   - `docs/design/frontend/README.md` is the navigation entry for frontend design docs.
+
+3. **Global acceptance standard**
+   - `docs/design/CHECKLIST.md` remains the single global acceptance standard for full-stack delivery.
+   - `docs/design/checklist/` phase checklists are execution checklists and must map back to `CHECKLIST.md`.
+
+4. **Master-flow alignment requirement**
+   - `docs/design/interaction-flows/master-flow.md` remains the single source of truth for interaction flow.
+   - Frontend feature docs must reference master-flow stages for flow semantics and must not redefine contradictory status/transition models.
+
+5. **CI governance for docs**
+   - Design-phase CI artifacts must include checks for:
+     - Retired path usage (e.g., `docs/design/FRONTEND.md`)
+     - Broken canonical cross-links between master-flow, phase docs, frontend docs, and checklists
+     - Required governance statements in checklist/readme anchors
+   - These checks are mandatory before coding-phase transition.
+
+### Consequences
+
+* ✅ Good, because frontend guidance becomes discoverable by topic instead of one large file
+* ✅ Good, because full-stack collaboration is explicitly gated by checklist and CI
+* ✅ Good, because master-flow alignment becomes a documented governance rule
+* 🟡 Neutral, because contributors must follow new docs paths and update old links
+* ❌ Bad, because there is short-term migration overhead for path updates and CI scripts
+
+### Confirmation
+
+* `docs/design/README.md` points to `docs/design/frontend/FRONTEND.md` and `docs/design/frontend/README.md`
+* `master-flow.md` and ADR references no longer point to retired `docs/design/FRONTEND.md`
+* `docs/design/checklist/README.md` explicitly states global acceptance relationship with `CHECKLIST.md`
+* Design CI includes docs governance checks and corresponding phase-0 checklist gates
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Keep single-file frontend spec
+
+* ✅ Good, because minimal change effort
+* ❌ Bad, because frontend sections become too broad and easy to ignore
+* ❌ Bad, because cross-flow conflicts are harder to detect
+
+### Option 2: Layered frontend docs under `docs/design/frontend/`
+
+* ✅ Good, because concerns are separated by architecture/feature/contract/testing
+* ✅ Good, because easier to enforce cross-links to master-flow and checklists
+* 🟡 Neutral, because requires migration/update of legacy links
+* ❌ Bad, because adds initial directory maintenance cost
+
+### Option 3: Separate frontend docs repository
+
+* ✅ Good, because independent frontend doc lifecycle
+* ❌ Bad, because violates ADR-0027 monorepo atomic change goal
+* ❌ Bad, because API-contract and flow sync would become cross-repo coordination
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0020](./ADR-0020-frontend-technology-stack.md) - Frontend stack and baseline spec
+* [ADR-0027](./ADR-0027-repository-structure-monorepo.md) - Monorepo requirement (`web/`)
+* [ADR-0021](./ADR-0021-api-contract-first.md) - API contract-first workflow
+* [ADR-0015](./ADR-0015-governance-model-v2.md) - Batch and governance interaction model
+
+### Implementation Notes
+
+* Migrate existing frontend references to the new path tree in one change set
+* Keep frontend feature docs scoped to UX/interaction behavior and reference backend phase docs for server-side internals
+* Treat CI docs governance scripts as required artifacts before coding phase
+
+### References
+
+* KubeVirt Shepherd design docs in `docs/design/`
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-06 | @codex | Initial decision |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -27,13 +27,31 @@ docs/design/
 ├── README.md                 # This file
 ├── DEPENDENCIES.md           # Dependency versions (single source of truth)
 ├── CHECKLIST.md              # Acceptance criteria
+├── interaction-flows/        # Canonical interaction outcomes (master-flow)
+│   ├── README.md             # Interaction flow index
+│   └── master-flow.md        # Product interaction source of truth
 ├── phases/                   # Implementation phase specifications
 │   ├── 00-prerequisites.md   # Project setup, toolchain
 │   ├── 01-contracts.md       # Interface definitions, schemas
 │   ├── 02-providers.md       # KubeVirt provider
 │   ├── 03-service-layer.md   # Business logic, transactions
 │   └── 04-governance.md      # Approval workflow, River Queue
+├── notes/                    # Proposed changes before ADR acceptance
+│   └── README.md             # Design notes guide
+├── database/                 # Database reference layer (schema/lifecycle/transactions/migrations)
+│   ├── README.md             # Database docs index
+│   ├── schema-catalog.md     # Canonical table groups and relationships
+│   ├── lifecycle-retention.md # Hard delete and retention policy baseline
+│   ├── transactions-consistency.md # Transaction and async consistency boundaries
+│   └── migrations.md         # Atlas/River migration rules
 ├── checklist/                # Per-phase acceptance checklists
+├── frontend/                 # Frontend design specifications (ADR-0030)
+│   ├── README.md             # Frontend docs index
+│   ├── FRONTEND.md           # Frontend engineering baseline
+│   ├── architecture/         # Frontend architecture decisions
+│   ├── features/             # Feature interaction and UX specs
+│   ├── contracts/            # API/type contract integration rules
+│   └── testing/              # Frontend testing and CI gates
 ├── examples/                 # Reference implementations
 │   ├── README.md             # Example index
 │   ├── config/               # Configuration management
@@ -43,6 +61,8 @@ docs/design/
 │   ├── domain/               # Domain models, events
 │   ├── provider/             # Provider interfaces
 │   └── usecase/              # Atomic transaction examples
+├── traceability/             # Traceability manifest (ADR-0032)
+│   └── master-flow.json      # Master-flow stage mapping (machine-readable)
 └── ci/                       # CI check scripts
     ├── README.md             # Script index
     └── scripts/              # Check scripts
@@ -168,7 +188,7 @@ docs/design/
 | Pattern | Use Instead |
 |---------|-------------|
 | `import "gorm.io/gorm"` | Ent ORM (ADR-0003) |
-| `go func() { ... }()` | Worker Pool |
+| `go func() { ... }()` | Worker Pool (ADR-0031) |
 | Wire/fx DI | Manual DI (ADR-0013) |
 | K8s calls inside DB transaction | Two-phase pattern (ADR-0012) |
 
@@ -176,7 +196,7 @@ docs/design/
 
 ## Architecture Decisions
 
-All architecture decisions are documented in [docs/adr/](../../adr/). For the authoritative list of **enforced constraints** with CI checks, see [CHECKLIST.md §Core ADR Constraints](./CHECKLIST.md#core-adr-constraints-single-reference-point).
+All architecture decisions are documented in [docs/adr/README.md](../adr/README.md). For the authoritative list of **enforced constraints** with CI checks, see [CHECKLIST.md §Core ADR Constraints](./CHECKLIST.md#core-adr-constraints-single-reference-point).
 
 ---
 
@@ -237,11 +257,13 @@ Reference implementations are in the [examples/](./examples/) directory:
 
 | Document | Description |
 |----------|-------------|
-| ⭐ **[master-flow.md](./interaction-flows/master-flow.md)** | **Single source of truth** for all interaction flows (data input/processing/output). Start here for understanding system behavior. |
+| ⭐ **[master-flow.md](./interaction-flows/master-flow.md)** | **Single source of truth for product interaction outcomes** (data input/processing/output and user-visible behavior). |
+| [database/README.md](./database/README.md) | **Database reference layer** (schema domains, retention lifecycle, transaction boundaries, migration policy) |
 | [DEPENDENCIES.md](./DEPENDENCIES.md) | Version pinning (single source of truth for all dependency versions) |
 | [CHECKLIST.md](./CHECKLIST.md) | Acceptance criteria and **Core ADR Constraints** (single source of truth for CI enforcement) |
-| [FRONTEND.md](./FRONTEND.md) | Frontend engineering specification (i18n, API types) |
-| [ci/README.md](./ci/README.md) | CI scripts index |
+| [frontend/README.md](./frontend/README.md) | Frontend design docs index (required reading before frontend changes) |
+| [frontend/FRONTEND.md](./frontend/FRONTEND.md) | Frontend engineering baseline (i18n, API types, schema fallback) |
+| [ci/README.md](./ci/README.md) | **Authoritative CI/development governance** (quality gates, enforcement scripts, workflow requirements) |
 | [examples/README.md](./examples/README.md) | Code examples index |
 
 ---
@@ -332,6 +354,6 @@ go run cmd/server/main.go
 
 ## References
 
-- [ADR Directory](../../adr/) - Architecture decisions
-- [RFC Directory](../../rfc/) - Future feature proposals
-- [Glossary](../../adr/GLOSSARY.md) - Technical terminology
+- [ADR Directory](../adr/README.md) - Architecture decisions
+- [RFC Directory](../rfc/README.md) - Future feature proposals
+- [Glossary](../adr/GLOSSARY.md) - Technical terminology

--- a/docs/design/checklist/README.md
+++ b/docs/design/checklist/README.md
@@ -1,6 +1,9 @@
 # Checklist Directory
 
-> This directory contains the acceptance checklists split by implementation phase.
+> **Role**: Phase execution checklists under the global acceptance standard.
+>
+> **Global Single Standard**: [../CHECKLIST.md](../CHECKLIST.md) is the only project-wide frontend+backend acceptance baseline.
+> Files in this directory are phase-scoped execution checklists that must stay aligned with it.
 
 ---
 
@@ -18,12 +21,13 @@
 
 ## Usage
 
-1. Each phase checklist should be completed before moving to the next phase
-2. All items marked with `[ ]` must become `[x]` before phase completion
-3. Pre-verification items at the end of each phase validate prerequisites for the next phase
+1. Complete each phase checklist before entering the next phase.
+2. All `[ ]` items must be converted to `[x]` for phase completion.
+3. Any new checklist item must map to an ADR, phase spec, or global checklist entry.
+4. Frontend-impacting changes must update both frontend checklist items and corresponding backend/API checklist items.
 
 ---
 
 ## Main Checklist
 
-For cross-phase verification, progress tracking, and prohibited patterns, see the main [CHECKLIST.md](../CHECKLIST.md).
+For cross-phase verification, progress tracking, and prohibited patterns, use [CHECKLIST.md](../CHECKLIST.md) as the authoritative reference.

--- a/docs/design/database/README.md
+++ b/docs/design/database/README.md
@@ -1,0 +1,55 @@
+# Database Design Index
+
+> **Authority**: This directory is the database-focused reference layer for `docs/design/`.
+> It defines persistent data boundaries, lifecycle, and transactional consistency rules.
+
+---
+
+## Scope
+
+This layer is authoritative for:
+
+- Database object ownership and table catalog
+- Resource lifecycle and retention policy at persistence level
+- Transaction/consistency boundaries (ADR-0006, ADR-0009, ADR-0012)
+- Migration and schema evolution rules
+
+This layer is not for:
+
+- End-user interaction storyboards (see [master-flow.md §Stage 5.D](../interaction-flows/master-flow.md#stage-5-d))
+- API request/response contract details (see [01-contracts.md §3 Core Ent Schemas](../phases/01-contracts.md#3-core-ent-schemas))
+- CI gate policy details (see [ci/README.md §Scope Boundary](../ci/README.md#scope-boundary))
+
+---
+
+## Document Map
+
+| Document | Purpose |
+|------|------|
+| [schema-catalog.md §Table Domains](./schema-catalog.md#table-domains) | Canonical table groups, ownership, and key relationships |
+| [lifecycle-retention.md §Retention Classes](./lifecycle-retention.md#retention-classes-table-centric) | Hard-delete policy, retained records, and archival baseline |
+| [transactions-consistency.md §Canonical Write Pattern](./transactions-consistency.md#canonical-write-pattern) | Transaction boundaries and async consistency model |
+| [vm-lifecycle-write-model.md §Stage 5.A](./vm-lifecycle-write-model.md#stage-5a-vm-request-submission-pending-approval) | VM request/approval/delete/batch/VNC write sets and state transitions |
+| [migrations.md §Apply Order](./migrations.md#apply-order) | Atlas/River migration flow and rollout rules |
+
+---
+
+## Relationship with Other Layers
+
+- [master-flow.md §Stage 5.D](../interaction-flows/master-flow.md#stage-5-d) describes interaction intent and links here for database principles.
+- [phase docs](../phases/04-governance.md#1-database-migration) provide implementation-level details that must comply with this layer.
+- [examples/README.md §Example Index](../examples/README.md#example-index) indexes code patterns implementing these rules.
+
+When conflicts are found:
+
+1. Accepted ADR
+2. This database layer + [CHECKLIST.md §Core ADR Constraints](../CHECKLIST.md#core-adr-constraints-single-reference-point)
+3. Phase and example docs
+4. Interaction flow representation
+
+---
+
+## Change Governance
+
+- Structural or behavioral DB changes (delete semantics, retention semantics, transaction model) must trace to ADR decisions.
+- Editorial and linkage updates can be applied directly with CI checks and review.

--- a/docs/design/database/lifecycle-retention.md
+++ b/docs/design/database/lifecycle-retention.md
@@ -1,0 +1,102 @@
+# Data Lifecycle and Retention
+
+> **Purpose**: Define persistence-level lifecycle, archival, and purge policy.
+> This document is database-focused and does not define user interaction flow.
+
+---
+
+## Scope Boundary
+
+This document defines:
+
+- Table-level retention classes
+- Archival strategy (`archived_at`, export, purge windows)
+- Database-side protection for immutable compliance data
+
+This document does not define:
+
+- Approval decisions or UI confirmation flow
+- API behavior and endpoint contracts
+- Action naming conventions for business workflow
+
+For those, see:
+
+- [master-flow.md §Stage 5.D Delete Operations](../interaction-flows/master-flow.md#stage-5-d)
+- [master-flow.md §Audit Log Design](../interaction-flows/master-flow.md#audit-log-design)
+- [04-governance.md §6.1 Delete Cascade and Confirmation](../phases/04-governance.md#61-delete-cascade-and-confirmation-mechanism-adr-0015-13-131)
+- [04-governance.md §7 Audit Logging](../phases/04-governance.md#7-audit-logging)
+
+---
+
+## Retention Classes (Table-Centric)
+
+| Class | Tables (Representative) | Lifecycle | Purge Policy |
+|------|------|------|------|
+| Primary runtime state | `systems`, `services`, `vms` | Final state uses hard delete for removed resources | No long-term tombstone in primary tables |
+| Immutable compliance/event | `audit_logs`, `domain_events` | Append-only records; may be marked archived | Purge only by scheduled admin-controlled job with separate audit trail |
+| Workflow history | `approval_tickets`, `batch_approval_tickets` | Retained for traceability; eligible for archival (`approval_tickets.parent_ticket_id` carries child lineage) | Purge by retention window and policy class |
+| Operational transient | `notifications`, selected queue/runtime records | Time-window retention | Periodic cleanup job |
+
+---
+
+## Archival Model
+
+### In-Database Archive Marking
+
+- Use nullable `archived_at` where table semantics require "retained but cold" data.
+- Keep index support for archive filtering (for example, index on `archived_at`).
+- Archived records remain queryable for compliance/reporting paths.
+
+### Export and Cold Storage
+
+- For large immutable datasets (especially `audit_logs`), support periodic export to external storage/SIEM.
+- Export does not bypass in-database minimum retention requirements.
+
+### Physical Purge
+
+- Physical deletion is done only by scheduled privileged job.
+- Purge job execution must itself be auditable.
+- Purge criteria must be time-window + class-based (for example, environment/sensitivity).
+
+---
+
+## Database Guardrails
+
+| Guardrail | Requirement |
+|------|------|
+| Append-only protection | Application roles must not have `UPDATE`/`DELETE` on immutable compliance tables |
+| Privilege separation | Purge capability restricted to dedicated admin role/job |
+| Archival safety | Archive queries rely on indexed time fields (`created_at`, `archived_at`) |
+| Change control | Retention window changes require documented review and traceability |
+
+---
+
+## Baseline Windows (Policy Defaults)
+
+| Policy Scope | Minimum Retention |
+|------|------|
+| Production audit data | >= 1 year |
+| Test audit data | >= 90 days |
+| Sensitive governance operations | >= 3 years |
+
+These are baseline defaults. Stricter organizational compliance rules take precedence.
+
+---
+
+## Operational Responsibilities
+
+| Job Type | Responsibility |
+|------|------|
+| Archive marker job | Mark eligible records with `archived_at` according to policy |
+| Export job | Deliver immutable records to external compliance/analytics sink |
+| Purge job | Permanently delete only records past policy threshold and legal hold checks |
+
+---
+
+## References
+
+- [schema-catalog.md §Table Domains](./schema-catalog.md#table-domains)
+- [migrations.md §Migration Rules](./migrations.md#migration-rules)
+- [04-governance.md §7 Audit Logging](../phases/04-governance.md#7-audit-logging)
+- [ADR-0015 §13 Deletion Cascade Constraints](../../adr/ADR-0015-governance-model-v2.md#13-deletion-cascade-constraints)
+- [ADR-0019 §3 Audit Logging and Sensitive Data Controls](../../adr/ADR-0019-governance-security-baseline-controls.md#3-audit-logging-and-sensitive-data-controls)

--- a/docs/design/database/migrations.md
+++ b/docs/design/database/migrations.md
@@ -1,0 +1,57 @@
+# Migrations
+
+> **Purpose**: Define schema evolution workflow for business tables and queue tables.
+
+---
+
+## Tooling Ownership
+
+| Scope | Tool | Source |
+|------|------|------|
+| Business schema | Atlas (from Ent schema) | `ent/schema/*.go`, Atlas migration files |
+| Queue schema | River migration tool | `river migrate-up` managed tables |
+
+---
+
+## Apply Order
+
+1. Apply Atlas migrations (business/domain tables).
+2. Apply River migrations (queue runtime tables).
+3. Run startup/schema validation checks.
+
+Rationale:
+
+- Business schema must exist before request/worker workflows rely on it.
+- River tables are runtime dependencies for async processing.
+
+---
+
+## Migration Rules
+
+- Backward compatibility first: avoid breaking running workers/controllers mid-rollout.
+- For destructive schema evolution, use staged rollout (expand -> migrate -> contract).
+- Keep DDL and code changes in the same PR/changeset when tightly coupled.
+- Regenerate code artifacts after schema changes (Ent/sqlc as applicable).
+
+---
+
+## Rollout Checklist
+
+- Migration scripts reviewed and reproducible in local/dev environments.
+- No prohibited manual DDL in app startup path.
+- CI checks pass for schema/codegen/governance scripts.
+- Rollback/mitigation notes included for non-trivial changes.
+
+---
+
+## Operational Notes
+
+- Monitor queue table bloat/autovacuum (`river_*`) and audit table growth.
+- Ensure retention/archival jobs are aligned with lifecycle policy.
+
+See:
+
+- [00-prerequisites.md §6 Database Connection](../phases/00-prerequisites.md#6-database-connection)
+- [00-prerequisites.md §Manual Migration](../phases/00-prerequisites.md#manual-migration-developmentci)
+- [04-governance.md §1 Database Migration](../phases/04-governance.md#1-database-migration)
+- [04-governance.md §2 River Queue](../phases/04-governance.md#2-river-queue-adr-0006)

--- a/docs/design/database/schema-catalog.md
+++ b/docs/design/database/schema-catalog.md
@@ -1,0 +1,51 @@
+# Schema Catalog
+
+> **Purpose**: Define canonical table domains and ownership boundaries.
+> Detailed field definitions remain in Ent schema and phase documents.
+
+---
+
+## Source of Truth
+
+- Ent schema definitions: `ent/schema/*.go`
+- Governance and audit schema details: [04-governance.md §6.1 and §7](../phases/04-governance.md#61-delete-cascade-and-confirmation-mechanism-adr-0015-13-131)
+- Contract and entity schema details: [01-contracts.md §3 Core Ent Schemas](../phases/01-contracts.md#3-core-ent-schemas)
+
+---
+
+## Table Domains
+
+| Domain | Core Tables | Notes |
+|------|------|------|
+| Primary resources | `systems`, `services`, `vms`, `templates`, `instance_sizes`, `clusters`, `namespace_registry` | Runtime-owned entities |
+| Governance and approvals | `approval_tickets`, `batch_approval_tickets`, `approval_policies` | Approval workflow and batch orchestration (`approval_tickets.parent_ticket_id` models child linkage) |
+| Platform RBAC | `users`, `roles`, `permissions`, `role_permissions`, `role_bindings`, `resource_role_bindings` | Platform-level access control |
+| Event and async | `domain_events`, River tables (`river_job`, `river_*`) | Claim-check and async execution |
+| Audit and notifications | `audit_logs`, `notifications` | Compliance and user feedback |
+| Auth provider integration | `auth_providers`, `idp_synced_groups`, `idp_group_mappings`, `external_approval_systems` | Enterprise auth and external approvals |
+| Security/bootstrap | `system_secrets`, session/auth tables | Secret bootstrap and auth runtime |
+| Recovery and compensation | `pending_adoptions` | Resource adoption compensation capability |
+| Rate limiting | `rate_limit_counter`, `rate_limit_exemption` | ADR-0015 two-layer limits support |
+
+---
+
+## Relationship Baseline
+
+- `systems` 1:N `services`
+- `services` 1:N `vms`
+- `approval_tickets` link request lifecycle to resources and events
+- `domain_events` are immutable execution intents consumed by River workers
+- `audit_logs` are append-only compliance records
+
+---
+
+## Hard Delete Boundary
+
+- Primary resource tables (`systems`, `services`, `vms`) use hard delete in final state.
+- `DELETING` is a transient operational state, not a long-term tombstone strategy.
+- Audit/event/ticket records are retained independently by policy.
+
+See:
+
+- [lifecycle-retention.md §Retention Classes](./lifecycle-retention.md#retention-classes-table-centric)
+- [04-governance.md §6.1 Delete Cascade and Confirmation](../phases/04-governance.md#61-delete-cascade-and-confirmation-mechanism-adr-0015-13-131)

--- a/docs/design/database/transactions-consistency.md
+++ b/docs/design/database/transactions-consistency.md
@@ -1,0 +1,58 @@
+# Transactions and Consistency
+
+> **Purpose**: Define transaction boundaries and async consistency model for database writes.
+
+---
+
+## Governing ADR Constraints
+
+- ADR-0006: unified async model for external-system writes
+- ADR-0009: immutable DomainEvent payload (claim-check)
+- ADR-0012: hybrid transaction strategy (Ent + sqlc scope control)
+- ADR-0015: approval/governance workflow model
+
+---
+
+## Canonical Write Pattern
+
+1. Synchronous transaction (request phase):
+   - Validate business constraints.
+   - Write core DB records (for example: ticket + domain event + initial audit).
+   - Insert River job in-transaction when required by workflow.
+2. Asynchronous worker phase:
+   - Consume DomainEvent/Job.
+   - Call provider/K8s API outside DB transaction.
+   - Persist final state/audit updates.
+
+---
+
+## Hard Rules
+
+- No K8s/provider calls inside database transactions.
+- DomainEvent payload is append-only/immutable.
+- Do not mix sqlc transaction handle and Ent transaction handle incorrectly.
+- For delete flows:
+  - Apply cascade checks before execution.
+  - Use transient `DELETING` lock where defined.
+  - Hard-delete primary row only after execution success.
+
+---
+
+## Failure Handling Baseline
+
+| Failure Point | Expected Behavior |
+|------|------|
+| Validation/pre-check failure | Reject request, no side-effect writes |
+| Transaction failure (request phase) | Rollback all writes in that transaction |
+| Worker external call failure | Keep record in retryable/failed state, append failure audit |
+| Partial batch failure | Preserve successful children, expose aggregate `PARTIAL_SUCCESS` |
+
+---
+
+## References
+
+- [03-service-layer.md §3 Transaction Integration](../phases/03-service-layer.md#3-transaction-integration-adr-0012)
+- [04-governance.md §2 River Queue](../phases/04-governance.md#2-river-queue-adr-0006)
+- [04-governance.md §3 Domain Event Pattern](../phases/04-governance.md#3-domain-event-pattern-adr-0009)
+- [ADR-0006 §Decision](../../adr/ADR-0006-unified-async-model.md#decision)
+- [ADR-0012 §Decision](../../adr/ADR-0012-hybrid-transaction.md#decision)

--- a/docs/design/database/vm-lifecycle-write-model.md
+++ b/docs/design/database/vm-lifecycle-write-model.md
@@ -1,0 +1,151 @@
+# VM Lifecycle Write Model
+
+> **Purpose**: Authoritative persistence model for VM lifecycle stages referenced by
+> `interaction-flows/master-flow.md`.
+>
+> **Scope**: Write sets, transaction boundaries, and status transitions.
+> Detailed DDL/index definitions remain in schema and migration documents.
+
+---
+
+## Authority Links
+
+- [ADR-0006 Unified Async Model](../../adr/ADR-0006-unified-async-model.md)
+- [ADR-0009 Domain Event Pattern](../../adr/ADR-0009-domain-event-pattern.md)
+- [ADR-0012 Hybrid Transaction](../../adr/ADR-0012-hybrid-transaction.md)
+- [ADR-0015 §13 Deletion Cascade Constraints](../../adr/ADR-0015-governance-model-v2.md#13-deletion-cascade-constraints)
+- [ADR-0015 §19 Batch Operations V1](../../adr/ADR-0015-governance-model-v2.md#19-batch-operations)
+- [04-governance.md §5.6 Batch Operations](../phases/04-governance.md#56-batch-operations-adr-0015-19)
+- [04-governance.md §6.1 Delete Cascade and Confirmation](../phases/04-governance.md#61-delete-cascade-and-confirmation-mechanism-adr-0015-13-131)
+- [04-governance.md §7 Audit Logging](../phases/04-governance.md#7-audit-logging)
+
+---
+
+## Stage 5.A: VM Request Submission (Pending Approval)
+
+### Transaction Boundary
+
+- Pre-check (outside transaction): duplicate pending request detection.
+- Main write transaction (single commit):
+  - Insert `domain_events` (`VM_CREATE_REQUESTED`, `PENDING`)
+  - Insert `approval_tickets` (`VM_CREATE`, `PENDING_APPROVAL`)
+  - Insert `audit_logs` (`vm.request_submitted`)
+  - Insert `notifications` (admin inbox)
+
+### Write-Set Diagram
+
+```
+User Submit
+  -> duplicate check (pending ticket exists?)
+  -> TX begin
+       -> domain_events: PENDING
+       -> approval_tickets: PENDING_APPROVAL
+       -> audit_logs: vm.request_submitted
+       -> notifications: APPROVAL_REQUIRED
+     TX commit
+  -> response 202 + ticket_id
+```
+
+### State Conclusions
+
+| Entity | Before | After |
+|------|------|------|
+| `approval_tickets` | none | `PENDING_APPROVAL` |
+| `domain_events` | none | `PENDING` |
+| `vms` | none | none |
+| `river_job` | none | none |
+
+---
+
+## Stage 5.B: Admin Approval / Rejection
+
+### Approve Path Transaction
+
+- Update `approval_tickets` to `APPROVED` and persist approval snapshot fields.
+- Update `domain_events` to `PROCESSING`.
+- Insert `vms` row with transient status `CREATING`.
+- Insert `river_job` with EventID claim-check payload.
+- Insert `audit_logs` (`vm.request_approved`) and notification for requester.
+
+### Reject Path Transaction
+
+- Update `approval_tickets` to `REJECTED`.
+- Update `domain_events` to `CANCELLED`.
+- Insert `audit_logs` (`vm.request_rejected`) and requester notification.
+- No `vms` insert, no `river_job` insert.
+
+### State Conclusions
+
+| Path | Ticket | Domain Event | VM Row | River Job |
+|------|--------|--------------|--------|-----------|
+| Approve | `PENDING_APPROVAL -> APPROVED` | `PENDING -> PROCESSING` | created (`CREATING`) | created (`available`) |
+| Reject | `PENDING_APPROVAL -> REJECTED` | `PENDING -> CANCELLED` | not created | not created |
+
+---
+
+## Stage 5.D: Delete Write Model
+
+### Canonical Policy
+
+- Primary resource tables (`vms`, `services`, `systems`) use hard delete.
+- `audit_logs`, `approval_tickets`, `domain_events` are retained independently and
+  archived by retention policy.
+
+### Delete Write Patterns
+
+| Entity | Approval | Primary Write Pattern |
+|------|----------|-----------------------|
+| VM | Required | Ticket + event + transient `DELETING` -> provider delete -> hard delete |
+| Service | Not required | Cascade validation + transient `DELETING` -> worker cleanup -> hard delete |
+| System | Not required | Cascade validation -> hard delete in transaction |
+
+### Audit Naming Baseline
+
+- Canonical actions: `*.delete_submitted`, `*.delete_approved`, `*.delete_executed`.
+- New content must not introduce `*.delete_request` as canonical naming.
+
+---
+
+## Stage 5.E: Batch Parent-Child Write Model
+
+### Submission Transaction
+
+- Layer 1/L2 throttling pre-check.
+- One atomic transaction:
+  - Insert parent batch ticket.
+  - Insert all child tickets.
+  - Insert initial audit record(s).
+  - If any child insert fails, rollback all.
+
+### Execution Model
+
+- Child jobs execute independently.
+- Parent row is aggregate projection (`IN_PROGRESS`, `COMPLETED`,
+  `PARTIAL_SUCCESS`, `FAILED`, `CANCELLED`).
+- Retry/cancel writes operate on child scope first, then recompute parent aggregate.
+
+---
+
+## Stage 6: VNC Access Write Model
+
+### Test Environment
+
+- No approval ticket.
+- Permission check + runtime state check.
+- Token issue and access audit write (`vnc.session_started`).
+
+### Production Environment
+
+- Create approval ticket (`VNC_ACCESS_REQUESTED`, `PENDING_APPROVAL`).
+- On approval: issue token and append audit + notification.
+- Token usage tracking is runtime-state oriented; storage implementation is
+  governed by security/ops policy and must still satisfy auditability.
+
+---
+
+## Related Docs
+
+- [master-flow.md §Part 3 VM Lifecycle Flow](../interaction-flows/master-flow.md#part-3-vm-lifecycle-flow)
+- [master-flow.md §Stage 6 VNC Console Access](../interaction-flows/master-flow.md#stage-6-vnc-console-access)
+- [lifecycle-retention.md §Retention Classes](./lifecycle-retention.md#retention-classes-table-centric)
+- [transactions-consistency.md §Canonical Write Pattern](./transactions-consistency.md#canonical-write-pattern)

--- a/docs/design/examples/README.md
+++ b/docs/design/examples/README.md
@@ -50,7 +50,7 @@ examples/
 |------|-------------|-------------|
 | [config/config.go](./config/config.go) | Configuration loading with Viper, hot-reload support | - |
 | [infrastructure/database.go](./infrastructure/database.go) | Shared pgxpool for Ent + sqlc + River | ADR-0012 |
-| [worker/pool.go](./worker/pool.go) | Worker pool with panic recovery | - |
+| [worker/pool.go](./worker/pool.go) | Worker pool with panic recovery | ADR-0031 |
 | [handlers/health.go](./handlers/health.go) | Health check endpoints | - |
 | [domain/vm.go](./domain/vm.go) | VM domain model (Anti-Corruption Layer) | ADR-0015 §3-4 |
 | [domain/event.go](./domain/event.go) | Domain event types (Power Ops, VNC, Batch) | ADR-0009, ADR-0015 §6 |
@@ -58,7 +58,7 @@ examples/
 | [provider/interface.go](./provider/interface.go) | KubeVirt provider interfaces | ADR-0004 |
 | [provider/storage_detector.go](./provider/storage_detector.go) | StorageClass auto-detection during health check | ADR-0015 §8 |
 | [usecase/create_vm.go](./usecase/create_vm.go) | Atomic transaction with pgx + sqlc + River | ADR-0012, ADR-0015 §3 |
-| [usecase/batch_approval.go](./usecase/batch_approval.go) | Batch approval via River Queue (not atomic) | ADR-0015 §19 |
+| [usecase/batch_approval.go](./usecase/batch_approval.go) | Parent-child batch tickets with atomic submission and independent child execution | ADR-0015 §19 |
 
 ---
 
@@ -131,9 +131,13 @@ All write operations return `202 Accepted` with event ID. Workers execute actual
 - Batch operations: `BATCH_CREATE_REQUESTED`, `BATCH_DELETE_REQUESTED`
 - Notifications: `NOTIFICATION_SENT`
 
-### Worker Pool (Coding Standard)
+**External approval boundary**:
+- V1 uses built-in approval for go-live; external approval is interface/schema-ready and added via plugin adapters in V2+.
+- See [Phase 4 §9 External Approval Systems](../phases/04-governance.md#9-external-approval-systems-v1-interface-only).
 
-Naked `go func()` is **forbidden**. Use [worker/pool.go](./worker/pool.go) pattern.
+### Worker Pool (ADR-0031)
+
+Naked `go func()` is **forbidden**. See [ADR-0031](../../adr/ADR-0031-concurrency-and-worker-pool-standard.md) and use [worker/pool.go](./worker/pool.go) pattern.
 
 ---
 

--- a/docs/design/frontend/FRONTEND.md
+++ b/docs/design/frontend/FRONTEND.md
@@ -19,7 +19,7 @@
 | Form Validation | Zod | 3.x | Schema validation |
 | Styling | Tailwind CSS | 4.x | Utility-first CSS |
 
-> **Version Source**: Always refer to [DEPENDENCIES.md](./DEPENDENCIES.md) for pinned versions.
+> **Version Source**: Always refer to [DEPENDENCIES.md](../DEPENDENCIES.md) for pinned versions.
 
 ---
 
@@ -206,6 +206,24 @@ const { data, error } = await api.GET('/api/v1/vms/{id}', {
 
 ---
 
+## Async Batch Queue UX (ADR-0015 §19)
+
+Batch operations follow the parent-child ticket model.
+
+Mandatory frontend behavior:
+
+- Render parent aggregate status and child execution details.
+- Track status through backend `status_url` endpoints until terminal parent state.
+- Support `retry failed children` and `terminate pending children`.
+- Handle `429 Too Many Requests` with `Retry-After` based cooldown.
+
+Detailed specification:
+
+- [Batch Operations Queue UI](./features/batch-operations-queue.md)
+- [master-flow.md Stage 5.E](../interaction-flows/master-flow.md#stage-5e-batch-operations)
+
+---
+
 ## Schema Cache Degradation Strategy (ADR-0023)
 
 > **Reference**: [ADR-0023: Schema Cache Management](../../adr/ADR-0023-schema-cache-and-api-standards.md)
@@ -380,7 +398,7 @@ NEXT_PUBLIC_DEFAULT_LOCALE=en
 
 ## Testing
 
-> **Implementation Guide**: [ADR-0020 Testing Toolchain](./notes/ADR-0020-frontend-testing-toolchain.md)
+> **Implementation Guide**: [ADR-0020 Testing Toolchain](../notes/ADR-0020-frontend-testing-toolchain.md)
 
 ### Testing Stack
 
@@ -435,10 +453,12 @@ web/
 
 ## Related Documentation
 
+- [Frontend Design Index](./README.md)
+- [Batch Queue UI (Parent-Child)](./features/batch-operations-queue.md)
+- [ADR-0030: Design Documentation Layering](../../adr/ADR-0030-design-documentation-layering-and-fullstack-governance.md)
 - [ADR-0020: Frontend Technology Stack](../../adr/ADR-0020-frontend-technology-stack.md)
-- [ADR-0020: Testing Toolchain Implementation](./notes/ADR-0020-frontend-testing-toolchain.md)
+- [ADR-0020: Testing Toolchain Implementation](../notes/ADR-0020-frontend-testing-toolchain.md)
 - [ADR-0021: API Contract-First Design](../../adr/ADR-0021-api-contract-first.md)
 - [ADR-0027: Monorepo Repository Structure](../../adr/ADR-0027-repository-structure-monorepo.md)
-- [01-contracts.md §Error System](./phases/01-contracts.md#6-error-system)
-- [DEPENDENCIES.md](./DEPENDENCIES.md)
-
+- [01-contracts.md §Error System](../phases/01-contracts.md#6-error-system)
+- [DEPENDENCIES.md](../DEPENDENCIES.md)

--- a/docs/design/frontend/README.md
+++ b/docs/design/frontend/README.md
@@ -1,0 +1,31 @@
+# Frontend Design Index
+
+> **Authority**: Frontend implementation specification under [ADR-0030](../../adr/ADR-0030-design-documentation-layering-and-fullstack-governance.md)
+> **Flow Source of Truth**: [master-flow.md](../interaction-flows/master-flow.md)
+
+---
+
+## Purpose
+
+This directory is the canonical entry for frontend design documents.
+
+Frontend docs are layered by concern to prevent drift and to keep alignment with backend phases and interaction flow.
+
+## Reading Order
+
+1. [FRONTEND.md](./FRONTEND.md) - baseline frontend engineering standard
+2. [architecture/README.md](./architecture/README.md) - app-level architecture and boundaries
+3. [features/batch-operations-queue.md](./features/batch-operations-queue.md) - parent-child batch queue UX and state model
+4. [contracts/README.md](./contracts/README.md) - API contract and generated type integration
+5. [testing/README.md](./testing/README.md) - frontend test and CI gates
+
+## Alignment Rules
+
+- UI state names and transitions MUST match [master-flow.md](../interaction-flows/master-flow.md).
+- API contracts MUST come from OpenAPI artifacts (ADR-0021/ADR-0029), not hand-written TS types.
+- Full-stack acceptance MUST be tracked in [CHECKLIST.md](../CHECKLIST.md) and phase checklists under [checklist/](../checklist/).
+
+## Scope Boundary
+
+- This directory defines frontend behavior and UX contracts.
+- Backend execution details remain in phase documents (`../phases/`).

--- a/docs/design/frontend/architecture/README.md
+++ b/docs/design/frontend/architecture/README.md
@@ -1,0 +1,21 @@
+# Frontend Architecture Layer
+
+> **Related ADRs**: [ADR-0020](../../../adr/ADR-0020-frontend-technology-stack.md), [ADR-0027](../../../adr/ADR-0027-repository-structure-monorepo.md), [ADR-0030](../../../adr/ADR-0030-design-documentation-layering-and-fullstack-governance.md)
+
+## Goals
+
+- Keep UI architecture consistent with monorepo contract-first development.
+- Make backend flow changes traceable to frontend behavior updates.
+- Avoid ad-hoc page-level logic that bypasses shared state/query/error patterns.
+
+## Mandatory Boundaries
+
+- `web/src/types/api.gen.ts` is the only backend contract type source.
+- Domain-level UI state is managed through `zustand` stores and `tanstack-query` queries/mutations.
+- Queue-style async operations (approval, batch, power ops) must expose explicit status, retry, and cancellation actions in UI.
+
+## Cross-References
+
+- Batch queue model: [features/batch-operations-queue.md](../features/batch-operations-queue.md)
+- OpenAPI contract workflow: [../contracts/README.md](../contracts/README.md)
+- Testing and CI gates: [../testing/README.md](../testing/README.md)

--- a/docs/design/frontend/contracts/README.md
+++ b/docs/design/frontend/contracts/README.md
@@ -1,0 +1,28 @@
+# Frontend Contract Layer
+
+> **Related ADRs**: [ADR-0021](../../../adr/ADR-0021-api-contract-first.md), [ADR-0029](../../../adr/ADR-0029-openapi-toolchain-governance.md)
+
+## Contract Rules
+
+- OpenAPI spec is the source of truth.
+- Frontend request/response types MUST be generated, not manually duplicated.
+- Any API behavior relied on by frontend (status values, pagination fields, retry headers) must exist in OpenAPI and be validated in CI.
+
+## Required Artifacts
+
+- `api/openapi.yaml` (canonical)
+- `internal/api/generated/` (Go)
+- `web/src/types/api.gen.ts` (TypeScript)
+
+## CI Gates
+
+- `make api-lint`
+- `make api-generate`
+- `make api-check`
+- `make api-compat` when 3.1-only features are used
+
+## Flow Alignment
+
+For asynchronous batch flows, frontend must rely on server status endpoints and rate-limit headers instead of assuming local completion.
+
+See: [batch-operations-queue.md](../features/batch-operations-queue.md)

--- a/docs/design/frontend/features/batch-operations-queue.md
+++ b/docs/design/frontend/features/batch-operations-queue.md
@@ -1,0 +1,197 @@
+# Batch Operations Queue UI (Parent-Child Model)
+
+> **Flow Source**: [master-flow.md Stage 5.E](../../interaction-flows/master-flow.md#stage-5e-batch-operations)  
+> **Backend Spec**: [04-governance.md §5.6](../../phases/04-governance.md#56-batch-operations-adr-0015-19)  
+> **ADR Source**: [ADR-0015 §19](../../../adr/ADR-0015-governance-model-v2.md#19-batch-operations)
+
+---
+
+## 1. Objective
+
+Define a frontend model that correctly visualizes and controls batch operations implemented as:
+
+- one parent batch ticket
+- many child operation tickets/jobs
+- independent child execution
+- parent aggregated status
+
+This document is mandatory for approvals batch, VM batch create/delete, and batch power operations.
+
+## 2. Parent/Child UI Model
+
+### 2.0 End-to-End UI Storyboard
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ Batch Queue UI Storyboard                                                                       │
+├──────────────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                                  │
+│  Screen A: Resource List                                                                         │
+│    - user selects targets                                                                        │
+│    - chooses batch action                                                                        │
+│    - clicks [Submit Batch]                                                                       │
+│                                  │                                                               │
+│                                  ▼                                                               │
+│  Screen B: Queue List                                                                             │
+│    - new parent row appears with `PENDING_APPROVAL`                                              │
+│    - polling starts by `status_url`                                                              │
+│    - parent counters update (total/success/failed/pending)                                       │
+│                                  │                                                               │
+│                                  ▼                                                               │
+│  Screen C: Parent Row Expanded                                                                    │
+│    - child detail table visible                                                                   │
+│    - each child shows status + attempt_count + last_error                                        │
+│                                  │                                                               │
+│                                  ▼                                                               │
+│  Screen D: Action States                                                                          │
+│    - `IN_PROGRESS`: allow [Terminate pending]                                                    │
+│    - `PARTIAL_SUCCESS` / `FAILED`: allow [Retry failed]                                         │
+│    - `COMPLETED` / `CANCELLED`: disable mutating actions, keep [Export result] / [View details] │
+│                                                                                                  │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.1 Parent Row
+
+Each parent row must display at least:
+
+- `batch_id`
+- `batch_type`
+- `status` (`PENDING_APPROVAL`, `APPROVED`, `IN_PROGRESS`, `COMPLETED`, `PARTIAL_SUCCESS`, `FAILED`, `CANCELLED`)
+- `child_count`, `success_count`, `failed_count`, `pending_count`
+- `created_at`, `updated_at`
+- `requester`
+
+### 2.2 Child Detail Panel
+
+Child tasks are rendered via expandable panel/table, showing:
+
+- `ticket_id`
+- target object (`vm_id`/`approval_ticket_id`)
+- `status` (`PENDING`, `RUNNING`, `SUCCESS`, `FAILED`, `CANCELLED`)
+- `attempt_count`
+- `last_error_code`, `last_error_message`
+- `last_attempt_at`
+
+### 2.3 Actions
+
+By parent status:
+
+| Parent Status | Allowed Actions |
+|---------------|-----------------|
+| `PENDING_APPROVAL` | Approve / Reject |
+| `APPROVED` | Refresh / View details (awaiting execution scheduling) |
+| `IN_PROGRESS` | Refresh / Terminate remaining pending children |
+| `PARTIAL_SUCCESS` | Retry failed children / Export result |
+| `FAILED` | Retry failed children / Export result |
+| `COMPLETED` | Export result |
+| `CANCELLED` | View details only |
+
+## 3. API Interaction Contract
+
+### 3.1 Submit and Track
+
+Submission endpoints return `202 Accepted` and include a status resource URL:
+
+```json
+{
+  "batch_id": "BAT-20260206-001",
+  "status": "PENDING_APPROVAL",
+  "status_url": "/api/v1/vms/batch/BAT-20260206-001",
+  "retry_after_seconds": 2
+}
+```
+
+Frontend MUST treat `202` as "accepted for processing" and transition UI into tracking mode.
+
+### 3.2 Polling Strategy
+
+Use TanStack Query polling for parent and child status endpoints:
+
+- Initial polling interval: `2s`
+- Backoff on consecutive transient failures: exponential (max `30s`)
+- Stop polling when parent reaches terminal status
+- Resume polling immediately after user-triggered retry/terminate
+
+### 3.3 Rate Limit Handling
+
+When backend returns `429 Too Many Requests`:
+
+- Read `Retry-After` header if present
+- Disable resubmit/retry buttons until countdown ends
+- Show clear user message and next allowed retry time
+- Keep form/selection state intact
+
+## 4. UX Requirements
+
+### 4.1 Table Interaction
+
+Use Ant Design `Table` with `rowSelection` for batch creation and action triggers.
+
+- Preserve selected keys across pagination/filter changes
+- Show selected count and current limit usage
+- Block submit if selection exceeds operation limit
+
+### 4.2 Status Presentation
+
+- Parent status: Tag + progress summary (success/failed/pending counts)
+- Child status: per-row icon/tag + last error tooltip
+- Partial success: explicit warning banner, never silent
+
+### 4.3 Retry and Terminate
+
+- `Retry failed` only targets failed children
+- `Terminate` cancels only not-yet-started or pending children
+- UI must always indicate which items were actually affected
+
+## 5. Accessibility and Observability
+
+### 5.1 Accessibility
+
+- Dynamic status summary must be announced via `aria-live="polite"`
+- Progress widgets should use proper `progressbar` semantics
+- Buttons must expose disabled reasons in accessible text
+
+### 5.2 Client Metrics
+
+Track at least:
+
+- batch submit latency
+- status polling failures
+- retry attempts by batch type
+- terminate success ratio
+
+## 6. Suggested React Query Pattern
+
+```ts
+const batchStatusQuery = useQuery({
+  queryKey: ['batch-status', batchId],
+  queryFn: ({ signal }) => api.getBatchStatus(batchId, { signal }),
+  refetchInterval: (q) => {
+    const status = q.state.data?.status;
+    if (!status || ['COMPLETED', 'FAILED', 'PARTIAL_SUCCESS', 'CANCELLED'].includes(status)) {
+      return false;
+    }
+    return 2000;
+  },
+  retry: 3,
+  retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
+});
+```
+
+## 7. Cross-Document Consistency Rules
+
+- Status enum definitions must stay synchronized with `master-flow.md` and OpenAPI.
+- Parent/child counters shown in UI must come from backend aggregate fields, not local recomputation.
+- Frontend should not infer completion from HTTP request success alone; only terminal parent status ends flow.
+
+## 8. External Best-Practice References
+
+- RFC 9110 `202 Accepted`: https://datatracker.ietf.org/doc/html/rfc9110#section-15.3.3
+- RFC 6585 `429 Too Many Requests` + `Retry-After`: https://datatracker.ietf.org/doc/rfc6585/
+- MDN `202 Accepted`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+- MDN `429 Too Many Requests`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+- TanStack Query retries and backoff: https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults
+- TanStack Query cancellation via AbortSignal: https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation
+- Ant Design Table selection patterns: https://ant.design/components/table/
+- ARIA live regions (`status`): https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions

--- a/docs/design/frontend/testing/README.md
+++ b/docs/design/frontend/testing/README.md
@@ -1,0 +1,21 @@
+# Frontend Testing Layer
+
+> **Primary Guide**: [ADR-0020 testing note](../../notes/ADR-0020-frontend-testing-toolchain.md)
+
+## Required Test Levels
+
+- Unit/component tests for queue widgets, state badges, and action guards.
+- Integration tests for status polling, retry submission, and cancellation pathways.
+- E2E tests for parent-child batch task lifecycle with partial-success scenarios.
+
+## Mandatory Scenarios for Batch UI
+
+- Parent ticket transitions: `PENDING_APPROVAL -> IN_PROGRESS -> COMPLETED|PARTIAL_SUCCESS|FAILED`.
+- Child task transitions with retries capped by backend policy.
+- `429` responses display retry countdown and preserve unsent form state.
+- Accessibility checks for live status updates (`aria-live`) and progress indicators.
+
+## CI Expectations
+
+- Coverage threshold gates remain mandatory (lines/functions/statements >= 80%, branches >= 75%).
+- Frontend tests and API contract checks must run together before merge for queue-related changes.

--- a/docs/design/interaction-flows/README.md
+++ b/docs/design/interaction-flows/README.md
@@ -7,14 +7,18 @@
 
 ## Purpose
 
-This directory serves as the **single source of truth** for all platform interaction flows, used by:
+This directory serves as the **single source of truth for product interaction flows**, used by:
 
 | Role | Usage |
 |------|-------|
 | **Frontend Developers** | UI/UX implementation reference |
-| **Backend Developers** | API and database operation reference |
+| **Backend Developers** | API interaction and state-transition reference |
 | **QA Engineers** | Test case design |
 | **Architects** | System verification |
+
+> **Scope boundary**: CI/tooling enforcement is not defined here.
+> For development governance and CI policy, see [../ci/README.md §Scope Boundary](../ci/README.md#scope-boundary).
+> Database schema/lifecycle/transaction details are defined in [../database/README.md §Document Map](../database/README.md#document-map).
 
 ---
 
@@ -46,7 +50,7 @@ Part 1: Platform Initialization
 │   ├── Stage 2.B: Authentication Configuration (OIDC/LDAP)
 │   ├── Stage 2.C: IdP Group Mapping
 │   ├── Stage 2.D: User Login Flow
-│   └── Stage 2.E: External Approval Systems (NEW)
+│   └── Stage 2.E: Approval Provider Standard (V1 built-in, V2+ external plugin)
 └── Stage 3: Admin Configuration (Cluster/InstanceSize/Template)
 
 Part 2: Resource Management
@@ -127,7 +131,7 @@ This directory content is **extracted from** ADR-0018 Appendix.
 | Date | Version | Change |
 |------|---------|--------|
 | 2026-01-28 | 1.0 | **STABLE**: ADR-0017 and ADR-0018 accepted |
-| 2026-01-26 | 0.1-draft | CNCF normalization: English as canonical, Chinese to i18n/ |
+| 2026-01-26 | 0.1-draft | Documentation normalization: English as canonical, Chinese moved to i18n/ |
 | 2026-01-26 | 0.1-draft | Added: Stage 1.5 Bootstrap, Stage 2.E External Approval Systems |
 | 2026-01-26 | 0.1-draft | Updated: All runtime config via PostgreSQL (removed YAML config) |
 | 2026-01-26 | 0.1-draft | Initial extraction from ADR-0018 |

--- a/docs/design/notes/ADR-0015-batch-operations-implementation.md
+++ b/docs/design/notes/ADR-0015-batch-operations-implementation.md
@@ -1,0 +1,283 @@
+# Design Note: ADR-0015 Batch Operations Implementation
+
+> Status: Applied to normative docs (2026-02-06)  
+> Related ADR: [ADR-0015 §19](../../adr/ADR-0015-governance-model-v2.md#19-batch-operations)  
+> Owner: @codex  
+> Date: 2026-02-06
+
+---
+
+## Summary
+
+This note defines a concrete implementation for ADR-0015 §19:
+
+- Parent-child ticket model for batch operations
+- Two-layer rate limiting (global + user-level)
+- Atomic ticket creation with independent child execution
+
+This note captured the design review baseline. The resulting changes were merged into `04-governance.md`, `master-flow.md`, and phase checklists on 2026-02-06.
+
+---
+
+## Scope
+
+In scope:
+
+- Batch create/delete/approve/power operation orchestration
+- Parent-child ticket schema and status aggregation
+- PostgreSQL-based two-layer rate limiting without Redis
+- API request/response shape and error model
+- Worker concurrency, retry, and observability requirements
+
+Out of scope:
+
+- UI pixel-level changes
+- Multi-tenant custom quota policies
+- Distributed transaction across clusters
+
+---
+
+## Baseline Requirements (ADR-0015 §19)
+
+ADR-0015 requires:
+
+1. Parent-child ticket model
+2. Two-layer rate limits
+3. Atomic creation, independent execution
+
+This note was created while docs were still in the simplified "frontend batch -> per-item jobs" model and did not yet define full parent-child persistence plus two-layer limiting.
+
+---
+
+## Reviewed Implementation Plan (Historical)
+
+## 1. API Contract
+
+Canonical endpoints from ADR-0015:
+
+- `POST /api/v1/vms/batch` (batch create/delete request submission)
+- `GET /api/v1/vms/batch/{id}` (parent ticket status)
+- `POST /api/v1/vms/batch/{id}/retry` (retry failed child items)
+- `POST /api/v1/admin/rate-limits/exemptions`
+- `DELETE /api/v1/admin/rate-limits/exemptions/{user_id}`
+- `PUT /api/v1/admin/rate-limits/users/{user_id}`
+- `GET /api/v1/admin/rate-limits/status`
+
+Extension for existing simplified endpoints:
+
+- Keep `POST /api/v1/approvals/batch` and `POST /api/v1/vms/batch/power`
+- Internally normalize them into the same parent-child ticket pipeline
+
+Request requirements:
+
+- Add optional `request_id` (UUID) for idempotency
+- Enforce max batch size by operation type (ADR default values)
+
+Response model:
+
+- Submit returns `202 Accepted` with `batch_id` and `status_url`
+- Status returns counts and per-child states
+
+---
+
+## 2. Data Model
+
+Use explicit parent table plus child rows:
+
+- `batch_approval_tickets`
+  - `ticket_id`, `batch_type`, `child_count`, `success_count`, `failed_count`, `pending_count`, `status`, `reason`, `created_by`, `created_at`, `updated_at`
+- `approval_tickets` (child)
+  - add `parent_ticket_id`, `sequence_no`, `status`, `error_message`, `attempt_count`, `last_attempt_at`
+
+Rate limit tables (ADR-0015 §19):
+
+- `rate_limit_counter`
+  - `scope` (`global` or `user`)
+  - `subject_id` (`global` or user id)
+  - `limit_type`
+  - `window_start`, `current_value`
+- `rate_limit_exemption`
+  - `user_id`, `exempted_by`, `reason`, `expires_at`
+
+Recommended indexes:
+
+- `batch_approval_tickets(status, created_at)`
+- `approval_tickets(parent_ticket_id, status, sequence_no)`
+- unique idempotency key: `(created_by, batch_type, request_id)` where `request_id` is not null
+- `rate_limit_counter(scope, subject_id, limit_type, window_start)` unique
+
+---
+
+## 3. Atomicity Boundary
+
+Creation phase (`single SQL transaction`):
+
+1. Validate limits (global and user)
+2. Validate all child requests
+3. Insert parent ticket
+4. Insert all child tickets
+5. Insert audit log
+6. Commit once
+
+If any child insert/validation fails, rollback entire submission.
+
+Execution phase (`independent`):
+
+- Each child ticket processed by its own River job
+- Parent status is aggregated from child counters
+- No rollback of successful children when siblings fail
+
+---
+
+## 4. Worker Concurrency and Queue Safety
+
+For workers pulling child tasks, use row-level locking with skip semantics:
+
+```sql
+SELECT id
+FROM approval_tickets
+WHERE parent_ticket_id = $1
+  AND status = 'PENDING'
+ORDER BY sequence_no
+FOR UPDATE SKIP LOCKED
+LIMIT $2;
+```
+
+Notes:
+
+- `SKIP LOCKED` is appropriate for queue-like multi-consumer processing.
+- Child completion updates parent counters with atomic increment/decrement SQL.
+
+---
+
+## 5. Parent Status Aggregation
+
+Status derivation:
+
+- `pending_count > 0` -> `IN_PROGRESS`
+- `pending_count = 0 && failed_count = 0` -> `COMPLETED`
+- `pending_count = 0 && success_count = 0` -> `FAILED`
+- otherwise -> `PARTIAL_SUCCESS`
+
+Persist aggregate fields on parent row to avoid expensive full scans.
+
+---
+
+## 6. Two-Layer Rate Limiting
+
+Layer 1 (Global protection):
+
+- max global pending batch parents: `100`
+- max global API requests: `1000/min`
+
+Layer 2 (User fairness):
+
+- max pending batch requests per user: `3`
+- cooldown: `2 minutes`
+- max pending child tickets per user: `30`
+
+Implementation rules:
+
+- Exemption check first
+- All counters updated in SQL transaction with deterministic window key
+- Use `429` with `Retry-After` and error body fields:
+  - `limit_type`, `current_value`, `max_value`, `retry_after`, `contact_admin`
+
+---
+
+## 7. Retry and Idempotency
+
+Retry:
+
+- Child retries follow River backoff policy
+- Retry endpoint only requeues `FAILED` children
+- Track `attempt_count` and cap retries per child
+
+Idempotency:
+
+- `request_id` deduplicates repeated submit calls
+- Duplicate request returns original `batch_id` and current parent status
+
+---
+
+## 8. Error Model
+
+Submission-time errors (request rejected, no ticket created):
+
+- `400 INVALID_BATCH_REQUEST`
+- `400 BATCH_SIZE_EXCEEDED`
+- `403 PERMISSION_DENIED`
+- `429 RATE_LIMIT_EXCEEDED`
+
+Execution-time errors (child failed, parent may be partial success):
+
+- child-specific app error in `error_message`
+- parent summary remains queryable
+
+---
+
+## 9. Observability and Audit
+
+Metrics:
+
+- `batch_submit_total{batch_type,result}`
+- `batch_child_execution_total{batch_type,status}`
+- `batch_parent_duration_seconds`
+- `rate_limit_rejections_total{limit_type}`
+
+Audit requirements:
+
+- submission event
+- per-child execution completion/failure
+- admin exemption changes
+
+Sensitive data must follow ADR-0019 redaction rules.
+
+---
+
+## 10. Rollout Plan
+
+1. Add schema and migrations for parent-child + rate limit tables
+2. Implement submit/status/retry service layer with atomic creation
+3. Migrate existing batch endpoints to unified parent-child internals
+4. Add CI checks and integration tests:
+   - atomic creation rollback test
+   - partial success aggregation test
+   - limit enforcement and `Retry-After` behavior
+5. Apply normative doc updates and re-run design governance checks
+
+---
+
+## Applied Changes (2026-02-06)
+
+- `docs/design/phases/04-governance.md` updated to ADR-complete §5.6 model
+- `docs/design/interaction-flows/master-flow.md` updated with parent-child + two-layer limit flows
+- `docs/design/checklist/phase-4-checklist.md` updated with parent-child/rate-limit/frontend acceptance items
+- `docs/design/examples/usecase/batch_approval.go` updated to parent-child atomic submission example
+
+---
+
+## Resolved Decisions
+
+1. Compatibility endpoints (`POST /api/v1/approvals/batch`, `POST /api/v1/vms/batch/power`) remain public but are normalized to the same parent-child pipeline.
+2. Submission remains strictly atomic for parent/child ticket creation; invalid child inputs fail the whole submission transaction.
+3. User-level limits use ADR defaults, with admin exemption/override APIs for exceptional cases.
+
+---
+
+## References (Best Practices)
+
+- ADR baseline:
+  - [ADR-0015 §19 Batch Operations](../../adr/ADR-0015-governance-model-v2.md#19-batch-operations)
+- Batch API behavior:
+  - Google AIP-233 Batch Create: https://google.aip.dev/233
+  - Google AIP-235 Batch Delete: https://google.aip.dev/235
+  - Google AIP-151 Long-running Operations: https://google.aip.dev/151
+  - Google AIP-155 Request ID/Idempotency: https://google.aip.dev/155
+- HTTP rate limit signaling:
+  - RFC 6585 (`429 Too Many Requests`): https://www.rfc-editor.org/rfc/rfc6585.html
+  - RFC 9110 (`Retry-After`): https://www.rfc-editor.org/rfc/rfc9110
+- Queue concurrency in PostgreSQL:
+  - PostgreSQL `SELECT ... FOR UPDATE ... SKIP LOCKED`: https://www.postgresql.org/docs/18/sql-select.html
+- Independent per-item failure handling analogy:
+  - Kubernetes Jobs (`backoffLimitPerIndex`): https://kubernetes.io/docs/concepts/workloads/controllers/job/

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -1,0 +1,320 @@
+{
+  "version": 1,
+  "master_flow": "docs/design/interaction-flows/master-flow.md",
+  "stages": [
+    {
+      "id": "stage-1",
+      "phases": [
+        "docs/design/phases/00-prerequisites.md",
+        "docs/design/phases/02-providers.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-0-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0018-instance-size-abstraction.md",
+        "docs/adr/ADR-0023-schema-cache-and-api-standards.md"
+      ],
+      "examples": [
+        "docs/design/examples/config/config.go"
+      ]
+    },
+    {
+      "id": "stage-1-5",
+      "phases": [
+        "docs/design/phases/00-prerequisites.md",
+        "docs/design/phases/01-contracts.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-0-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0025-secret-bootstrap.md"
+      ]
+    },
+    {
+      "id": "stage-2",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md",
+        "docs/adr/ADR-0019-governance-security-baseline-controls.md",
+        "docs/adr/ADR-0026-idp-config-naming.md"
+      ]
+    },
+    {
+      "id": "stage-2-a",
+      "phases": [
+        "docs/design/phases/01-contracts.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0019-governance-security-baseline-controls.md"
+      ]
+    },
+    {
+      "id": "stage-2-a-plus",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ]
+    },
+    {
+      "id": "stage-2-b",
+      "phases": [
+        "docs/design/phases/01-contracts.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0026-idp-config-naming.md"
+      ]
+    },
+    {
+      "id": "stage-2-c",
+      "phases": [
+        "docs/design/phases/01-contracts.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0026-idp-config-naming.md"
+      ]
+    },
+    {
+      "id": "stage-2-d",
+      "phases": [
+        "docs/design/phases/01-contracts.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md"
+      ]
+    },
+    {
+      "id": "stage-2-e",
+      "phases": [
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0005-workflow-extensibility.md"
+      ]
+    },
+    {
+      "id": "stage-3",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/02-providers.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md",
+        "docs/design/checklist/phase-2-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0014-capability-detection.md",
+        "docs/adr/ADR-0018-instance-size-abstraction.md"
+      ]
+    },
+    {
+      "id": "stage-3-c",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/03-service-layer.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-3-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0017-vm-request-flow-clarification.md"
+      ]
+    },
+    {
+      "id": "stage-3-jit-namespace",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/03-service-layer.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-3-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0017-vm-request-flow-clarification.md",
+        "docs/adr/ADR-0023-schema-cache-and-api-standards.md"
+      ]
+    },
+    {
+      "id": "stage-4-a",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/03-service-layer.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-3-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md"
+      ]
+    },
+    {
+      "id": "stage-4-a-plus",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ]
+    },
+    {
+      "id": "stage-4-b",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/03-service-layer.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-3-checklist.md"
+      ]
+    },
+    {
+      "id": "stage-4-c",
+      "phases": [
+        "docs/design/phases/03-service-layer.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-3-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md",
+        "docs/adr/ADR-0019-governance-security-baseline-controls.md"
+      ]
+    },
+    {
+      "id": "stage-5-a",
+      "phases": [
+        "docs/design/phases/03-service-layer.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-3-checklist.md",
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0006-unified-async-model.md",
+        "docs/adr/ADR-0012-hybrid-transaction.md",
+        "docs/adr/ADR-0017-vm-request-flow-clarification.md"
+      ],
+      "examples": [
+        "docs/design/examples/usecase/create_vm.go"
+      ]
+    },
+    {
+      "id": "stage-5-b",
+      "phases": [
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0005-workflow-extensibility.md",
+        "docs/adr/ADR-0006-unified-async-model.md",
+        "docs/adr/ADR-0009-domain-event-pattern.md"
+      ]
+    },
+    {
+      "id": "stage-5b-constraint-note-dedicated-cpu-vs-overcommit",
+      "phases": [
+        "docs/design/phases/01-contracts.md",
+        "docs/design/phases/03-service-layer.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-1-checklist.md",
+        "docs/design/checklist/phase-3-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0018-instance-size-abstraction.md"
+      ]
+    },
+    {
+      "id": "stage-5-d",
+      "phases": [
+        "docs/design/phases/03-service-layer.md",
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md"
+      ]
+    },
+    {
+      "id": "stage-5e-batch-operations",
+      "phases": [
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md"
+      ],
+      "examples": [
+        "docs/design/examples/usecase/batch_approval.go"
+      ]
+    },
+    {
+      "id": "stage-5f-notification-system",
+      "phases": [
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md"
+      ],
+      "examples": [
+        "docs/design/examples/notification/sender.go"
+      ]
+    },
+    {
+      "id": "stage-6-vnc-console-access",
+      "phases": [
+        "docs/design/phases/04-governance.md"
+      ],
+      "checklists": [
+        "docs/design/checklist/phase-4-checklist.md"
+      ],
+      "adrs": [
+        "docs/adr/ADR-0015-governance-model-v2.md"
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary

Implement ADR-0030 documentation layering: restructure design docs into dedicated layers.

## Changes

### New Files
- `docs/adr/ADR-0030-design-documentation-layering-and-fullstack-governance.md` — ADR for layered doc structure
- `docs/design/frontend/` — Frontend design layer (README, FRONTEND.md, architecture/, features/, contracts/, testing/)
- `docs/design/database/` — Database reference layer (schema-catalog, lifecycle-retention, transactions, migrations)
- `docs/design/traceability/master-flow.json` — Machine-readable traceability manifest (ADR-0032)
- `docs/design/notes/ADR-0015-batch-operations-implementation.md` — Batch operations design note

### Moved Files
- `docs/design/FRONTEND.md` → `docs/design/frontend/FRONTEND.md`

### Updated Files
- `README.md` — Added documentation map section
- `docs/README.md` — Updated tree structure with new directories + traceability
- `docs/design/README.md` — Updated tree structure, document map, and links
- `docs/design/interaction-flows/README.md` — Added scope boundary references
- `docs/design/checklist/README.md` — Updated links
- `docs/design/examples/README.md` — Updated links
- `docs/adr/ADR-0023-schema-cache-and-api-standards.md` — Fix FRONTEND.md path after move

## Verification

- [x] All new directories have README.md
- [x] FRONTEND.md correctly moved (git detects as rename)
- [x] ADR-0023 path reference updated
- [x] Tree diagrams consistent across all README files

Refs #156
Refs #152
Refs #138

Signed-off-by: jindyzhao <jindyzhao0128@gmail.com>