### PR TITLE
chore(dev): normalize docker workflow layout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+
+# Git
+.git
+.gitignore
+
+# Go
+bin/
+coverage.out
+coverage.html
+vendor/
+
+# Node/Web
+web/node_modules/
+web/.next/
+web/coverage/
+web/.turbo/
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# IDE
+.vscode/
+.idea/
+
+# Agent
+.agent/
+.env
+.env.local
+
+# Temp
+tmp/
+
+# Documentation (unless needed for build which typically isn't for binary)
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,36 @@
 # Multi-stage build for KubeVirt Shepherd
 # Stage 1: Build
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.7-bookworm AS builder
 
 WORKDIR /build
 
 # Cache dependencies
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod go mod download
 
 # Build
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/shepherd ./cmd/server/...
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/seed ./cmd/seed/...
+RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod --mount=type=cache,id=shepherd-go-build,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/shepherd ./cmd/server/...
+RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod --mount=type=cache,id=shepherd-go-build,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/seed ./cmd/seed/...
 
 # Stage 2: Runtime
 FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /build/bin/shepherd /usr/local/bin/shepherd
 COPY --from=builder /build/bin/seed /usr/local/bin/seed
+
+USER nonroot:nonroot
+
+EXPOSE 8080
+
+ENTRYPOINT ["shepherd"]
+
+# Development runtime image:
+# binaries are built on host and copied in directly to reuse host Go caches.
+FROM gcr.io/distroless/static-debian12:nonroot AS dev-runtime
+
+COPY build/bin/shepherd /usr/local/bin/shepherd
+COPY build/bin/seed /usr/local/bin/seed
 
 USER nonroot:nonroot
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ System (Business Line) → Service (Application) → VM Instance
 - [x] Implementation specifications  
 - [ ] Core implementation
 
+## Local Development
+
+Use the integrated Docker workflow to start/reset frontend, backend, and database together:
+
+```bash
+./start-dev.sh
+```
+
+- Web ingress: `http://localhost:3000`
+- API direct (diagnostic): `http://localhost:8080`
+- PostgreSQL: `localhost:5432`
+
+See `docs/design/frontend/local-dev-docker.md` for topology and workflow details.
+
 ## Community
 
 - [GitHub Issues][issues] - Bug reports and feature requests

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  db:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: shepherd
+      POSTGRES_PASSWORD: shepherd_password
+      POSTGRES_DB: shepherd_db
+    ports:
+      - "5432:5432"
+    # Ephemeral dev DB: no persistent volume mounted.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shepherd -d shepherd_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  server:
+    image: shepherd-server
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: "postgres://shepherd:shepherd_password@db:5432/shepherd_db?sslmode=disable"
+      DATABASE_AUTO_MIGRATE: "true"
+      SECURITY_SESSION_SECRET: "dev-secret-key-must-be-32-bytes-long!!"
+      SECURITY_ENCRYPTION_KEY: "dev-encryption-key-32-bytes-long!!"
+      GIN_MODE: debug
+      # Keep wildcard disabled by default; use nginx single-origin ingress instead.
+      SERVER_ALLOW_CREDENTIALS: "true"
+      SERVER_UNSAFE_ALLOW_ALL_ORIGINS: "false"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  web:
+    image: shepherd-web
+    environment:
+      NEXT_PUBLIC_API_URL: "/api/v1"
+      # Enable only when filesystem events are unreliable.
+      WATCHPACK_POLLING: "${WATCHPACK_POLLING:-false}"
+    volumes:
+      - ../../web:/app
+      - ../../web/node_modules:/app/node_modules
+    depends_on:
+      - server
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "3000:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - web
+      - server

