### PR TITLE
feat(core): add usecase orchestration

### DIFF
--- a/internal/usecase/approval_atomic.go
+++ b/internal/usecase/approval_atomic.go
@@ -1,0 +1,218 @@
+// Package usecase provides application use cases (Clean Architecture).
+//
+// ADR-0012: Core approval writes + River enqueue must be atomic in a single pgx.Tx.
+//
+// Import Path (ADR-0016): kv-shepherd.io/shepherd/internal/usecase
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"kv-shepherd.io/shepherd/internal/jobs"
+	sqlcrepo "kv-shepherd.io/shepherd/internal/repository/sqlc"
+)
+
+// ApprovalAtomicWriter executes approval state transition + River enqueue in one pgx transaction.
+type ApprovalAtomicWriter struct {
+	pool        *pgxpool.Pool
+	riverClient *river.Client[pgx.Tx]
+	queries     *sqlcrepo.Queries
+}
+
+// NewApprovalAtomicWriter creates a new ADR-0012 atomic writer.
+func NewApprovalAtomicWriter(pool *pgxpool.Pool, riverClient *river.Client[pgx.Tx]) *ApprovalAtomicWriter {
+	return &ApprovalAtomicWriter{
+		pool:        pool,
+		riverClient: riverClient,
+		queries:     sqlcrepo.New(pool),
+	}
+}
+
+// ApproveCreateAndEnqueue atomically:
+// 1) marks ticket APPROVED,
+// 2) marks event PROCESSING,
+// 3) allocates VM instance/index + inserts VM row,
+// 4) inserts River vm_create job via InsertTx.
+func (w *ApprovalAtomicWriter) ApproveCreateAndEnqueue(
+	ctx context.Context,
+	ticketID, eventID, approver, clusterID, storageClass, serviceID, namespace, requesterID string,
+) (vmID, vmName string, err error) {
+	if w.pool == nil || w.riverClient == nil || w.queries == nil {
+		return "", "", fmt.Errorf("approval atomic writer is not initialized")
+	}
+	if err := w.validateCreateInput(ticketID, eventID, approver, clusterID, serviceID, namespace, requesterID); err != nil {
+		return "", "", err
+	}
+
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("begin approval create tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	qtx := w.queries.WithTx(tx)
+
+	affected, err := qtx.ApproveCreateTicket(ctx, sqlcrepo.ApproveCreateTicketParams{
+		Approver:             pgtype.Text{String: approver, Valid: true},
+		SelectedClusterID:    pgtype.Text{String: clusterID, Valid: true},
+		SelectedStorageClass: strings.TrimSpace(storageClass),
+		ID:                   ticketID,
+		EventID:              eventID,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("approve create ticket %s: %w", ticketID, err)
+	}
+	if affected == 0 {
+		return "", "", fmt.Errorf("approve create ticket %s: not pending or operation type mismatch", ticketID)
+	}
+
+	affected, err = qtx.SetDomainEventStatus(ctx, sqlcrepo.SetDomainEventStatusParams{
+		ID:     eventID,
+		Status: "PROCESSING",
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("set event %s to PROCESSING: %w", eventID, err)
+	}
+	if affected == 0 {
+		return "", "", fmt.Errorf("domain event %s not found", eventID)
+	}
+
+	allocated, err := qtx.AllocateServiceInstance(ctx, serviceID)
+	if err != nil {
+		return "", "", fmt.Errorf("allocate service instance for service %s: %w", serviceID, err)
+	}
+
+	instance := fmt.Sprintf("%02d", allocated.AllocatedIndex)
+	vmName = fmt.Sprintf("%s-%s-%s-%s", namespace, allocated.SystemName, allocated.ServiceName, instance)
+
+	vmUUID, err := uuid.NewV7()
+	if err != nil {
+		return "", "", fmt.Errorf("generate vm id: %w", err)
+	}
+	vmID = vmUUID.String()
+
+	if err := qtx.InsertVM(ctx, sqlcrepo.InsertVMParams{
+		ID:         vmID,
+		Name:       vmName,
+		Instance:   instance,
+		Namespace:  namespace,
+		ClusterID:  pgtype.Text{String: clusterID, Valid: true},
+		Hostname:   pgtype.Text{String: vmName, Valid: true},
+		CreatedBy:  requesterID,
+		TicketID:   pgtype.Text{String: ticketID, Valid: true},
+		ServiceVms: serviceID,
+	}); err != nil {
+		return "", "", fmt.Errorf("insert vm %s: %w", vmID, err)
+	}
+
+	if _, err := w.riverClient.InsertTx(ctx, tx, jobs.VMCreateArgs{
+		EventID: eventID,
+	}, nil); err != nil {
+		return "", "", fmt.Errorf("enqueue vm_create for event %s: %w", eventID, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", "", fmt.Errorf("commit approval create tx: %w", err)
+	}
+
+	return vmID, vmName, nil
+}
+
+// ApproveDeleteAndEnqueue atomically:
+// 1) marks ticket APPROVED,
+// 2) marks event PROCESSING,
+// 3) marks VM DELETING (best effort),
+// 4) inserts River vm_delete job via InsertTx.
+func (w *ApprovalAtomicWriter) ApproveDeleteAndEnqueue(
+	ctx context.Context,
+	ticketID, eventID, approver, vmID string,
+) error {
+	if w.pool == nil || w.riverClient == nil || w.queries == nil {
+		return fmt.Errorf("approval atomic writer is not initialized")
+	}
+	if strings.TrimSpace(ticketID) == "" || strings.TrimSpace(eventID) == "" || strings.TrimSpace(approver) == "" {
+		return fmt.Errorf("approve delete input is incomplete")
+	}
+
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin approval delete tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	qtx := w.queries.WithTx(tx)
+
+	affected, err := qtx.ApproveDeleteTicket(ctx, sqlcrepo.ApproveDeleteTicketParams{
+		Approver: pgtype.Text{String: approver, Valid: true},
+		ID:       ticketID,
+		EventID:  eventID,
+	})
+	if err != nil {
+		return fmt.Errorf("approve delete ticket %s: %w", ticketID, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("approve delete ticket %s: not pending or operation type mismatch", ticketID)
+	}
+
+	affected, err = qtx.SetDomainEventStatus(ctx, sqlcrepo.SetDomainEventStatusParams{
+		ID:     eventID,
+		Status: "PROCESSING",
+	})
+	if err != nil {
+		return fmt.Errorf("set event %s to PROCESSING: %w", eventID, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("domain event %s not found", eventID)
+	}
+
+	if strings.TrimSpace(vmID) != "" {
+		if _, err := qtx.SetVMStatus(ctx, sqlcrepo.SetVMStatusParams{
+			ID:     vmID,
+			Status: "DELETING",
+		}); err != nil {
+			return fmt.Errorf("set vm %s status to DELETING: %w", vmID, err)
+		}
+	}
+
+	if _, err := w.riverClient.InsertTx(ctx, tx, jobs.VMDeleteArgs{
+		EventID: eventID,
+	}, nil); err != nil {
+		return fmt.Errorf("enqueue vm_delete for event %s: %w", eventID, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit approval delete tx: %w", err)
+	}
+	return nil
+}
+
+func (w *ApprovalAtomicWriter) validateCreateInput(
+	ticketID, eventID, approver, clusterID, serviceID, namespace, requesterID string,
+) error {
+	switch {
+	case strings.TrimSpace(ticketID) == "":
+		return fmt.Errorf("ticket id is required")
+	case strings.TrimSpace(eventID) == "":
+		return fmt.Errorf("event id is required")
+	case strings.TrimSpace(approver) == "":
+		return fmt.Errorf("approver is required")
+	case strings.TrimSpace(clusterID) == "":
+		return fmt.Errorf("selected cluster is required for create approval")
+	case strings.TrimSpace(serviceID) == "":
+		return fmt.Errorf("service id is required")
+	case strings.TrimSpace(namespace) == "":
+		return fmt.Errorf("namespace is required")
+	case strings.TrimSpace(requesterID) == "":
+		return fmt.Errorf("requester id is required")
+	default:
+		return nil
+	}
+}

--- a/internal/usecase/create_vm.go
+++ b/internal/usecase/create_vm.go
@@ -1,0 +1,195 @@
+// Package usecase provides application use cases (Clean Architecture).
+//
+// UseCases are reusable across HTTP, CLI, gRPC, Cron.
+// ADR-0012: Atomic transactions managed at UseCase level.
+//
+// Import Path (ADR-0016): kv-shepherd.io/shepherd/internal/usecase
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"kv-shepherd.io/shepherd/ent"
+	"kv-shepherd.io/shepherd/ent/approvalticket"
+	"kv-shepherd.io/shepherd/internal/domain"
+	"kv-shepherd.io/shepherd/internal/governance/audit"
+	apperrors "kv-shepherd.io/shepherd/internal/pkg/errors"
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+	"kv-shepherd.io/shepherd/internal/service"
+)
+
+// CreateVMInput represents the input for creating a VM.
+type CreateVMInput struct {
+	ServiceID      string `json:"service_id"`
+	TemplateID     string `json:"template_id"`
+	InstanceSizeID string `json:"instance_size_id"`
+	Namespace      string `json:"namespace"`
+	Reason         string `json:"reason"`
+	RequestedBy    string `json:"requested_by"`
+}
+
+// CreateVMOutput represents the output of a VM creation request.
+type CreateVMOutput struct {
+	TicketID string `json:"ticket_id"`
+	EventID  string `json:"event_id"`
+	Status   string `json:"status"`
+}
+
+// CreateVMUseCase orchestrates VM creation.
+// ADR-0012: Two-phase execution (DB write → K8s create).
+type CreateVMUseCase struct {
+	entClient       *ent.Client
+	vmService       *service.VMService
+	instanceSizeSvc *service.InstanceSizeService
+	auditLogger     *audit.Logger
+}
+
+// NewCreateVMUseCase creates a new CreateVMUseCase.
+func NewCreateVMUseCase(
+	entClient *ent.Client,
+	vmService *service.VMService,
+	instanceSizeSvc *service.InstanceSizeService,
+) *CreateVMUseCase {
+	return &CreateVMUseCase{
+		entClient:       entClient,
+		vmService:       vmService,
+		instanceSizeSvc: instanceSizeSvc,
+	}
+}
+
+// WithAuditLogger sets the audit logger (optional dependency).
+func (uc *CreateVMUseCase) WithAuditLogger(al *audit.Logger) *CreateVMUseCase {
+	uc.auditLogger = al
+	return uc
+}
+
+// Execute runs the VM creation use case.
+// Phase 1: Creates DomainEvent + ApprovalTicket in atomic transaction.
+// Phase 2: After approval, K8s create is executed by River worker.
+// master-flow.md Stage 5.A: includes duplicate pending guard + audit log.
+func (uc *CreateVMUseCase) Execute(ctx context.Context, input CreateVMInput) (*CreateVMOutput, error) {
+	// Validate instance size exists
+	_, err := uc.instanceSizeSvc.GetByID(ctx, input.InstanceSizeID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid instance size: %w", err)
+	}
+
+	// Duplicate pending guard (master-flow.md Stage 5.A)
+	existingCount, err := uc.entClient.ApprovalTicket.Query().
+		Where(
+			approvalticket.StatusEQ(approvalticket.StatusPENDING),
+			approvalticket.RequesterEQ(input.RequestedBy),
+		).Count(ctx)
+	if err == nil && existingCount > 0 {
+		return nil, apperrors.Conflict(apperrors.CodeDuplicateRequest,
+			"a pending VM request already exists for this user")
+	}
+
+	// Create domain event payload
+	payload := domain.VMCreationPayload{
+		RequesterID:    input.RequestedBy,
+		ServiceID:      input.ServiceID,
+		TemplateID:     input.TemplateID,
+		InstanceSizeID: input.InstanceSizeID,
+		Namespace:      input.Namespace,
+		Reason:         input.Reason,
+	}
+
+	payloadBytes, err := payload.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	// Atomic transaction: create DomainEvent + ApprovalTicket (ADR-0012)
+	var eventID, ticketID string
+	txErr := withTx(ctx, uc.entClient, func(tx *ent.Tx) error {
+		// Create domain event
+		event, err := tx.DomainEvent.Create().
+			SetID(generateID()).
+			SetEventType(string(domain.EventVMCreationRequested)).
+			SetAggregateType("vm").
+			SetAggregateID(input.ServiceID).
+			SetPayload(payloadBytes).
+			SetCreatedBy(input.RequestedBy).
+			Save(ctx)
+		if err != nil {
+			return fmt.Errorf("create domain event: %w", err)
+		}
+		eventID = event.ID
+
+		// Create approval ticket
+		ticket, err := tx.ApprovalTicket.Create().
+			SetID(generateID()).
+			SetEventID(event.ID).
+			SetRequester(input.RequestedBy).
+			SetReason(input.Reason).
+			Save(ctx)
+		if err != nil {
+			return fmt.Errorf("create approval ticket: %w", err)
+		}
+		ticketID = ticket.ID
+
+		return nil
+	})
+
+	if txErr != nil {
+		return nil, fmt.Errorf("create vm request: %w", txErr)
+	}
+
+	// Audit log (master-flow.md Stage 5.A)
+	if uc.auditLogger != nil {
+		_ = uc.auditLogger.LogAction(ctx, "vm.request", "approval_ticket", ticketID, input.RequestedBy, map[string]interface{}{
+			"service_id":       input.ServiceID,
+			"template_id":      input.TemplateID,
+			"instance_size_id": input.InstanceSizeID,
+			"namespace":        input.Namespace,
+		})
+	}
+
+	logger.Info("VM creation request submitted",
+		zap.String("event_id", eventID),
+		zap.String("ticket_id", ticketID),
+		zap.String("requester", input.RequestedBy),
+	)
+
+	return &CreateVMOutput{
+		TicketID: ticketID,
+		EventID:  eventID,
+		Status:   "PENDING",
+	}, nil
+}
+
+// withTx executes a function within a transaction.
+func withTx(ctx context.Context, client *ent.Client, fn func(tx *ent.Tx) error) error {
+	tx, err := client.Tx(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if v := recover(); v != nil {
+			_ = tx.Rollback()
+			panic(v)
+		}
+	}()
+	if err := fn(tx); err != nil {
+		if rerr := tx.Rollback(); rerr != nil {
+			return fmt.Errorf("%w: rolling back: %v", err, rerr)
+		}
+		return err
+	}
+	return tx.Commit()
+}
+
+// generateID generates a unique UUID v7 (time-ordered, K-sortable).
+func generateID() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		// Fallback to v4 if v7 fails (should never happen)
+		return uuid.New().String()
+	}
+	return id.String()
+}

--- a/internal/usecase/delete_vm.go
+++ b/internal/usecase/delete_vm.go
@@ -1,0 +1,184 @@
+// Package usecase — DeleteVMUseCase orchestrates the VM deletion approval flow.
+//
+// ADR-0015 §5.D: VM deletion requires approval ticket.
+// ADR-0012: Atomic transaction for DomainEvent + ApprovalTicket.
+//
+// Import Path (ADR-0016): kv-shepherd.io/shepherd/internal/usecase
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"kv-shepherd.io/shepherd/ent"
+	"kv-shepherd.io/shepherd/ent/approvalticket"
+	entvm "kv-shepherd.io/shepherd/ent/vm"
+	"kv-shepherd.io/shepherd/internal/domain"
+	"kv-shepherd.io/shepherd/internal/governance/audit"
+	apperrors "kv-shepherd.io/shepherd/internal/pkg/errors"
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+)
+
+// DeleteVMInput represents the input for requesting VM deletion.
+type DeleteVMInput struct {
+	VMID        string `json:"vm_id"`
+	Confirm     bool   `json:"confirm"`
+	ConfirmName string `json:"confirm_name"`
+	Reason      string `json:"reason"`
+	RequestedBy string `json:"requested_by"`
+}
+
+// DeleteVMOutput represents the output of a VM deletion request.
+type DeleteVMOutput struct {
+	TicketID string `json:"ticket_id"`
+	EventID  string `json:"event_id"`
+	Status   string `json:"status"`
+}
+
+// DeleteVMUseCase orchestrates VM deletion through the approval flow.
+// ADR-0015 §5.D: VM deletion requires an approval ticket with operation_type=DELETE.
+// Flow: User confirms deletion → DomainEvent + ApprovalTicket created → Admin approves → River job executes K8s delete.
+type DeleteVMUseCase struct {
+	entClient   *ent.Client
+	auditLogger *audit.Logger
+}
+
+// NewDeleteVMUseCase creates a new DeleteVMUseCase.
+func NewDeleteVMUseCase(entClient *ent.Client) *DeleteVMUseCase {
+	return &DeleteVMUseCase{entClient: entClient}
+}
+
+// WithAuditLogger sets the audit logger (optional dependency).
+func (uc *DeleteVMUseCase) WithAuditLogger(al *audit.Logger) *DeleteVMUseCase {
+	uc.auditLogger = al
+	return uc
+}
+
+// Execute runs the VM deletion request use case.
+// Phase 1: Validates VM state and confirmation.
+// Phase 2: Creates DomainEvent + ApprovalTicket (operation_type=DELETE) in atomic transaction.
+// Phase 3: After admin approval, Gateway enqueues River job for K8s deletion.
+func (uc *DeleteVMUseCase) Execute(ctx context.Context, input DeleteVMInput) (*DeleteVMOutput, error) {
+	// Step 1: Fetch VM and validate state.
+	vm, err := uc.entClient.VM.Get(ctx, input.VMID)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, apperrors.NotFound(apperrors.CodeVMNotFound, fmt.Sprintf("VM %s not found", input.VMID))
+		}
+		return nil, fmt.Errorf("get VM %s: %w", input.VMID, err)
+	}
+
+	// Step 2: Confirmation gate (ADR-0015 §13 addendum).
+	confirmed := false
+	if input.Confirm {
+		confirmed = true
+	}
+	if input.ConfirmName != "" {
+		if input.ConfirmName == vm.Name {
+			confirmed = true
+		} else {
+			return nil, apperrors.BadRequest("CONFIRMATION_NAME_MISMATCH",
+				fmt.Sprintf("expected '%s', got '%s'", vm.Name, input.ConfirmName))
+		}
+	}
+	if !confirmed {
+		return nil, apperrors.BadRequest("DELETE_CONFIRMATION_REQUIRED",
+			"deletion requires confirm=true or confirm_name matching VM name")
+	}
+
+	// Step 3: State guard — only STOPPED or FAILED VMs can be deleted.
+	if vm.Status != entvm.StatusSTOPPED && vm.Status != entvm.StatusFAILED {
+		return nil, apperrors.Conflict("INVALID_STATE_TRANSITION",
+			fmt.Sprintf("cannot delete VM in %s state, must be STOPPED or FAILED", vm.Status))
+	}
+
+	// Step 4: Duplicate pending guard — prevent multiple delete requests for same VM.
+	existingCount, err := uc.entClient.ApprovalTicket.Query().
+		Where(
+			approvalticket.StatusEQ(approvalticket.StatusPENDING),
+			approvalticket.OperationTypeEQ(approvalticket.OperationTypeDELETE),
+			approvalticket.RequesterEQ(input.RequestedBy),
+		).Count(ctx)
+	if err == nil && existingCount > 0 {
+		return nil, apperrors.Conflict(apperrors.CodeDuplicateRequest,
+			"a pending VM delete request already exists for this user")
+	}
+
+	// Step 5: Build domain event payload.
+	payload := domain.VMDeletePayload{
+		VMID:      input.VMID,
+		VMName:    vm.Name,
+		ClusterID: vm.ClusterID,
+		Namespace: vm.Namespace,
+		Actor:     input.RequestedBy,
+	}
+	payloadBytes, err := payload.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal delete payload: %w", err)
+	}
+
+	// Step 6: Atomic transaction — DomainEvent + ApprovalTicket (ADR-0012).
+	reason := input.Reason
+	if reason == "" {
+		reason = fmt.Sprintf("Request to delete VM %s", vm.Name)
+	}
+
+	var eventID, ticketID string
+	txErr := withTx(ctx, uc.entClient, func(tx *ent.Tx) error {
+		// Create domain event.
+		event, err := tx.DomainEvent.Create().
+			SetID(generateID()).
+			SetEventType(string(domain.EventVMDeletionRequested)).
+			SetAggregateType("vm").
+			SetAggregateID(input.VMID).
+			SetPayload(payloadBytes).
+			SetCreatedBy(input.RequestedBy).
+			Save(ctx)
+		if err != nil {
+			return fmt.Errorf("create domain event: %w", err)
+		}
+		eventID = event.ID
+
+		// Create approval ticket with operation_type=DELETE.
+		ticket, err := tx.ApprovalTicket.Create().
+			SetID(generateID()).
+			SetEventID(event.ID).
+			SetOperationType(approvalticket.OperationTypeDELETE).
+			SetRequester(input.RequestedBy).
+			SetReason(reason).
+			Save(ctx)
+		if err != nil {
+			return fmt.Errorf("create approval ticket: %w", err)
+		}
+		ticketID = ticket.ID
+
+		return nil
+	})
+
+	if txErr != nil {
+		return nil, fmt.Errorf("create vm delete request: %w", txErr)
+	}
+
+	// Step 7: Audit log (best-effort, outside transaction).
+	if uc.auditLogger != nil {
+		_ = uc.auditLogger.LogAction(ctx, "vm.delete_requested", "approval_ticket", ticketID, input.RequestedBy, map[string]interface{}{
+			"vm_id":   input.VMID,
+			"vm_name": vm.Name,
+		})
+	}
+
+	logger.Info("VM deletion request submitted (pending approval)",
+		zap.String("event_id", eventID),
+		zap.String("ticket_id", ticketID),
+		zap.String("vm_id", input.VMID),
+		zap.String("requester", input.RequestedBy),
+	)
+
+	return &DeleteVMOutput{
+		TicketID: ticketID,
+		EventID:  eventID,
+		Status:   "PENDING",
+	}, nil
+}


### PR DESCRIPTION
## Description
- add usecase orchestration for VM create/delete and approval atomic flow
- keep this layer separated from service/provider runtime PRs

## Related Issue
- Refs #176

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI

## Checklist
- [x] One PR = One Issue
- [x] DCO signed commits
- [x] Scope-only files changed
- [ ] Required checks passed