### PR TITLE
docs(adr): add ADR-0035 as proposed

### DIFF
--- a/docs/adr/ADR-0035-auth-provider-plugin-boundary.md
+++ b/docs/adr/ADR-0035-auth-provider-plugin-boundary.md
@@ -1,0 +1,106 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+date: 2026-02-15
+deciders: ["@jindyzhao"]
+consulted: ["@jindyzhao"]
+informed: ["@jindyzhao"]
+---
+
+# ADR-0035: Auth Provider Plugin Boundary and Type Discovery
+
+> **Review Period**: Until 2026-02-17 (48-hour minimum)<br>
+> **Discussion**: TBD (Issue link required before acceptance)<br>
+> **Amends**: [ADR-0026](./ADR-0026-idp-config-naming.md#standard-provider-output-contract)
+
+---
+
+## Context and Problem Statement
+
+The project must treat `auth providers` as a stable core contract, while allowing
+new provider implementations to be added without changing core auth/RBAC logic.
+Runtime and frontend had drift risk from provider-specific assumptions
+(OIDC/LDAP wording and defaults), which weakens extensibility.
+
+## Decision Drivers
+
+* Keep core auth/RBAC logic provider-agnostic.
+* Allow new provider plugins to integrate through a single standard contract.
+* Make provider types discoverable by API for frontend schema-driven UI.
+* Enforce this boundary with CI, not convention only.
+
+## Considered Options
+
+* **Option 1**: Keep OIDC/LDAP-first flow in core and extend ad hoc.
+* **Option 2**: Introduce strict plugin boundary with runtime type registry + discovery API.
+* **Option 3**: Move all provider logic into core with static enum and feature flags.
+
+## Decision Outcome
+
+**Chosen option**: "Introduce strict plugin boundary with runtime type registry + discovery API".
+
+### Consequences
+
+* ✅ Good, because core only depends on standard adapter interface.
+* ✅ Good, because frontend reads provider types from API, not hardcoded lists.
+* ✅ Good, because unknown/non-registered provider types are rejected explicitly.
+* 🟡 Neutral, because built-in compatibility types (`oidc`, `ldap`, `sso`, `generic`) remain pre-registered.
+* ❌ Bad, because plugin developers must register type metadata before usage.
+
+### Confirmation
+
+* CI gate `check_auth_provider_plugin_boundary.go` must pass.
+* Backend exposes `GET /admin/auth-provider-types` and frontend consumes it.
+* Runtime auth-provider handlers must resolve adapters via registry only.
+* No OIDC/LDAP hardcoded branch logic in runtime auth-provider paths.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Keep OIDC/LDAP-first flow in core
+
+* ✅ Good, because implementation is straightforward in short term.
+* ❌ Bad, because every new provider requires core edits.
+* ❌ Bad, because frontend/backed drift risk increases over time.
+
+### Option 2: Plugin boundary + discovery API
+
+* ✅ Good, because extension is standardized and discoverable.
+* ✅ Good, because it aligns with contract-first and schema-driven frontend.
+* ❌ Bad, because initial migration requires API/CI updates.
+
+### Option 3: Static enum + feature flags
+
+* ✅ Good, because behavior is predictable.
+* ❌ Bad, because it blocks third-party provider expansion without core release.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0026](./ADR-0026-idp-config-naming.md) - standardized provider output contract
+* [ADR-0021](./ADR-0021-api-contract-first.md) - API contract-first governance
+* ADR-0034 (proposed, tracked in issue #235) - test-first/spec-driven enforcement
+
+### References
+
+* OpenAPI 3.1 specification: https://spec.openapis.org/oas/v3.1.0.html
+
+### Implementation Notes
+
+* Add registry-backed provider type discovery endpoint: `GET /admin/auth-provider-types`.
+* Auth-provider create/update validation must require registered type.
+* Frontend create flow must query provider type list from API and remove hardcoded defaults.
+* CI blocks provider-specific hardcoded branching in runtime/auth-provider flow.
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-15 | @jindyzhao | Initial draft |
+| 2026-02-15 | @jindyzhao | Status set to proposed pending public review/issue linkage |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,7 @@
 | [ADR-0032](./ADR-0032-master-flow-traceability-manifest.md) | Master-Flow Traceability Manifest and Drift Enforcement | **Accepted** | - |
 | [ADR-0033](./ADR-0033-realtime-notification-acceleration.md) | Realtime Notification Acceleration with PostgreSQL LISTEN/NOTIFY | **Proposed** | - |
 | [ADR-0034](./ADR-0034-master-flow-spec-driven-test-first.md) | Master-Flow Spec-Driven Test-First Execution Standard | **Proposed** | - |
+| [ADR-0035](./ADR-0035-auth-provider-plugin-boundary.md) | Auth Provider Plugin Boundary and Type Discovery | **Proposed** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:
 >

--- a/docs/design/notes/ADR-0035-auth-provider-plugin-boundary.md
+++ b/docs/design/notes/ADR-0035-auth-provider-plugin-boundary.md
@@ -1,0 +1,92 @@
+# ADR-0035 Implementation: Auth Provider Plugin Boundary and Type Discovery
+
+> **Parent ADR**: [ADR-0035](../../adr/ADR-0035-auth-provider-plugin-boundary.md)  
+> **Status**: Implementation specification draft (parent ADR status: **proposed**)  
+> **Date**: 2026-02-15
+
+---
+
+## Summary
+
+This note defines the concrete implementation for keeping auth-provider core
+provider-agnostic, while allowing plugin-type onboarding through standardized
+registration and API discovery.
+
+---
+
+## Delivered Artifacts
+
+### 1. Runtime Registry Contract
+
+* `internal/provider/auth_provider_admin_registry.go`
+
+Delivered behavior:
+
+* adapter registration by normalized `type` key
+* duplicate type registration rejected
+* adapter type discovery list API (`ListAuthProviderAdminAdapterTypes`)
+* built-in compatibility plugins registered: `generic`, `oidc`, `ldap`, `sso`
+
+### 2. API Discovery Endpoint
+
+* `GET /api/v1/admin/auth-provider-types`
+* OpenAPI schema:
+  - `AuthProviderType`
+  - `AuthProviderTypeList`
+
+Delivered behavior:
+
+* frontend/admin can discover supported provider types and config schema metadata
+* runtime create/update remains contract-first and rejects unknown types
+
+### 3. Frontend Alignment
+
+* `web/src/features/admin-auth-providers/hooks/useAdminAuthProvidersController.ts`
+* `web/src/features/admin-auth-providers/components/AdminAuthProvidersContent.tsx`
+
+Delivered behavior:
+
+* auth provider type options loaded from `GET /admin/auth-provider-types`
+* create modal no longer hardcodes `oidc` as immutable default option list
+* UI select is schema-driven from backend registry
+
+### 4. CI Enforcement
+
+* `docs/design/ci/scripts/check_auth_provider_plugin_boundary.go`
+
+Blocking checks:
+
+* runtime auth-provider handlers must resolve adapters via registry
+* disallow provider-specific runtime branch patterns (`oidc`/`ldap`/`sso` hardcoded branches)
+* frontend auth-provider controller must consume discovery API
+* frontend must not reintroduce hardcoded provider-type options constant
+* OpenAPI must not regress to OIDC/LDAP-only summary wording
+
+### 5. Master-Flow Wording Alignment
+
+* `docs/design/interaction-flows/master-flow.md` Stage 2.B/2.D updated to plugin-standard wording
+* OIDC/LDAP retained as plugin examples, not core-only built-ins
+
+### 6. Plugin Development Template and Auto-Registration Skeleton
+
+* `pkg/authproviderplugin/admin.go` (public plugin contract wrapper)
+* `plugins/authprovider/template/template.go` (minimal plugin template)
+* `plugins/authprovider/example/plugin.go` (third-party style example plugin)
+* `plugins/authprovider/autoreg/autoreg.go` (side-effect import loader)
+* `plugins/authprovider/README.md` (integration instructions)
+
+Delivered behavior:
+
+* plugin authors implement the contract via `pkg/authproviderplugin`
+* plugin package self-registers via `MustRegisterAdminAdapter`
+* composition root imports `plugins/authprovider/autoreg` once for automatic plugin registration
+
+---
+
+## Acceptance Criteria
+
+* `go run docs/design/ci/scripts/check_auth_provider_plugin_boundary.go` passes.
+* `go run docs/design/ci/scripts/check_no_global_platform_admin_gate.go` passes.
+* `go test ./internal/api/handlers -run 'TestListAuthProviderTypesAndRejectUnknownType|TestAuthProviderStage2CFlow|TestAdminUserRoleBindingAndAuthProviderCRUD'` passes (with PostgreSQL test harness).
+* frontend typecheck and admin auth-provider hook tests pass.
+* `master-flow.md` Stage 2.B narrative reflects plugin-standard model.

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -84,7 +84,8 @@
         "docs/design/checklist/phase-1-checklist.md"
       ],
       "adrs": [
-        "docs/adr/ADR-0026-idp-config-naming.md"
+        "docs/adr/ADR-0026-idp-config-naming.md",
+        "docs/adr/ADR-0035-auth-provider-plugin-boundary.md"
       ]
     },
     {
@@ -96,7 +97,8 @@
         "docs/design/checklist/phase-1-checklist.md"
       ],
       "adrs": [
-        "docs/adr/ADR-0026-idp-config-naming.md"
+        "docs/adr/ADR-0026-idp-config-naming.md",
+        "docs/adr/ADR-0035-auth-provider-plugin-boundary.md"
       ]
     },
     {


### PR DESCRIPTION
## Summary
Atomic docs PR for ADR-0035 proposal only.

## Scope
- Add `docs/adr/ADR-0035-auth-provider-plugin-boundary.md` (status: proposed)
- Add `docs/design/notes/ADR-0035-auth-provider-plugin-boundary.md`
- Update `docs/adr/README.md` index for ADR-0035

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`

## Tracking
- Refs #236
- Supersedes bundled PR #239