### PR TITLE
docs: update master-flow structure and sync i18n

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,9 @@ Use inclusive terminology in new code and documentation. Prefer "allowlist/denyl
 - ADR changes require discussion and approval
 - Keep examples in `docs/design/examples/` synchronized with actual patterns
 - If documentation lint or link-check tools exist in this repo, run them for doc changes; otherwise perform a manual sanity check (headings, lists, links).
+- Frontend design docs must be updated under `docs/design/frontend/` (ADR-0030 layering); do not add new frontend specs under `docs/design/` root.
+- Interaction/state-flow changes must update `docs/design/interaction-flows/master-flow.md` and matching frontend/phase docs in the same PR.
+- Run `bash docs/design/ci/scripts/check_design_doc_governance.sh` for documentation changes that touch design/ADR/interaction-flow content.
 
 ### Decision Documents (ADR + Design Notes)
 


### PR DESCRIPTION
## Summary

Major structural update to `master-flow.md` (English canonical + Chinese translation sync).

## Changes

### Structural Improvements
- Add **unified authoring contract** (Stage fixed structure: Purpose → Actors → Flow → State Transitions → Failure Cases → Authority Links → Scope Boundary)
- Add **Global Design Conclusions** table (name governance, write model, event integrity, transaction boundary, delete semantics, batch baseline)
- Add **Cross-Layer Authority** table mapping authoritative layers (ADRs, master-flow, phases, database, frontend, CI)
- Add **Scope Boundary** section separating interaction intent from implementation details

### Content Updates
- Add **Stage 4.C** content (Service Detail View & Update Operations)
- Fix VNC audit action: `VNC_SESSION_STARTED` → `vnc.access` (canonical dot-notation)
- Fix `created_by` removal from service INSERT (services don't track creator)
- Update **batch operations** to parent-child ticket model (ADR-0015 §19)
- Move Schema Cache lifecycle content to dedicated docs (ADR-0023 scope)

### i18n Sync
- Sync Chinese translation (`docs/i18n/zh-CN/`) with all EN structural changes
- Fix relative path references in Chinese version

### Other
- Update `RFC-0011-vnc-console.md` references
- Add Decision Documents section to `CONTRIBUTING.md`

## Verification

- [x] All cross-references verified against target documents
- [x] VNC action naming consistent across all documents
- [x] Chinese translation structurally aligned with English canonical
- [x] DCO signed

Refs #125
Refs #117

Signed-off-by: jindyzhao <jindyzhao0128@gmail.com>