### PR TITLE
fix(web): clear frontend lint warnings

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -12,6 +12,7 @@
  * AGENTS.md §6.5: Prevent hydration mismatch without flickering.
  */
 import { useState } from 'react';
+import Image from 'next/image';
 import { Card, Form, Input, Button, Typography, Space, Alert } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
@@ -68,11 +69,7 @@ export default function LoginPage() {
                     size="large"
                     style={{ width: '100%', textAlign: 'center', marginBottom: 32 }}
                 >
-                    <img
-                        src="/logo-wide.svg"
-                        alt="Shepherd"
-                        style={{ width: 220, height: 'auto' }}
-                    />
+                    <Image src="/logo-wide.svg" alt="Shepherd" width={220} height={56} />
                     <div>
                         <Title level={3} style={{ marginBottom: 4 }}>
                             {t('app.name')}

--- a/web/src/app/(protected)/admin/clusters/page.tsx
+++ b/web/src/app/(protected)/admin/clusters/page.tsx
@@ -18,7 +18,6 @@ import {
     Modal,
     Form,
     Input,
-    Upload,
     Card,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -26,7 +25,6 @@ import {
     PlusOutlined,
     ReloadOutlined,
     ClusterOutlined,
-    UploadOutlined,
 } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';

--- a/web/src/app/(protected)/admin/namespaces/page.tsx
+++ b/web/src/app/(protected)/admin/namespaces/page.tsx
@@ -21,7 +21,6 @@ import {
     Select,
     Switch,
     Card,
-    Popconfirm,
     Tooltip,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';

--- a/web/src/app/(protected)/auth/change-password/page.tsx
+++ b/web/src/app/(protected)/auth/change-password/page.tsx
@@ -9,6 +9,7 @@
  * Uses the same visual style as the login page.
  */
 import { useState } from 'react';
+import Image from 'next/image';
 import { Card, Form, Input, Button, Typography, Space, Alert } from 'antd';
 import { LockOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
@@ -82,11 +83,7 @@ export default function ChangePasswordPage() {
                     size="large"
                     style={{ width: '100%', textAlign: 'center', marginBottom: 32 }}
                 >
-                    <img
-                        src="/logo-wide.svg"
-                        alt="Shepherd"
-                        style={{ width: 220, height: 'auto' }}
-                    />
+                    <Image src="/logo-wide.svg" alt="Shepherd" width={220} height={56} />
                     <div>
                         <Title level={3} style={{ marginBottom: 4 }}>
                             {t('auth.change_password')}

--- a/web/src/components/layouts/AppLayout.tsx
+++ b/web/src/components/layouts/AppLayout.tsx
@@ -10,6 +10,7 @@
  * Auth route group (auth) uses its own layout without sidebar.
  */
 import React from 'react';
+import Image from 'next/image';
 import { useRouter, usePathname } from 'next/navigation';
 import {
     DashboardOutlined,
@@ -28,7 +29,7 @@ import {
 } from '@ant-design/icons';
 import { ProLayout } from '@ant-design/pro-components';
 import type { ProLayoutProps } from '@ant-design/pro-components';
-import { Dropdown, Avatar, Typography } from 'antd';
+import { Dropdown, Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/auth';
 import NotificationBell from '@/components/ui/NotificationBell';
@@ -120,7 +121,7 @@ export default function AppLayout({
     return (
         <ProLayout
             title="Shepherd"
-            logo={<img src="/logo-icon.svg" alt="Shepherd" width={32} height={32} />}
+            logo={<Image src="/logo-icon.svg" alt="Shepherd" width={32} height={32} />}
             route={getMenuRoutes(t)}
             location={{ pathname }}
             fixSiderbar

--- a/web/src/components/ui/NotificationBell.tsx
+++ b/web/src/components/ui/NotificationBell.tsx
@@ -38,7 +38,6 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { useApiGet, useApiAction } from '@/hooks/useApiQuery';
 import type { components } from '@/types/api.gen';
-import { useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api/client';
 
 const { Text, Paragraph } = Typography;
@@ -87,7 +86,6 @@ function formatRelativeTime(dateStr: string): string {
 export default function NotificationBell() {
     const router = useRouter();
     const { t } = useTranslation('common');
-    const queryClient = useQueryClient();
     const [open, setOpen] = useState(false);
 
     // Fetch unread count (poll every 30s).

--- a/web/src/hooks/useApiQuery.ts
+++ b/web/src/hooks/useApiQuery.ts
@@ -9,7 +9,6 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { UseQueryOptions } from '@tanstack/react-query';
-import { api } from '@/lib/api/client';
 
 /**
  * API error shape — matches backend Error schema.


### PR DESCRIPTION
## Summary
- remove unused imports/variables flagged by eslint in admin, layout, bell, and query hooks
- replace raw `<img>` usage with `next/image` in login/change-password and shell logo
- keep behavior unchanged while eliminating warning sources

## Validation
- `npx eslint src` (in `web/`)
- `npm run test:run` (in `web/`)
- `npm run build` (in `web/`)

Refs #230