--- a/deploy/dev/nginx/default.conf
+++ b/deploy/dev/nginx/default.conf
@@ -1,0 +1,38 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    # API requests go directly to backend service.
+    location /api/v1/ {
+        proxy_pass http://server:8080/api/v1/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # All UI routes are served by Next.js dev server.
+    location / {
+        proxy_pass http://web:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+}

--- a/deploy/dev/start-dev.sh
+++ b/deploy/dev/start-dev.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/deploy/dev/docker-compose.yml"
+HOST_USER_ID="${USER_ID:-$(id -u)}"
+HOST_GROUP_ID="${GROUP_ID:-$(id -g)}"
+NODE_MODULES_DIR="${ROOT_DIR}/web/node_modules"
+LOCK_HASH_FILE="${NODE_MODULES_DIR}/.package-lock.hash"
+SERVICES_TO_DELETE=("db" "server" "web" "nginx")
+COMPOSE_CMD=(docker compose -f "${COMPOSE_FILE}")
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Missing required command: $cmd"
+        exit 1
+    fi
+}
+
+compute_sha256() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print $1}'
+    else
+        shasum -a 256 "$file" | awk '{print $1}'
+    fi
+}
+
+require_cmd docker
+require_cmd go
+require_cmd npm
+require_cmd curl
+
+if ! [[ "$HOST_USER_ID" =~ ^[0-9]+$ ]] || ! [[ "$HOST_GROUP_ID" =~ ^[0-9]+$ ]]; then
+    echo "USER_ID/GROUP_ID must be numeric. USER_ID=${HOST_USER_ID}, GROUP_ID=${HOST_GROUP_ID}"
+    exit 1
+fi
+
+echo "Checking development environment status..."
+echo "Resetting development environment (clear DB data every run)..."
+
+for svc in "${SERVICES_TO_DELETE[@]}"; do
+    echo "  Removing service: $svc"
+    "${COMPOSE_CMD[@]}" rm -s -f -v "$svc" || true
+done
+
+"${COMPOSE_CMD[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+echo "Cleanup complete."
+
+echo "Building backend binaries on host (reuse local Go cache)..."
+mkdir -p "${ROOT_DIR}/build/bin"
+(
+    cd "$ROOT_DIR"
+    GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/shepherd ./cmd/server/...
+    GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/seed ./cmd/seed/...
+)
+
+echo "Packaging backend image (shepherd-server)..."
+DOCKER_BUILDKIT=1 docker build --network=host \
+    --target dev-runtime \
+    -t shepherd-server -f "${ROOT_DIR}/Dockerfile" "${ROOT_DIR}"
+
+current_lock_hash="$(compute_sha256 "${ROOT_DIR}/web/package-lock.json")"
+if [ ! -d "$NODE_MODULES_DIR" ] || [ ! -f "$LOCK_HASH_FILE" ] || [ "$(cat "$LOCK_HASH_FILE" 2>/dev/null || true)" != "$current_lock_hash" ]; then
+    echo "Installing frontend dependencies into ${NODE_MODULES_DIR}..."
+    (cd "${ROOT_DIR}/web" && npm ci)
+    mkdir -p "$NODE_MODULES_DIR"
+    printf "%s" "$current_lock_hash" > "$LOCK_HASH_FILE"
+else
+    echo "Reusing frontend dependencies from ${NODE_MODULES_DIR}..."
+fi
+
+echo "Packaging frontend image (shepherd-web)..."
+DOCKER_BUILDKIT=1 docker build --network=host \
+    --build-arg "USER_ID=${HOST_USER_ID}" \
+    --build-arg "GROUP_ID=${HOST_GROUP_ID}" \
+    -t shepherd-web -f "${ROOT_DIR}/deploy/dev/web.Dockerfile" "${ROOT_DIR}/web"
+
+echo "Starting development environment (db -> server -> web -> nginx)..."
+USER_ID="$HOST_USER_ID" GROUP_ID="$HOST_GROUP_ID" "${COMPOSE_CMD[@]}" up -d
+
+echo "Waiting for database..."
+until "${COMPOSE_CMD[@]}" exec -T db pg_isready -U shepherd -d shepherd_db >/dev/null 2>&1; do
+    printf "."
+    sleep 2
+done
+echo " db ready"
+
+echo "Waiting for backend (http://localhost:8080/api/v1/health/live)..."
+backend_ready=false
+for _ in {1..30}; do
+    if curl -fsS http://localhost:8080/api/v1/health/live >/dev/null; then
+        backend_ready=true
+        echo " backend ready"
+        break
+    fi
+    printf "."
+    sleep 2
+done
+if [ "$backend_ready" != "true" ]; then
+    echo " backend did not become ready in time"
+    "${COMPOSE_CMD[@]}" logs --tail=200 server || true
+    exit 1
+fi
+
+echo "Seeding default development data (admin/admin)..."
+"${COMPOSE_CMD[@]}" exec -T server /usr/local/bin/seed >/dev/null
+echo " seed complete"
+
+echo "Waiting for ingress (http://localhost:3000)..."
+for _ in {1..30}; do
+    if curl -fsS http://localhost:3000/ >/dev/null; then
+        echo " ingress ready"
+        break
+    fi
+    printf "."
+    sleep 2
+done
+
+echo "Prewarming common routes..."
+for route in / /login /dashboard; do
+    curl -fsS "http://localhost:3000${route}" >/dev/null || true
+done
+echo " warmup complete"
+
+echo ""
+echo "Development environment is UP"
+echo "  - Web (nginx ingress): http://localhost:3000"
+echo "  - Backend direct:      http://localhost:8080"
+echo "  - DB:                  localhost:5432"

