### PR TITLE
ci: add master-flow traceability check

### DIFF
--- a/docs/design/ci/scripts/check_master_flow_traceability.go
+++ b/docs/design/ci/scripts/check_master_flow_traceability.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (


### PR DESCRIPTION
## Description
- add dedicated `check_master_flow_traceability.go` for master-flow drift enforcement
- keep this traceability concern isolated from other governance checks

## Related Issue
- Refs #152

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] CI

## Checklist
- [x] One PR = One Issue
- [x] DCO signed commits
- [x] Scope-only files changed
- [ ] Required checks passed