### PR TITLE
chore(gitignore): ignore local server binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage.html
 # Build artifacts
 *.log
 tmp/
+server
 
 # Configuration (only commit .example)
 config/config.yaml


### PR DESCRIPTION
## Summary
- add `server` to `.gitignore`
- prevent accidental commits of local build artifact

## Issue
Refs #163