### PR TITLE
chore: update .gitignore for local secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ coverage.html
 *.log
 tmp/
 
+# Configuration (only commit .example)
+config/config.yaml
+config.yaml
+
 # Environment and secrets
 .env
 .env.local
@@ -54,3 +58,4 @@ kubeconfig.*
 
 # OS files
 Thumbs.db
+k8s-admin.yaml


### PR DESCRIPTION
## Description
Update `.gitignore` to ignore local environment/sensitive files and reduce accidental local-file commits.

## Related Issue
- Refs #163

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Test update

## Checklist
- [x] One PR = One Issue
- [x] DCO signed commit included
- [x] Scope-only file changes (`.gitignore`)
- [x] No `Closes/Fixes` used