### PR TITLE
chore(deps): freeze K8s/KubeVirt auto-upgrades and lock baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # KubeVirt/K8s stack is intentionally pinned; upgrade in manual batch windows.
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "kubevirt.io/*"
+      - dependency-name: "sigs.k8s.io/*"
     labels:
       - "dependencies"
       - "go"

--- a/go.mod
+++ b/go.mod
@@ -113,3 +113,11 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+// Lock Kubernetes core dependencies to match kubevirt.io/client-go v1.7.0 baseline.
+replace (
+	k8s.io/api => k8s.io/api v0.33.5
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.5
+	k8s.io/apimachinery => k8s.io/apimachinery v0.33.5
+	k8s.io/client-go => k8s.io/client-go v0.33.5
+)


### PR DESCRIPTION
## Description
Apply dependency-governance hardening to prevent unintended K8s/KubeVirt stack drift while keeping Dependabot enabled.

## Related Issue
- Refs #202

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🔧 Refactoring (no functional runtime changes)
- [ ] 🧪 Test update

## What Changed
1. `.github/dependabot.yml`
- Added `gomod` ignore rules for:
  - `k8s.io/*`
  - `kubevirt.io/*`
  - `sigs.k8s.io/*`
- Purpose: keep auto-detection active but freeze high-risk dependency families for manual batch upgrades.

2. `go.mod`
- Added explicit `replace` lock block for Kubernetes core alignment:
  - `k8s.io/api => v0.33.5`
  - `k8s.io/apiextensions-apiserver => v0.33.5`
  - `k8s.io/apimachinery => v0.33.5`
  - `k8s.io/client-go => v0.33.5`

## ADR / Governance Compliance
- Aligns with existing KubeVirt/K8s compatibility constraints in `docs/design/DEPENDENCIES.md`.
- Does not introduce a new architecture decision.

## Verification
- Verified diff scope contains only:
  - `.github/dependabot.yml`
  - `go.mod`
- Note: local `go list -m ...` check is currently blocked by an existing `go.sum` missing-entry condition in workspace baseline (`github.com/stretchr/testify@v1.9.0`), not introduced by this change.

## Checklist
### Code Quality
- [x] Changes are minimal and scoped
- [x] No unrelated files included

### Documentation
- [x] PR body documents rationale and policy impact

### Architecture
- [x] Complies with existing ADR/dependency constraints
- [x] No new ADR required for this implementation-level governance change

### CI Checks
- [x] No code-path behavior change
- [x] Dependency governance hardening only