### PR TITLE
feat(governance): add notification retention cleanup job

### DIFF
--- a/internal/app/modules/governance.go
+++ b/internal/app/modules/governance.go
@@ -2,10 +2,12 @@ package modules
 
 import (
 	"context"
+	"time"
 
 	"github.com/riverqueue/river"
 
 	"kv-shepherd.io/shepherd/internal/api/handlers"
+	"kv-shepherd.io/shepherd/internal/jobs"
 )
 
 // GovernanceModule is a domain boundary placeholder for system/service/RBAC composition.
@@ -23,6 +25,11 @@ func (m *GovernanceModule) Name() string { return "governance" }
 
 func (m *GovernanceModule) ContributeServerDeps(_ *handlers.ServerDeps) {}
 
-func (m *GovernanceModule) RegisterWorkers(_ *river.Workers) {}
+func (m *GovernanceModule) RegisterWorkers(workers *river.Workers) {
+	if workers == nil || m == nil || m.infra == nil || m.infra.EntClient == nil {
+		return
+	}
+	river.AddWorker(workers, jobs.NewNotificationCleanupWorker(m.infra.EntClient, 90*24*time.Hour))
+}
 
 func (m *GovernanceModule) Shutdown(context.Context) error { return nil }

--- a/internal/infrastructure/database.go
+++ b/internal/infrastructure/database.go
@@ -123,7 +123,8 @@ func (c *DatabaseClients) InitRiverClient(workers *river.Workers, cfg config.Riv
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: cfg.MaxWorkers},
 		},
-		Workers: workers,
+		Workers:                     workers,
+		CompletedJobRetentionPeriod: cfg.CompletedJobRetentionPeriod,
 	})
 	if err != nil {
 		return fmt.Errorf("create river client: %w", err)

--- a/internal/jobs/notification_cleanup.go
+++ b/internal/jobs/notification_cleanup.go
@@ -1,0 +1,82 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/riverqueue/river"
+	"go.uber.org/zap"
+
+	"kv-shepherd.io/shepherd/ent"
+	"kv-shepherd.io/shepherd/ent/notification"
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+)
+
+const (
+	// DefaultNotificationRetention is the V1 retention baseline for inbox
+	// notifications (master-flow Stage 5.F / phase-4 checklist).
+	DefaultNotificationRetention = 90 * 24 * time.Hour
+)
+
+// NotificationCleanupArgs is a periodic maintenance job that removes expired
+// notifications from the platform inbox.
+type NotificationCleanupArgs struct{}
+
+// Kind returns the job kind identifier for periodic notification cleanup.
+func (NotificationCleanupArgs) Kind() string { return "notification_cleanup" }
+
+// InsertOpts ensures at most one cleanup job is enqueued within the same day.
+func (NotificationCleanupArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue:       river.QueueDefault,
+		MaxAttempts: 1,
+		UniqueOpts: river.UniqueOpts{
+			ByPeriod: 24 * time.Hour,
+			ByQueue:  true,
+			ByArgs:   true,
+		},
+	}
+}
+
+// NotificationCleanupWorker deletes notifications older than the configured
+// retention duration.
+type NotificationCleanupWorker struct {
+	river.WorkerDefaults[NotificationCleanupArgs]
+	entClient *ent.Client
+	retention time.Duration
+}
+
+// NewNotificationCleanupWorker creates a cleanup worker. Non-positive retention
+// falls back to the 90-day default.
+func NewNotificationCleanupWorker(entClient *ent.Client, retention time.Duration) *NotificationCleanupWorker {
+	if retention <= 0 {
+		retention = DefaultNotificationRetention
+	}
+	return &NotificationCleanupWorker{
+		entClient: entClient,
+		retention: retention,
+	}
+}
+
+// Work removes expired notification rows.
+func (w *NotificationCleanupWorker) Work(ctx context.Context, _ *river.Job[NotificationCleanupArgs]) error {
+	if w == nil || w.entClient == nil {
+		return fmt.Errorf("notification cleanup worker is not initialized")
+	}
+
+	cutoff := time.Now().UTC().Add(-w.retention)
+	deleted, err := w.entClient.Notification.Delete().
+		Where(notification.CreatedAtLT(cutoff)).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("delete expired notifications before %s: %w", cutoff.Format(time.RFC3339), err)
+	}
+
+	logger.Info("notification cleanup completed",
+		zap.Int("deleted_rows", deleted),
+		zap.String("cutoff", cutoff.Format(time.RFC3339)),
+		zap.Duration("retention", w.retention),
+	)
+	return nil
+}

--- a/internal/jobs/notification_cleanup_test.go
+++ b/internal/jobs/notification_cleanup_test.go
@@ -1,0 +1,79 @@
+package jobs
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+)
+
+func TestNotificationCleanupArgsKind(t *testing.T) {
+	t.Parallel()
+
+	if got := (NotificationCleanupArgs{}).Kind(); got != "notification_cleanup" {
+		t.Fatalf("Kind() = %q, want %q", got, "notification_cleanup")
+	}
+}
+
+func TestNotificationCleanupArgsInsertOpts(t *testing.T) {
+	t.Parallel()
+
+	opts := (NotificationCleanupArgs{}).InsertOpts()
+	if opts.Queue != river.QueueDefault {
+		t.Fatalf("Queue = %q, want %q", opts.Queue, river.QueueDefault)
+	}
+	if opts.MaxAttempts != 1 {
+		t.Fatalf("MaxAttempts = %d, want 1", opts.MaxAttempts)
+	}
+	if opts.UniqueOpts.ByPeriod != 24*time.Hour {
+		t.Fatalf("UniqueOpts.ByPeriod = %s, want %s", opts.UniqueOpts.ByPeriod, 24*time.Hour)
+	}
+	if !opts.UniqueOpts.ByQueue {
+		t.Fatal("UniqueOpts.ByQueue = false, want true")
+	}
+	if !opts.UniqueOpts.ByArgs {
+		t.Fatal("UniqueOpts.ByArgs = false, want true")
+	}
+}
+
+func TestNewNotificationCleanupWorkerRetention(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to ninety days when non-positive", func(t *testing.T) {
+		w := NewNotificationCleanupWorker(nil, 0)
+		if w.retention != DefaultNotificationRetention {
+			t.Fatalf("retention = %s, want %s", w.retention, DefaultNotificationRetention)
+		}
+	})
+
+	t.Run("uses explicit retention when provided", func(t *testing.T) {
+		want := 7 * 24 * time.Hour
+		w := NewNotificationCleanupWorker(nil, want)
+		if w.retention != want {
+			t.Fatalf("retention = %s, want %s", w.retention, want)
+		}
+	})
+}
+
+func TestNotificationCleanupWorkerWork_Uninitialized(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var w *NotificationCleanupWorker
+		err := w.Work(context.Background(), nil)
+		if err == nil || !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("Work() error = %v, want contains %q", err, "not initialized")
+		}
+	})
+
+	t.Run("nil ent client", func(t *testing.T) {
+		w := &NotificationCleanupWorker{}
+		err := w.Work(context.Background(), nil)
+		if err == nil || !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("Work() error = %v, want contains %q", err, "not initialized")
+		}
+	})
+}
+


### PR DESCRIPTION
## Summary
- add periodic notification cleanup worker (90-day retention default)
- register governance worker and schedule periodic run on bootstrap
- wire River completed job retention config
- add unit tests for job args/worker guardrails

## Validation
- `go test ./internal/jobs ./internal/app/...`

Refs #170