### PR TITLE
ci: enforce ent codegen sync in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Check no Redis imports (ADR)
         run: bash docs/design/ci/scripts/check_no_redis_import.sh
 
+      - name: Check Ent codegen sync (ADR-0003)
+        run: go run docs/design/ci/scripts/check_ent_codegen.go
+
       - name: Check manual DI - no Wire/Dig (ADR-0013)
         run: bash docs/design/ci/scripts/check_manual_di.sh
 


### PR DESCRIPTION
## Summary
- add CI gate to run `go run docs/design/ci/scripts/check_ent_codegen.go`
- enforce ADR-0003 ent codegen sync in main workflow

## Validation
- `go run docs/design/ci/scripts/check_ent_codegen.go`

Refs #174