### PR TITLE
docs(design): add coding and security guides

### DIFF
--- a/docs/design/CODING_STYLE.md
+++ b/docs/design/CODING_STYLE.md
@@ -1,0 +1,219 @@
+# Go Coding Style Guide
+
+> **Supplements**: [Effective Go](https://golang.org/doc/effective_go), `golangci-lint`, `gofmt`/`goimports`
+> **Authority**: This document is the project's authoritative source for Go coding style.
+> **ADR References**: [ADR-0003](../adr/ADR-0003-database-orm.md), [ADR-0013](../adr/ADR-0013-manual-di.md), [ADR-0016](../adr/ADR-0016-go-module-vanity-import.md)
+
+---
+
+## File & Function Size Limits
+
+| Metric | Target | Hard Limit | Action |
+|--------|--------|------------|--------|
+| File size | 200–400 lines | 800 lines | Refactor: split into cohesive files |
+| Function body | ≤50 lines | — | Split into helper functions |
+| Nesting depth | ≤3 levels | 4 levels | Use early returns to flatten |
+
+These limits are guidelines enforced during code review, not CI.
+
+---
+
+## Import Ordering
+
+Use three groups separated by blank lines:
+
+```go
+import (
+    // 1. Standard library
+    "context"
+    "fmt"
+    "time"
+
+    // 2. Third-party libraries
+    "github.com/google/uuid"
+    "golang.org/x/sync/errgroup"
+
+    // 3. Project internal packages (vanity import, ADR-0016)
+    "kv-shepherd.io/shepherd/ent"
+    "kv-shepherd.io/shepherd/internal/service"
+)
+```
+
+`goimports` handles this automatically when configured with `-local kv-shepherd.io/shepherd`.
+
+---
+
+## Struct Field Ordering
+
+Order struct fields by lifecycle stage:
+
+```go
+type VMService struct {
+    // 1. Dependencies (injected at construction)
+    db       *ent.Client
+    provider Provider
+    queue    *river.Client
+
+    // 2. Configuration (set at init, read-only after)
+    timeout time.Duration
+    logger  *slog.Logger
+
+    // 3. Internal state (mutated at runtime)
+    mu    sync.RWMutex
+    cache map[uuid.UUID]*VM
+}
+```
+
+---
+
+## Naming Conventions
+
+### Functions
+
+```go
+// ✅ Descriptive but concise
+func CreateVirtualMachine(ctx context.Context, req *CreateVMRequest) (*VM, error)
+
+// ✅ Short when context is clear (method on VMService)
+func (s *VMService) Get(ctx context.Context, id uuid.UUID) (*VM, error)
+
+// ❌ Too vague
+func Create(ctx context.Context, r *Req) (*R, error)
+
+// ❌ Needlessly verbose
+func (s *VMService) GetVirtualMachineByIdentifier(ctx context.Context, id uuid.UUID) (*VM, error)
+```
+
+### Error Values
+
+```go
+// Package-level sentinel errors
+var (
+    ErrVMNotFound = errors.New("vm not found")
+    ErrVMDeleted  = errors.New("vm already deleted")
+)
+```
+
+---
+
+## Error Handling
+
+Use early returns to keep the main logic path at the left margin:
+
+```go
+// ✅ Good: early returns
+func ProcessVM(vm *VM) error {
+    if vm == nil {
+        return errors.New("vm is nil")
+    }
+    if vm.Status == StatusDeleted {
+        return ErrVMDeleted
+    }
+
+    // Main logic at left margin
+    return nil
+}
+
+// ❌ Bad: deep nesting
+func ProcessVM(vm *VM) error {
+    if vm != nil {
+        if vm.Status != StatusDeleted {
+            // Main logic buried in nesting
+        }
+    }
+    return errors.New("vm is nil")
+}
+```
+
+---
+
+## Logging (slog)
+
+All logging **MUST** use structured `slog` calls:
+
+```go
+// ✅ Structured logging
+s.logger.Info("creating vm",
+    slog.String("name", req.Name),
+    slog.String("namespace", req.Namespace),
+    slog.String("tenant_id", req.TenantID.String()),
+)
+
+// ❌ Unstructured logging
+log.Printf("Creating VM %s in namespace %s", req.Name, req.Namespace)
+```
+
+**FORBIDDEN**: Logging sensitive data (passwords, tokens, kubeconfig content).  
+See [SECURITY_CODING.md §Logging & Error Safety](SECURITY_CODING.md) for details.
+
+---
+
+## Comment Standards
+
+```go
+// VMService provides virtual machine management functionality.
+//
+// It handles creation, updates, deletion of VMs and interacts
+// with the KubeVirt provider layer.
+type VMService struct { ... }
+
+// CreateVM creates a new virtual machine.
+//
+// Parameters:
+//   - ctx: Context for timeout and cancellation
+//   - req: Creation request containing VM configuration
+//
+// Returns the created VM entity or an error if creation fails.
+func (s *VMService) CreateVM(ctx context.Context, req *CreateVMRequest) (*ent.VM, error) {
+    // ...
+}
+```
+
+### TODO/FIXME Format
+
+Issue reference is **required**. Bare comments without issue references are forbidden.
+
+```go
+// TODO(#123): implement retry logic for transient failures
+// FIXME(#456): race condition when concurrent updates to same VM
+```
+
+---
+
+## Style Prohibitions (Code Review Enforcement)
+
+> **CI-enforced prohibitions**: See [CHECKLIST.md §Prohibited Patterns](CHECKLIST.md#prohibited-patterns)
+
+These additional style rules are enforced during code review:
+
+| Pattern | Rule |
+|---------|------|
+| `result, _ := doSomething()` | FORBIDDEN — handle all errors |
+| `if condition { }` | FORBIDDEN — no empty blocks |
+| `// TODO: fix later` | FORBIDDEN — must include issue number |
+| Magic numbers (`if retries > 3`) | Use named constants: `const maxRetries = 3` |
+| `log.Printf(...)` | Use `slog` structured logging |
+
+---
+
+## Performance Considerations
+
+- Preallocate slice capacity when size is known: `make([]T, 0, expectedSize)`
+- Avoid unnecessary memory allocations in hot paths
+- Use `sync.Pool` for frequent small allocations
+- Use appropriate concurrency patterns per [ADR-0031](../adr/ADR-0031-concurrency-and-worker-pool-standard.md)
+
+---
+
+## Testing Style
+
+See [CONTRIBUTING.md §Testing](../../CONTRIBUTING.md#testing) for testing requirements and patterns.
+
+---
+
+## Related Documents
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — Contribution workflow and commit standards
+- [CHECKLIST.md §Prohibited Patterns](CHECKLIST.md#prohibited-patterns) — CI-enforced constraints
+- [SECURITY_CODING.md](SECURITY_CODING.md) — Security coding guide
+- [examples/](examples/) — Reference implementations

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -261,6 +261,8 @@ Reference implementations are in the [examples/](./examples/) directory:
 | [database/README.md](./database/README.md) | **Database reference layer** (schema domains, retention lifecycle, transaction boundaries, migration policy) |
 | [DEPENDENCIES.md](./DEPENDENCIES.md) | Version pinning (single source of truth for all dependency versions) |
 | [CHECKLIST.md](./CHECKLIST.md) | Acceptance criteria and **Core ADR Constraints** (single source of truth for CI enforcement) |
+| [CODING_STYLE.md](./CODING_STYLE.md) | Go coding style guide (file/function limits, import order, logging, naming conventions) |
+| [SECURITY_CODING.md](./SECURITY_CODING.md) | Security coding practices (secrets, input validation, tenant isolation, RBAC) |
 | [frontend/README.md](./frontend/README.md) | Frontend design docs index (required reading before frontend changes) |
 | [frontend/FRONTEND.md](./frontend/FRONTEND.md) | Frontend engineering baseline (i18n, API types, schema fallback) |
 | [ci/README.md](./ci/README.md) | **Authoritative CI/development governance** (quality gates, enforcement scripts, workflow requirements) |

--- a/docs/design/SECURITY_CODING.md
+++ b/docs/design/SECURITY_CODING.md
@@ -1,0 +1,204 @@
+# Security Coding Guide
+
+> **Authority**: This document is the project's authoritative source for security coding practices.
+> **ADR Reference**: [ADR-0019 §Security Baseline](../adr/ADR-0019-governance-security-baseline-controls.md)
+> **Vulnerability Reporting**: See [SECURITY.md](../../SECURITY.md)
+
+---
+
+## Mandatory Security Checks
+
+All code touching user data, authentication, or external system interactions **MUST** pass these checks during code review.
+
+---
+
+### 1. Secrets Management
+
+**FORBIDDEN**: Hardcoded secrets in source code.
+
+```go
+// ❌ FORBIDDEN
+const apiKey = "sk-xxxxx"
+const dbPassword = "password123"
+kubeconfig := "apiVersion: v1\nclusters:..."
+
+// ✅ CORRECT
+apiKey := os.Getenv("API_KEY")
+if apiKey == "" {
+    return errors.New("API_KEY not configured")
+}
+
+// Kubeconfig uses encrypted storage (AES-256-GCM)
+kubeconfig, err := s.secretStore.GetKubeconfig(ctx, clusterID)
+```
+
+**Checklist**:
+- [ ] No hardcoded API keys, tokens, or passwords
+- [ ] All secrets via environment variables or encrypted storage
+- [ ] `.env` files listed in `.gitignore`
+- [ ] No secrets in Git history
+- [ ] Kubeconfig uses AES-256-GCM encryption
+
+---
+
+### 2. Input Validation
+
+**Rule**: All user inputs must have validation using whitelists (not blacklists).
+
+```go
+func (r *CreateVMRequest) Validate() error {
+    if r.Name == "" {
+        return errors.New("name is required")
+    }
+    if len(r.Name) > 63 {
+        return errors.New("name too long")
+    }
+    if !validNameRegex.MatchString(r.Name) {
+        return errors.New("name contains invalid characters")
+    }
+    return nil
+}
+
+// Always validate in handler layer
+func (h *VMHandler) Create(ctx context.Context, req *CreateVMRequest) error {
+    if err := req.Validate(); err != nil {
+        return status.Errorf(codes.InvalidArgument, "validation: %v", err)
+    }
+    // Continue processing...
+}
+```
+
+**Checklist**:
+- [ ] All user inputs validated
+- [ ] Uses whitelist validation (not blacklist)
+- [ ] Error messages don't leak internal structure
+
+---
+
+### 3. SQL Injection Prevention
+
+**Rule**: Always use Ent ORM or parameterized queries. Never concatenate user input into queries.
+
+```go
+// ❌ FORBIDDEN: String concatenation
+query := fmt.Sprintf("SELECT * FROM vms WHERE name = '%s'", userName)
+
+// ✅ CORRECT: Ent ORM (ADR-0003)
+vms, err := client.VM.Query().
+    Where(vm.Name(userName)).
+    All(ctx)
+
+// ✅ CORRECT: Parameterized query (if raw SQL needed, whitelisted dirs only)
+rows, err := db.Query("SELECT * FROM vms WHERE name = $1", userName)
+```
+
+---
+
+### 4. Tenant Isolation
+
+**Rule**: ALL data queries MUST include tenant ID filter. No cross-tenant data access.
+
+```go
+func (s *VMService) GetVM(ctx context.Context, id uuid.UUID) (*ent.VM, error) {
+    tenantID := auth.TenantIDFromContext(ctx)
+
+    vm, err := s.db.VM.Query().
+        Where(
+            vm.ID(id),
+            vm.TenantID(tenantID), // REQUIRED — never omit
+        ).
+        Only(ctx)
+
+    if err != nil {
+        return nil, fmt.Errorf("get vm: %w", err)
+    }
+    return vm, nil
+}
+```
+
+**Checklist**:
+- [ ] All API endpoints have authentication
+- [ ] Sensitive operations have authorization checks
+- [ ] Tenant isolation in every query
+- [ ] Follows least privilege principle
+
+---
+
+### 5. Logging & Error Safety
+
+**Rule**: Never expose internal details to users. Log details server-side only.
+
+```go
+// ❌ FORBIDDEN: Logging sensitive data
+log.Printf("User login: %s, password: %s", email, password)
+log.Printf("Kubeconfig: %s", kubeconfig)
+
+// ✅ CORRECT: Redact sensitive data
+s.logger.Info("user login", slog.String("email", email))
+// Don't log passwords or kubeconfig content
+
+// ❌ FORBIDDEN: Exposing internal details to user
+return fmt.Errorf("database error: %s, query: %s", err, query)
+
+// ✅ CORRECT: Generic user-facing error + detailed server log
+s.logger.Error("internal error", slog.String("error", err.Error()))
+return errors.New("internal error, please try again")
+```
+
+---
+
+### 6. Kubernetes RBAC
+
+**Rule**: Service accounts must use minimum required permissions (ADR-0019).
+
+```go
+// Create minimal permission Role
+role := &rbacv1.Role{
+    Rules: []rbacv1.PolicyRule{
+        {
+            APIGroups: []string{"kubevirt.io"},
+            Resources: []string{"virtualmachines"},
+            Verbs:     []string{"get", "list", "watch"},
+        },
+    },
+}
+```
+
+- No wildcard permissions (`*`) except bootstrap role
+- Bootstrap role must be disabled after initial setup
+- RFC 1035 naming for all platform-managed resources
+
+---
+
+## Code Review Security Checklist
+
+Every code review **MUST** verify:
+
+- [ ] No hardcoded secrets
+- [ ] All inputs validated (whitelist approach)
+- [ ] Uses Ent ORM or parameterized queries
+- [ ] Proper authentication and authorization
+- [ ] Logs don't contain sensitive information
+- [ ] Error messages don't leak internal details
+- [ ] Tenant isolation correctly implemented
+- [ ] K8s RBAC uses minimum permissions
+
+---
+
+## Severity Response Table
+
+| Level | Description | Required Response |
+|-------|-------------|-------------------|
+| **CRITICAL** | Remote code execution, data breach | Fix immediately, deploy hotfix |
+| **HIGH** | Auth bypass, privilege escalation | Fix within 7 days |
+| **MEDIUM** | Information disclosure, DoS | Fix in next release |
+| **LOW** | Minor issues | Address per roadmap |
+
+---
+
+## References
+
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [ADR-0019 §Security Baseline](../adr/ADR-0019-governance-security-baseline-controls.md)
+- [SECURITY.md](../../SECURITY.md)
+- [CODING_STYLE.md §Logging](CODING_STYLE.md)


### PR DESCRIPTION
## Summary
- add `docs/design/CODING_STYLE.md`
- add `docs/design/SECURITY_CODING.md`
- link both guides from `CONTRIBUTING.md` and `docs/design/README.md`

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`

## Issue
Refs #216