### PR TITLE
feat(auth): harden jwt validation and password security

### DIFF
--- a/internal/api/handlers/server_auth_test.go
+++ b/internal/api/handlers/server_auth_test.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestHashPassword_UsesConfiguredCost(t *testing.T) {
+	hash, err := HashPassword("Passw0rd!Example")
+	if err != nil {
+		t.Fatalf("HashPassword() error = %v", err)
+	}
+
+	cost, err := bcrypt.Cost([]byte(hash))
+	if err != nil {
+		t.Fatalf("bcrypt.Cost() error = %v", err)
+	}
+
+	if cost != passwordHashCost {
+		t.Fatalf("bcrypt cost = %d, want %d", cost, passwordHashCost)
+	}
+}

--- a/internal/api/middleware/jwt.go
+++ b/internal/api/middleware/jwt.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 )
 
 // JWTClaims defines custom JWT claims for Shepherd.
@@ -20,17 +22,41 @@ type JWTClaims struct {
 	jwt.RegisteredClaims
 }
 
+const defaultJWTLeeway = 30 * time.Second
+
+var (
+	ErrJWTSigningKeyMissing = errors.New("jwt signing key is not configured")
+	ErrTokenRevoked         = errors.New("token revoked")
+	ErrTokenIDRequired      = errors.New("token id is required for revocation checks")
+)
+
+// TokenRevocationChecker checks whether a token JTI is revoked.
+type TokenRevocationChecker interface {
+	IsRevoked(ctx context.Context, tokenID string) (bool, error)
+}
+
 // JWTConfig holds JWT signing configuration.
 type JWTConfig struct {
-	SigningKey []byte
-	Issuer    string
-	ExpiresIn time.Duration
+	SigningKey        []byte
+	VerificationKeys  [][]byte
+	Issuer            string
+	ExpiresIn         time.Duration
+	Leeway            time.Duration
+	RevocationChecker TokenRevocationChecker
 }
 
 // GenerateToken creates a signed JWT for the given user.
 func GenerateToken(cfg JWTConfig, userID, username string, roles, permissions []string) (string, time.Time, error) {
+	if len(cfg.SigningKey) == 0 {
+		return "", time.Time{}, ErrJWTSigningKeyMissing
+	}
+
 	now := time.Now()
 	expiresAt := now.Add(cfg.ExpiresIn)
+	tokenID, err := uuid.NewV7()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generate token id: %w", err)
+	}
 
 	claims := JWTClaims{
 		UserID:      userID,
@@ -42,6 +68,8 @@ func GenerateToken(cfg JWTConfig, userID, username string, roles, permissions []
 			Subject:   userID,
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ID:        tokenID.String(),
 		},
 	}
 
@@ -53,8 +81,97 @@ func GenerateToken(cfg JWTConfig, userID, username string, roles, permissions []
 	return tokenString, expiresAt, nil
 }
 
