### PR TITLE
docs(adr): add ADR-0034 as proposed

### DIFF
--- a/docs/adr/ADR-0034-master-flow-spec-driven-test-first.md
+++ b/docs/adr/ADR-0034-master-flow-spec-driven-test-first.md
@@ -1,0 +1,133 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+date: 2026-02-14
+deciders: ["@jindyzhao"]
+consulted: ["@jindyzhao"]
+informed: ["@jindyzhao"]
+---
+
+# ADR-0034: Master-Flow Spec-Driven Test-First Execution Standard
+
+> **Review Period**: Until 2026-02-17 (48-hour minimum)  
+> **Discussion**: TBD (Issue link required before acceptance)  
+> **Related**: [ADR-0015](./ADR-0015-governance-model-v2.md), [ADR-0021](./ADR-0021-api-contract-first.md), [ADR-0030](./ADR-0030-design-documentation-layering-and-fullstack-governance.md), [ADR-0032](./ADR-0032-master-flow-traceability-manifest.md)
+
+---
+
+## Context and Problem Statement
+
+`docs/design/interaction-flows/master-flow.md` is already the canonical interaction truth, and the repository has strict API/CI governance.
+
+However, for complex cross-layer workflows (RBAC inheritance, async queue writes, approval chains, batch parent-child execution), "code-first then test" still allows spec drift to accumulate before discovery.
+
+We need a mandatory execution model where stage-level tests are treated as first-class spec artifacts and are enforced by CI before feature completion claims.
+
+## Decision Drivers
+
+* Keep `master-flow.md` as single interaction truth.
+* Convert stage intent into executable test evidence as early as possible.
+* Prevent "implemented but unverified" claims in high-risk lifecycle stages.
+* Fit existing CI gate architecture and traceability pattern (ADR-0032).
+
+## Considered Options
+
+* **Option 1**: Continue implementation-first, tests as follow-up.
+* **Option 2**: Team convention only ("please write tests first"), no enforcement.
+* **Option 3**: Spec-driven test-first with machine-readable stage matrix + CI blocking gate.
+
+## Decision Outcome
+
+**Chosen option**: "Option 3", because only enforceable gates can consistently prevent spec drift in this codebase.
+
+### Normative Decisions
+
+1. **Stage test matrix is mandatory**
+   - Add `docs/design/traceability/master-flow-tests.json` as canonical mapping from master-flow stages to executable test artifacts.
+   - Matrix entries map `stage id -> test files`, not prose-only descriptions.
+
+2. **Risk-based required stage set**
+   - A required stage set is defined in the matrix for critical flows (resource ownership, VM lifecycle, batch, notification, VNC).
+   - Required stages MUST have either:
+     - at least one executable test artifact, or
+     - an explicit deferred entry in allowlist with reason.
+
+3. **Deferred test debt must be explicit**
+   - Deferred stages are tracked in `docs/design/ci/allowlists/master_flow_test_deferred.txt`.
+   - Deferred entries are temporary and CI-enforced (stale entries must be removed once tests exist).
+
+4. **CI gate is blocking**
+   - Add a required CI script that validates:
+     - stage IDs exist in `master-flow.md`,
+     - matrix references point to existing executable test files,
+     - required stages are covered or explicitly deferred,
+     - no stale deferred entries remain.
+
+5. **Execution rule for feature work**
+   - For changes affecting required stages, PRs MUST update matrix/deferred entries and executable tests in the same change set.
+   - "Checklist done" claims for required stages are invalid without matrix-backed test evidence.
+
+### Consequences
+
+* ✅ Good, because stage-level intent becomes executable and reviewable.
+* ✅ Good, because hidden drift is surfaced early by CI instead of late integration failures.
+* ✅ Good, because the mechanism reuses current gate architecture and avoids new platform dependencies.
+* ❌ Bad, because teams must maintain matrix/deferred metadata in addition to tests (mitigated by automation and strict stale-entry checks).
+
+### Confirmation
+
+* `docs/design/ci/scripts/check_master_flow_test_matrix.go` blocks merge when:
+  - required stage coverage is missing without deferral,
+  - mapped test files are missing/non-executable,
+  - deferred entries are stale or invalid.
+* CI workflow runs this script as required gate.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Implementation-first
+
+* ✅ Good, because initial coding speed appears high.
+* ❌ Bad, because drift is discovered late and fixes are costlier.
+
+### Option 2: Convention-only test-first
+
+* ✅ Good, because no tooling changes are needed.
+* ❌ Bad, because compliance depends on memory and review strictness.
+
+### Option 3: Enforced spec-driven test-first
+
+* ✅ Good, because stage coverage is objective and machine-checkable.
+* ✅ Good, because documentation, tests, and runtime evolve together.
+* ❌ Bad, because introduces additional governance artifacts.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0021](./ADR-0021-api-contract-first.md) - contract-first API baseline
+* [ADR-0030](./ADR-0030-design-documentation-layering-and-fullstack-governance.md) - documentation authority boundaries
+* [ADR-0032](./ADR-0032-master-flow-traceability-manifest.md) - stage traceability baseline
+
+### References
+
+* Playwright best practices (stable locators, web-first assertions): https://playwright.dev/docs/best-practices
+* `docs/design/interaction-flows/master-flow.md`
+
+### Implementation Notes
+
+Detailed rollout and file-level impacts are tracked in:
+
+* `docs/design/notes/ADR-0034-master-flow-spec-driven-test-first.md`
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-14 | @jindyzhao | Initial draft |
+| 2026-02-15 | @jindyzhao | Status set to proposed pending public review/issue linkage |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@
 | [ADR-0031](./ADR-0031-concurrency-and-worker-pool-standard.md) | Concurrency Safety and Worker Pool Standard | **Accepted** | - |
 | [ADR-0032](./ADR-0032-master-flow-traceability-manifest.md) | Master-Flow Traceability Manifest and Drift Enforcement | **Accepted** | - |
 | [ADR-0033](./ADR-0033-realtime-notification-acceleration.md) | Realtime Notification Acceleration with PostgreSQL LISTEN/NOTIFY | **Proposed** | - |
