### PR TITLE
fix(app): harden CORS handling defaults

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -7,6 +7,14 @@ server:
   read_timeout: "30s"
   write_timeout: "30s"
   shutdown_timeout: "30s"
+  # CORS allowlist (comma-separated env override: SERVER_ALLOWED_ORIGINS)
+  allowed_origins:
+    - "http://localhost:3000"
+    - "http://127.0.0.1:3000"
+  # Keep true only if browser cookies/credentialed CORS are required
+  allow_credentials: true
+  # Unsafe dev-only switch; do not enable in shared/prod environments
+  unsafe_allow_all_origins: false
 
 database:
   # Option 1: Use DATABASE_URL (takes precedence)

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -73,7 +73,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config) (*Application, error) {
 
 	return &Application{
 		Config:  cfg,
-		Router:  newRouter(server, serverDeps.JWTCfg),
+		Router:  newRouter(cfg, server, serverDeps.JWTCfg),
 		DB:      infra.DB,
 		Pools:   infra.Pools,
 		Modules: allModules,

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"kv-shepherd.io/shepherd/internal/api/generated"
 	"kv-shepherd.io/shepherd/internal/api/middleware"
+	"kv-shepherd.io/shepherd/internal/config"
 )
 
 // Public routes that do NOT require JWT authentication.
@@ -23,19 +25,11 @@ var adminPrefixes = []string{
 	"/api/v1/audit-logs",
 }
 
-func newRouter(server generated.ServerInterface, jwtCfg middleware.JWTConfig) *gin.Engine {
+func newRouter(cfg *config.Config, server generated.ServerInterface, jwtCfg middleware.JWTConfig) *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Recovery(), middleware.RequestID(), middleware.ErrorHandler())
 
-	// CORS: allow frontend dev server (localhost:3000) and production origins.
-	router.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"http://localhost:3000", "http://127.0.0.1:3000"},
-		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Accept", "X-Request-ID"},
-		ExposeHeaders:    []string{"Content-Length", "X-Request-ID"},
-		AllowCredentials: true,
-		MaxAge:           12 * time.Hour,
-	}))
+	router.Use(cors.New(buildCORSConfig(cfg)))
 
 	router.Use(jwtSkipPublic(jwtCfg))
 	router.Use(rbacAdminRoutes())
@@ -44,6 +38,44 @@ func newRouter(server generated.ServerInterface, jwtCfg middleware.JWTConfig) *g
 		BaseURL: "/api/v1",
 	})
 	return router
+}
+
+func buildCORSConfig(cfg *config.Config) cors.Config {
+	allowAllOrigins := cfg.Server.UnsafeAllowAllOrigins
+	allowedOrigins := sanitizeAllowedOrigins(cfg.Server.AllowedOrigins)
+
+	corsCfg := cors.Config{
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Accept", "X-Request-ID"},
+		ExposeHeaders:    []string{"Content-Length", "X-Request-ID"},
+		AllowCredentials: cfg.Server.AllowCredentials,
+		MaxAge:           12 * time.Hour,
+	}
+
+	if allowAllOrigins {
+		corsCfg.AllowAllOrigins = true
+		// gin-contrib/cors docs: AllowAllOrigins cannot be used with credentials.
+		corsCfg.AllowCredentials = false
+		return corsCfg
+	}
+
+	if len(allowedOrigins) == 0 {
+		allowedOrigins = []string{"http://localhost:3000", "http://127.0.0.1:3000"}
+	}
+	corsCfg.AllowOrigins = allowedOrigins
+	return corsCfg
+}
+
+func sanitizeAllowedOrigins(origins []string) []string {
+	cleaned := make([]string, 0, len(origins))
+	for _, origin := range origins {
+		origin = strings.TrimSpace(origin)
+		if origin == "" || origin == "*" {
+			continue
+		}
+		cleaned = append(cleaned, origin)
+	}
+	return slices.Compact(cleaned)
 }
 
 // jwtSkipPublic returns middleware that applies JWT auth only on non-public routes.