+func (cfg JWTConfig) parserOptions() []jwt.ParserOption {
+	leeway := cfg.Leeway
+	if leeway <= 0 {
+		leeway = defaultJWTLeeway
+	}
+
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
+		jwt.WithLeeway(leeway),
+		jwt.WithExpirationRequired(),
+		// Keep nbf optional for compatibility with legacy V1 tokens minted
+		// before NotBefore was introduced; when present it is still validated.
+		jwt.WithIssuedAt(),
+	}
+	if cfg.Issuer != "" {
+		opts = append(opts, jwt.WithIssuer(cfg.Issuer))
+	}
+	return opts
+}
+
+func (cfg JWTConfig) verificationKeySet() jwt.VerificationKeySet {
+	keys := make([]jwt.VerificationKey, 0, 1+len(cfg.VerificationKeys))
+	seen := make(map[string]struct{}, 1+len(cfg.VerificationKeys))
+
+	if len(cfg.SigningKey) > 0 {
+		keys = append(keys, cfg.SigningKey)
+		seen[string(cfg.SigningKey)] = struct{}{}
+	}
+
+	for _, key := range cfg.VerificationKeys {
+		if len(key) == 0 {
+			continue
+		}
+		if _, ok := seen[string(key)]; ok {
+			continue
+		}
+		keys = append(keys, key)
+		seen[string(key)] = struct{}{}
+	}
+
+	return jwt.VerificationKeySet{Keys: keys}
+}
+
+func (cfg JWTConfig) keyfunc() jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+
+		keySet := cfg.verificationKeySet()
+		switch len(keySet.Keys) {
+		case 0:
+			return nil, ErrJWTSigningKeyMissing
+		case 1:
+			return keySet.Keys[0], nil
+		default:
+			return keySet, nil
+		}
+	}
+}
+
+// ValidateToken validates token signature + standard claims and checks optional revocation.
+func (cfg JWTConfig) ValidateToken(ctx context.Context, tokenString string) (*JWTClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, cfg.keyfunc(), cfg.parserOptions()...)
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := token.Claims.(*JWTClaims)
+	if !ok || !token.Valid {
+		return nil, jwt.ErrTokenInvalidClaims
+	}
+
+	if cfg.RevocationChecker != nil {
+		if claims.ID == "" {
+			return nil, ErrTokenIDRequired
+		}
+		revoked, err := cfg.RevocationChecker.IsRevoked(ctx, claims.ID)
+		if err != nil {
+			return nil, fmt.Errorf("check token revocation: %w", err)
+		}
+		if revoked {
+			return nil, ErrTokenRevoked
+		}
+	}
+
+	return claims, nil
+}
+
 // JWTAuth returns a Gin middleware that validates Bearer tokens and populates context.
-func JWTAuth(signingKey []byte) gin.HandlerFunc {
+func JWTAuthWithConfig(cfg JWTConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
@@ -75,31 +192,21 @@ func JWTAuth(signingKey []byte) gin.HandlerFunc {
 		}
 
 		tokenString := parts[1]
-		token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
-			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-			}
-			return signingKey, nil
-		}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+		claims, err := cfg.ValidateToken(c.Request.Context(), tokenString)
 
 		if err != nil {
 			code := "UNAUTHORIZED"
 			msg := "invalid token"
 			if errors.Is(err, jwt.ErrTokenExpired) {
 				msg = "token expired"
+			} else if errors.Is(err, jwt.ErrTokenNotValidYet) || errors.Is(err, jwt.ErrTokenUsedBeforeIssued) {
+				msg = "token not active"
+			} else if errors.Is(err, ErrTokenRevoked) {
+				msg = "token revoked"
 			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"code":    code,
 				"message": msg,
-			})
-			return
-		}
-
-		claims, ok := token.Claims.(*JWTClaims)
-		if !ok || !token.Valid {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"code":    "UNAUTHORIZED",
-				"message": "invalid token claims",
 			})
 			return
 		}
@@ -115,4 +222,9 @@ func JWTAuth(signingKey []byte) gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+// JWTAuth is a compatibility wrapper for legacy call sites.
+func JWTAuth(signingKey []byte) gin.HandlerFunc {
+	return JWTAuthWithConfig(JWTConfig{SigningKey: signingKey})
 }