--- a/deploy/dev/web.Dockerfile
+++ b/deploy/dev/web.Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+# Create runtime user matching host UID/GID to avoid permission issues on bind mounts.
+RUN if [ "${USER_ID}" != "1000" ] || [ "${GROUP_ID}" != "1000" ]; then \
+      deluser --remove-home node && \
+      addgroup -g "${GROUP_ID}" shepherd && \
+      adduser -u "${USER_ID}" -G shepherd -h /home/shepherd -D shepherd; \
+    else \
+      mkdir -p /home/node && chown -R node:node /home/node; \
+    fi
+
+WORKDIR /app
+RUN mkdir -p /app && chown -R ${USER_ID}:${GROUP_ID} /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+USER ${USER_ID}:${GROUP_ID}
+
+EXPOSE 3000
+CMD ["npm", "run", "dev", "--", "-H", "0.0.0.0"]

--- a/docs/design/frontend/README.md
+++ b/docs/design/frontend/README.md
@@ -15,9 +15,10 @@ Frontend docs are layered by concern to prevent drift and to keep alignment with
 
 1. [FRONTEND.md](./FRONTEND.md) - baseline frontend engineering standard
 2. [architecture/README.md](./architecture/README.md) - app-level architecture and boundaries
-3. [features/batch-operations-queue.md](./features/batch-operations-queue.md) - parent-child batch queue UX and state model
-4. [contracts/README.md](./contracts/README.md) - API contract and generated type integration
-5. [testing/README.md](./testing/README.md) - frontend test and CI gates
+3. [local-dev-docker.md](./local-dev-docker.md) - integrated local Docker workflow and ingress model
+4. [features/batch-operations-queue.md](./features/batch-operations-queue.md) - parent-child batch queue UX and state model
+5. [contracts/README.md](./contracts/README.md) - API contract and generated type integration
+6. [testing/README.md](./testing/README.md) - frontend test and CI gates
 
 ## Alignment Rules
 

--- a/docs/design/frontend/local-dev-docker.md
+++ b/docs/design/frontend/local-dev-docker.md
@@ -1,0 +1,46 @@
+# Local Dev Docker Workflow
+
+## Goal
+
+Provide a single-command local development workflow that starts and resets backend, frontend, and database together for fast early-stage iteration.
+
+## Entry Points
+
+- `./start-dev.sh` (root convenience wrapper)
+- `deploy/dev/start-dev.sh` (actual script)
+- Compose file: `deploy/dev/docker-compose.yml`
+
+## Layout
+
+- `deploy/dev/docker-compose.yml`: integrated development stack
+- `deploy/dev/nginx/default.conf`: single ingress reverse proxy
+- `deploy/dev/web.Dockerfile`: frontend dev runtime image
+- `web/.dockerignore`: build context filter for web image
+
+## Runtime Topology
+
+- `nginx` exposed at `:3000` as the single browser ingress
+- `web` (Next.js dev server) internal only
+- `server` (Go API) internal + optional direct `:8080` for diagnostics
+- `db` (PostgreSQL) exposed at `:5432` for local DB tooling
+
+## Why Nginx In Front
+
+- Browser traffic uses a single origin (`http://<host>:3000`) for both UI and API path (`/api/v1`)
+- This avoids ad-hoc wildcard CORS exceptions for remote device access
+- Reverse proxy settings preserve host/proto headers for accurate backend behavior
+
+## Reset Policy
+
+`deploy/dev/start-dev.sh` intentionally performs full reset on each run:
+
+- remove running compose services
+- `down --volumes --remove-orphans`
+- rebuild backend/frontend images
+- re-seed development data
+
+This is optimized for early development consistency over state persistence.
+
+## Future Evolution
+
+When project maturity requires faster partial restarts or stable local data, split profiles can be added (for example, keep DB persistent while hot-reloading app containers).

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/deploy/dev/start-dev.sh" "$@"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,19 @@
+
+# Next.js
+.next/
+out/
+coverage/
+node_modules/
+.turbo/
+npm-debug.log
+yarn-error.log
+
+# IDE
+.idea/
+.vscode/
+
+# Env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
## Summary
- move dev docker assets to `deploy/dev/`
- keep root `start-dev.sh` as thin wrapper for one-command startup
- add nginx dev ingress for unified browser entrypoint
- document local integrated workflow in frontend design docs

## Validation
- `bash -n deploy/dev/start-dev.sh start-dev.sh`
- `docker compose -f deploy/dev/docker-compose.yml config`

Refs #218