--- a/internal/app/router_test.go
+++ b/internal/app/router_test.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"testing"
+
+	"kv-shepherd.io/shepherd/internal/config"
+)
+
+func TestBuildCORSConfig_DefaultsToAllowlistWhenOriginsEmpty(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			AllowedOrigins:        nil,
+			AllowCredentials:      true,
+			UnsafeAllowAllOrigins: false,
+		},
+	}
+
+	got := buildCORSConfig(cfg)
+	if got.AllowAllOrigins {
+		t.Fatalf("AllowAllOrigins = %v, want false", got.AllowAllOrigins)
+	}
+	if !got.AllowCredentials {
+		t.Fatalf("AllowCredentials = %v, want true", got.AllowCredentials)
+	}
+	if len(got.AllowOrigins) != 2 {
+		t.Fatalf("len(AllowOrigins) = %d, want 2", len(got.AllowOrigins))
+	}
+}
+
+func TestBuildCORSConfig_StripsWildcardUnlessUnsafeFlagEnabled(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			AllowedOrigins:        []string{"*", "https://example.com"},
+			AllowCredentials:      true,
+			UnsafeAllowAllOrigins: false,
+		},
+	}
+
+	got := buildCORSConfig(cfg)
+	if got.AllowAllOrigins {
+		t.Fatalf("AllowAllOrigins = %v, want false", got.AllowAllOrigins)
+	}
+	if len(got.AllowOrigins) != 1 || got.AllowOrigins[0] != "https://example.com" {
+		t.Fatalf("AllowOrigins = %#v, want []string{\"https://example.com\"}", got.AllowOrigins)
+	}
+}
+
+func TestBuildCORSConfig_UnsafeAllowAllDisablesCredentials(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			AllowedOrigins:        []string{"*"},
+			AllowCredentials:      true,
+			UnsafeAllowAllOrigins: true,
+		},
+	}
+
+	got := buildCORSConfig(cfg)
+	if !got.AllowAllOrigins {
+		t.Fatalf("AllowAllOrigins = %v, want true", got.AllowAllOrigins)
+	}
+	if got.AllowCredentials {
+		t.Fatalf("AllowCredentials = %v, want false", got.AllowCredentials)
+	}
+	if len(got.AllowOrigins) != 0 {
+		t.Fatalf("AllowOrigins = %#v, want empty", got.AllowOrigins)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,10 +34,14 @@ type Config struct {
 
 // ServerConfig contains HTTP server settings.
 type ServerConfig struct {
-	Port            int           `mapstructure:"port"`
-	ReadTimeout     time.Duration `mapstructure:"read_timeout"`
-	WriteTimeout    time.Duration `mapstructure:"write_timeout"`
-	ShutdownTimeout time.Duration `mapstructure:"shutdown_timeout"`
+	Port             int           `mapstructure:"port"`
+	ReadTimeout      time.Duration `mapstructure:"read_timeout"`
+	WriteTimeout     time.Duration `mapstructure:"write_timeout"`
+	ShutdownTimeout  time.Duration `mapstructure:"shutdown_timeout"`
+	AllowedOrigins   []string      `mapstructure:"allowed_origins"`
+	AllowCredentials bool          `mapstructure:"allow_credentials"`
+	// UnsafeAllowAllOrigins disables origin allowlist checks and must only be used in trusted local development.
+	UnsafeAllowAllOrigins bool `mapstructure:"unsafe_allow_all_origins"`
 }
 
 // DatabaseConfig contains PostgreSQL connection settings.
@@ -251,8 +255,12 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.read_timeout", "30s")
 	v.SetDefault("server.write_timeout", "30s")
 	v.SetDefault("server.shutdown_timeout", "30s")
+	v.SetDefault("server.allowed_origins", []string{"http://localhost:3000", "http://127.0.0.1:3000"})
+	v.SetDefault("server.allow_credentials", true)
+	v.SetDefault("server.unsafe_allow_all_origins", false)
 
 	// Database (ADR-0012 shared pool)
+	v.SetDefault("database.url", "")
 	v.SetDefault("database.host", "localhost")
 	v.SetDefault("database.port", 5432)
 	v.SetDefault("database.user", "shepherd")


### PR DESCRIPTION
## Summary
- make CORS fail closed by default
- require explicit `server.unsafe_allow_all_origins` opt-in for wildcard origins
- keep credential behavior safe for wildcard cases
- add focused tests and config example updates

## Validation
- `GOCACHE=/tmp/go-build go test ./internal/config ./internal/app`

Refs #218