+| [ADR-0034](./ADR-0034-master-flow-spec-driven-test-first.md) | Master-Flow Spec-Driven Test-First Execution Standard | **Proposed** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:
 >

--- a/docs/design/notes/ADR-0034-master-flow-spec-driven-test-first.md
+++ b/docs/design/notes/ADR-0034-master-flow-spec-driven-test-first.md
@@ -1,0 +1,105 @@
+# ADR-0034 Implementation: Master-Flow Spec-Driven Test-First
+
+> **Parent ADR**: [ADR-0034](../../adr/ADR-0034-master-flow-spec-driven-test-first.md)  
+> **Status**: Implementation specification draft for ADR-0034 (parent ADR status: **proposed**)  
+> **Date**: 2026-02-14
+
+---
+
+## Summary
+
+This note defines the concrete implementation artifacts for enforcing spec-driven, test-first delivery using `master-flow.md` as the canonical behavior source.
+
+Core implementation = **stage test matrix + deferred allowlist + blocking CI gate**.
+Strict profile now targets **full master-flow stage coverage**.
+
+---
+
+## Scope
+
+In scope:
+
+* Machine-readable stage-to-test mapping.
+* CI blocking checks for required-stage coverage/deferred debt hygiene.
+* Full stage mapping across all stage IDs in `master-flow.json`.
+
+Out of scope:
+
+* Auto-generating all E2E/API tests from `master-flow.md` in this change.
+* Replacing existing test gates (`check_critical_test_presence`, `check_stage5c_behavior_tests`, etc.).
+
+---
+
+## Delivered Artifacts
+
+### 1. Stage Test Matrix
+
+* `docs/design/traceability/master-flow-tests.json`
+
+Schema (v1):
+
+* `version`
+* `master_flow`
+* `required_stages[]`
+* `stages[]`:
+  - `id`
+  - `tests[]` (must be executable test files)
+
+### 2. Deferred Stage Allowlist
+
+* `docs/design/ci/allowlists/master_flow_test_deferred.txt`
+
+Rules:
+
+* Only required stages may appear.
+* Entry must be removed once stage has executable test mapping.
+* Stale entries are CI failures.
+
+### 3. Blocking Gate
+
+* `docs/design/ci/scripts/check_master_flow_test_matrix.go`
+
+Validation behavior:
+
+* Required stage IDs exist in `master-flow.md`.
+* Stage mapping IDs are valid and unique.
+* Test paths exist and are executable tests:
+  - Go: `_test.go` with `func TestXxx(t *testing.T)`
+  - TS/JS: contains `test(` / `test.describe(` / `it(`
+* Required stage coverage = mapped OR deferred.
+* Deferred stale/invalid entries fail CI.
+
+### 4. Coverage Baseline (Strict Profile)
+
+`required_stages` is aligned to all stage IDs currently declared in
+`docs/design/traceability/master-flow.json` (24 stage IDs).
+
+### 5. Coverage Depth Reinforcement (2026-02-14)
+
+To reduce "source-fragment only" evidence risk, behavior-level tests were added:
+
+- Stage 4.A / 4.B / 4.C:
+  - `internal/api/handlers/server_system_behavior_test.go`
+  - Covers visibility filtering and update flow runtime behavior.
+- Stage 2.E / Stage 5.B:
+  - `internal/governance/approval/gateway_behavior_test.go`
+  - Covers approve/reject/cancel state transition behavior and atomic-writer handoff.
+
+---
+
+## Rollout Plan
+
+1. Add matrix + deferred file + gate script.
+2. Wire gate into CI required checks.
+3. Add/expand tests stage-by-stage and remove deferred entries.
+4. Keep checklist progress synchronized with matrix evidence.
+
+---
+
+## Acceptance Criteria
+
+* `go run docs/design/ci/scripts/check_master_flow_test_matrix.go` passes.
+* CI workflow includes the new required step.
+* All stages in `master-flow.json` have executable test evidence in matrix.
+* Deferred allowlist remains empty.
+* `docs/design/ci/README.md` documents the new gate.

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -32,7 +32,8 @@
       ],
       "adrs": [
         "docs/adr/ADR-0025-secret-bootstrap.md",
-        "docs/adr/ADR-0032-master-flow-traceability-manifest.md"
+        "docs/adr/ADR-0032-master-flow-traceability-manifest.md",
+        "docs/adr/ADR-0034-master-flow-spec-driven-test-first.md"
       ]
     },
     {


### PR DESCRIPTION
## Summary
Atomic docs PR for ADR-0034 proposal only.

## Scope
- Add `docs/adr/ADR-0034-master-flow-spec-driven-test-first.md` (status: proposed)
- Add `docs/design/notes/ADR-0034-master-flow-spec-driven-test-first.md`
- Update `docs/adr/README.md` index for ADR-0034

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`

## Tracking
- Refs #235
- Supersedes bundled PR #239