--- a/internal/api/middleware/jwt_test.go
+++ b/internal/api/middleware/jwt_test.go
@@ -1,0 +1,188 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRevocationChecker struct {
+	revoked map[string]bool
+	err     error
+}
+
+func (f fakeRevocationChecker) IsRevoked(_ context.Context, tokenID string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.revoked[tokenID], nil
+}
+
+func TestJWTConfigValidateToken_Success(t *testing.T) {
+	cfg := JWTConfig{
+		SigningKey: []byte("test-signing-key-1234567890123456"),
+		Issuer:     "shepherd",
+		ExpiresIn:  time.Hour,
+	}
+
+	token, _, err := GenerateToken(cfg, "u-1", "alice", []string{"operator"}, []string{"vm:read"})
+	require.NoError(t, err)
+
+	claims, err := cfg.ValidateToken(context.Background(), token)
+	require.NoError(t, err)
+	assert.Equal(t, "u-1", claims.UserID)
+	assert.Equal(t, "alice", claims.Username)
+	assert.NotEmpty(t, claims.ID)
+	require.NotNil(t, claims.NotBefore)
+}
+
+func TestJWTConfigValidateToken_RejectsInvalidIssuer(t *testing.T) {
+	issuerCfg := JWTConfig{
+		SigningKey: []byte("issuer-key-123456789012345678901234"),
+		Issuer:     "shepherd",
+		ExpiresIn:  time.Hour,
+	}
+	token, _, err := GenerateToken(issuerCfg, "u-1", "alice", nil, nil)
+	require.NoError(t, err)
+
+	validatorCfg := JWTConfig{
+		SigningKey: issuerCfg.SigningKey,
+		Issuer:     "other-issuer",
+	}
+	_, err = validatorCfg.ValidateToken(context.Background(), token)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jwt.ErrTokenInvalidIssuer)
+}
+
+func TestJWTConfigValidateToken_SupportsVerificationKeyRotation(t *testing.T) {
+	oldKey := []byte("old-key-123456789012345678901234567890")
+	newKey := []byte("new-key-123456789012345678901234567890")
+
+	token, _, err := GenerateToken(JWTConfig{
+		SigningKey: oldKey,
+		Issuer:     "shepherd",
+		ExpiresIn:  time.Hour,
+	}, "u-1", "alice", nil, nil)
+	require.NoError(t, err)
+
+	claims, err := JWTConfig{
+		SigningKey:       newKey,
+		VerificationKeys: [][]byte{oldKey},
+		Issuer:           "shepherd",
+	}.ValidateToken(context.Background(), token)
+	require.NoError(t, err)
+	assert.Equal(t, "u-1", claims.UserID)
+}
+
+func TestJWTConfigValidateToken_RejectsNoneSigningMethod(t *testing.T) {
+	now := time.Now()
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, JWTClaims{
+		UserID: "u-1",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "shepherd",
+			Subject:   "u-1",
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			NotBefore: jwt.NewNumericDate(now),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+	})
+	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	_, err = JWTConfig{
+		SigningKey: []byte("signing-key-123456789012345678901234"),
+		Issuer:     "shepherd",
+	}.ValidateToken(context.Background(), tokenString)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
+}
+
+func TestJWTConfigValidateToken_AllowsLegacyTokenWithoutNotBefore(t *testing.T) {
+	now := time.Now()
+	legacyClaims := JWTClaims{
+		UserID:   "u-legacy",
+		Username: "legacy-user",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "shepherd",
+			Subject:   "u-legacy",
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        "legacy-jti",
+		},
+	}
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacyClaims).
+		SignedString([]byte("legacy-signing-key-1234567890123456789"))
+	require.NoError(t, err)
+
+	claims, err := JWTConfig{
+		SigningKey: []byte("legacy-signing-key-1234567890123456789"),
+		Issuer:     "shepherd",
+	}.ValidateToken(context.Background(), token)
+	require.NoError(t, err)
+	assert.Equal(t, "u-legacy", claims.UserID)
+	assert.Nil(t, claims.NotBefore)
+}
+
+func TestJWTConfigValidateToken_RevocationCheck(t *testing.T) {
+	cfg := JWTConfig{
+		SigningKey: []byte("revocation-key-1234567890123456789012"),
+		Issuer:     "shepherd",
+		ExpiresIn:  time.Hour,
+	}
+	token, _, err := GenerateToken(cfg, "u-1", "alice", nil, nil)
+	require.NoError(t, err)
+
+	claims, err := cfg.ValidateToken(context.Background(), token)
+	require.NoError(t, err)
+	require.NotEmpty(t, claims.ID)
+
+	_, err = JWTConfig{
+		SigningKey: cfg.SigningKey,
+		Issuer:     "shepherd",
+		RevocationChecker: fakeRevocationChecker{
+			revoked: map[string]bool{claims.ID: true},
+		},
+	}.ValidateToken(context.Background(), token)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTokenRevoked)
+}
+
+func TestJWTConfigValidateToken_RequiresSigningKey(t *testing.T) {
+	token, _, err := GenerateToken(JWTConfig{
+		SigningKey: []byte("key-to-sign-valid-token-1234567890123456"),
+		Issuer:     "shepherd",
+		ExpiresIn:  time.Hour,
+	}, "u-1", "alice", nil, nil)
+	require.NoError(t, err)
+
+	_, err = JWTConfig{Issuer: "shepherd"}.ValidateToken(context.Background(), token)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jwt.ErrTokenUnverifiable)
+	assert.ErrorIs(t, err, ErrJWTSigningKeyMissing)
+}
+
+func TestJWTConfigValidateToken_RevocationCheckerError(t *testing.T) {
+	cfg := JWTConfig{
+		SigningKey: []byte("revocation-error-key-1234567890123456"),
+		Issuer:     "shepherd",
+		ExpiresIn:  time.Hour,
+	}
+	token, _, err := GenerateToken(cfg, "u-1", "alice", nil, nil)
+	require.NoError(t, err)
+
+	_, err = JWTConfig{
+		SigningKey: cfg.SigningKey,
+		Issuer:     cfg.Issuer,
+		RevocationChecker: fakeRevocationChecker{
+			err: errors.New("db down"),
+		},
+	}.ValidateToken(context.Background(), token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check token revocation")
+}

--- a/internal/app/modules/server_deps.go
+++ b/internal/app/modules/server_deps.go
@@ -1,6 +1,8 @@
 package modules
 
 import (
+	"strings"
+
 	"kv-shepherd.io/shepherd/internal/api/handlers"
 	"kv-shepherd.io/shepherd/internal/api/middleware"
 	"kv-shepherd.io/shepherd/internal/config"
@@ -8,10 +10,24 @@ import (
 
 // NewServerDeps builds base server deps then lets each module contribute explicit wiring.
 func NewServerDeps(cfg *config.Config, infra *Infrastructure, mods []Module) handlers.ServerDeps {
+	verificationKeys := make([][]byte, 0, len(cfg.Security.JWTVerificationKeys))
+	for _, key := range cfg.Security.JWTVerificationKeys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		verificationKeys = append(verificationKeys, []byte(key))
+	}
+
 	deps := handlers.ServerDeps{
-		EntClient:   infra.EntClient,
-		Pool:        infra.Pool,
-		JWTCfg:      middleware.JWTConfig{SigningKey: []byte(cfg.Security.SessionSecret), Issuer: "shepherd", ExpiresIn: cfg.Session.Lifetime},
+		EntClient: infra.EntClient,
+		Pool:      infra.Pool,
+		JWTCfg: middleware.JWTConfig{
+			SigningKey:       []byte(cfg.Security.SessionSecret),
+			VerificationKeys: verificationKeys,
+			Issuer:           "shepherd",
+			ExpiresIn:        cfg.Session.Lifetime,
+		},
 		Audit:       infra.AuditLogger,
 		RiverClient: infra.RiverClient,
 	}

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -21,10 +21,10 @@ var adminPrefixes = []string{
 	"/api/v1/audit-logs",
 }
 
-func newRouter(server generated.ServerInterface, signingKey []byte) *gin.Engine {
+func newRouter(server generated.ServerInterface, jwtCfg middleware.JWTConfig) *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Recovery(), middleware.RequestID(), middleware.ErrorHandler())
-	router.Use(jwtSkipPublic(signingKey))
+	router.Use(jwtSkipPublic(jwtCfg))
 	router.Use(rbacAdminRoutes())
 
 	generated.RegisterHandlersWithOptions(router, server, generated.GinServerOptions{
@@ -34,8 +34,8 @@ func newRouter(server generated.ServerInterface, signingKey []byte) *gin.Engine 
 }
 
 // jwtSkipPublic returns middleware that applies JWT auth only on non-public routes.
-func jwtSkipPublic(signingKey []byte) gin.HandlerFunc {
-	jwtMw := middleware.JWTAuth(signingKey)
+func jwtSkipPublic(jwtCfg middleware.JWTConfig) gin.HandlerFunc {
+	jwtMw := middleware.JWTAuthWithConfig(jwtCfg)
 	return func(c *gin.Context) {
 		for _, prefix := range publicPrefixes {
 			if strings.HasPrefix(c.Request.URL.Path, prefix) {


### PR DESCRIPTION
## Summary
- harden JWT parser validation (alg allow-list, issuer/exp/iat validation, key-rotation verification set)
- keep legacy token compatibility by not requiring `nbf` for old tokens
- add revocation checker extension point and tests
- increase bcrypt hash cost to `12` and redact login failure logs
- keep bootstrap logging on structured `zap` path

## Validation
- `go test ./internal/api/middleware ./internal/api/handlers ./internal/config`

Closes #208