### PR TITLE
feat(frontend): add data-testid to admin page components for E2E testability

### DIFF
--- a/web/src/features/admin-approvals/components/AdminApprovalsContent.tsx
+++ b/web/src/features/admin-approvals/components/AdminApprovalsContent.tsx
@@ -147,6 +147,7 @@ export function AdminApprovalsContent() {
                             type="primary"
                             size="small"
                             icon={<CheckCircleOutlined />}
+                            data-testid={`approval-action-approve-${record.id}`}
                             onClick={() => approvals.openApproveModal(record)}
                         >
                             {t('common:button.approve')}
@@ -155,6 +156,7 @@ export function AdminApprovalsContent() {
                             danger
                             size="small"
                             icon={<CloseCircleOutlined />}
+                            data-testid={`approval-action-reject-${record.id}`}
                             onClick={() => approvals.openRejectModal(record)}
                         >
                             {t('common:button.reject')}
@@ -168,6 +170,7 @@ export function AdminApprovalsContent() {
                             <Button
                                 size="small"
                                 icon={<ExclamationCircleOutlined />}
+                                data-testid={`approval-action-cancel-${record.id}`}
                                 loading={approvals.cancelPending}
                             >
                                 {t('cancel')}
@@ -180,7 +183,7 @@ export function AdminApprovalsContent() {
     ];
 
     return (
-        <div>
+        <div data-testid="admin-approvals-page">
             {approvals.messageContextHolder}
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
                 <div>
@@ -189,6 +192,7 @@ export function AdminApprovalsContent() {
                 </div>
                 <Space>
                     <Segmented
+                        data-testid="approvals-status-filter"
                         value={approvals.statusFilter}
                         onChange={(value) => approvals.changeStatusFilter(value as 'ALL' | ApprovalStatus)}
                         options={STATUS_FILTER_OPTIONS.map((option) => ({
@@ -196,7 +200,7 @@ export function AdminApprovalsContent() {
                             value: option.key,
                         }))}
                     />
-                    <Button icon={<ReloadOutlined />} onClick={() => approvals.refetch()}>
+                    <Button icon={<ReloadOutlined />} data-testid="approvals-refresh-btn" onClick={() => approvals.refetch()}>
                         {t('common:button.refresh')}
                     </Button>
                 </Space>
@@ -251,6 +255,7 @@ export function AdminApprovalsContent() {
                 onCancel={approvals.closeApproveModal}
                 confirmLoading={approvals.approvePending}
                 forceRender
+                data-testid="approve-modal"
             >
                 <Form form={approvals.approveForm} layout="vertical" name="approve-form">
                     {approvals.approveModal?.operation_type !== 'DELETE' && (
@@ -331,6 +336,7 @@ export function AdminApprovalsContent() {
                 onCancel={approvals.closeRejectModal}
                 confirmLoading={approvals.rejectPending}
                 forceRender
+                data-testid="reject-modal"
             >
                 <Form form={approvals.rejectForm} layout="vertical" name="reject-form">
                     <Form.Item

--- a/web/src/features/admin-clusters/components/AdminClustersContent.tsx
+++ b/web/src/features/admin-clusters/components/AdminClustersContent.tsx
@@ -71,6 +71,7 @@ export function AdminClustersContent() {
                 <Select
                     value={env ?? 'test'}
                     style={{ width: 120 }}
+                    data-testid={`cluster-env-select-${record.id}`}
                     options={[
                         { value: 'test', label: t('clusters.env_test') },
                         { value: 'prod', label: t('clusters.env_prod') },
@@ -110,7 +111,7 @@ export function AdminClustersContent() {
     ];
 
     return (
-        <div>
+        <div data-testid="admin-clusters-page">
             {clusters.messageContextHolder}
             <div style={{
                 display: 'flex',
@@ -123,10 +124,10 @@ export function AdminClustersContent() {
                     <Text type="secondary">{t('clusters.subtitle')}</Text>
                 </div>
                 <Space>
-                    <Button icon={<ReloadOutlined />} onClick={() => clusters.refetch()}>
+                    <Button icon={<ReloadOutlined />} data-testid="clusters-refresh-btn" onClick={() => clusters.refetch()}>
                         {t('common:button.refresh')}
                     </Button>
-                    <Button type="primary" icon={<PlusOutlined />} onClick={clusters.openCreateModal}>
+                    <Button type="primary" icon={<PlusOutlined />} data-testid="cluster-create-button" onClick={clusters.openCreateModal}>
                         {t('clusters.add')}
                     </Button>
                 </Space>
@@ -156,6 +157,7 @@ export function AdminClustersContent() {
                 onCancel={clusters.closeCreateModal}
                 confirmLoading={clusters.createPending}
                 forceRender
+                data-testid="cluster-create-modal"
             >
                 <Form form={clusters.form} layout="vertical" name="create-cluster">
                     <Form.Item

--- a/web/src/features/admin-namespaces/components/AdminNamespacesContent.tsx
+++ b/web/src/features/admin-namespaces/components/AdminNamespacesContent.tsx
@@ -105,6 +105,7 @@ export function AdminNamespacesContent() {
                             type="text"
                             size="small"
                             icon={<EditOutlined />}
+                            data-testid={`namespace-action-edit-${record.id}`}
                             onClick={() => namespaces.openEditModal(record)}
                         />
                     </Tooltip>
@@ -114,6 +115,7 @@ export function AdminNamespacesContent() {
                             size="small"
                             danger
                             icon={<DeleteOutlined />}
+                            data-testid={`namespace-action-delete-${record.id}`}
                             onClick={() => namespaces.openDeleteModal(record)}
                         />
                     </Tooltip>
@@ -131,7 +133,7 @@ export function AdminNamespacesContent() {
     };
 
     return (
-        <div>
+        <div data-testid="admin-namespaces-page">
             {namespaces.messageContextHolder}
             <div style={{
                 display: 'flex',
@@ -148,16 +150,18 @@ export function AdminNamespacesContent() {
                         placeholder={t('namespaces.filter_env')}
                         allowClear
                         style={{ width: 160 }}
+                        data-testid="namespaces-env-filter"
                         value={namespaces.envFilter || undefined}
                         onChange={namespaces.changeEnvFilter}
                         options={ENV_OPTIONS.map((item) => ({ ...item }))}
                     />
-                    <Button icon={<ReloadOutlined />} onClick={() => namespaces.refetch()}>
+                    <Button icon={<ReloadOutlined />} data-testid="namespaces-refresh-btn" onClick={() => namespaces.refetch()}>
                         {t('common:button.refresh')}
                     </Button>
                     <Button
                         type="primary"
                         icon={<PlusOutlined />}
+                        data-testid="namespace-create-button"
                         onClick={namespaces.openCreateModal}
                     >
                         {t('namespaces.add')}
@@ -189,6 +193,7 @@ export function AdminNamespacesContent() {
                 onCancel={namespaces.closeCreateModal}
                 confirmLoading={namespaces.createPending}
                 forceRender
+                data-testid="namespace-create-modal"
             >
                 <Form form={namespaces.createForm} layout="vertical" name="create-namespace">
                     <Form.Item
@@ -230,6 +235,7 @@ export function AdminNamespacesContent() {
                 onCancel={namespaces.closeEditModal}
                 confirmLoading={namespaces.updatePending}
                 forceRender
+                data-testid="namespace-edit-modal"
             >
                 <Form form={namespaces.editForm} layout="vertical" name="edit-namespace">
                     <Paragraph type="secondary" style={{ marginBottom: 16 }}>
@@ -267,6 +273,7 @@ export function AdminNamespacesContent() {
                     disabled: namespaces.deleteConfirmName !== namespaces.deletingNs?.name,
                 }}
                 okText={t('common:button.delete')}
+                data-testid="namespace-delete-modal"
             >
                 <Paragraph>
                     {t('namespaces.delete_confirm', { name: namespaces.deletingNs?.name })}
@@ -278,6 +285,7 @@ export function AdminNamespacesContent() {
                     value={namespaces.deleteConfirmName}
                     onChange={(e) => namespaces.setDeleteConfirmName(e.target.value)}
                     placeholder={namespaces.deletingNs?.name}
+                    data-testid="namespace-delete-confirm-input"
                     status={
                         namespaces.deleteConfirmName && namespaces.deleteConfirmName !== namespaces.deletingNs?.name
                             ? 'error'

--- a/web/src/features/admin-rbac/components/AdminRbacContent.tsx
+++ b/web/src/features/admin-rbac/components/AdminRbacContent.tsx
@@ -97,6 +97,7 @@ export function AdminRbacContent() {
                         size="small"
                         icon={<EditOutlined />}
                         disabled={role.built_in}
+                        data-testid={`rbac-role-action-edit-${role.id}`}
                         onClick={() => rbac.openEditRoleModal(role)}
                     >
                         {t('common:button.edit')}
@@ -106,6 +107,7 @@ export function AdminRbacContent() {
                         danger
                         icon={<DeleteOutlined />}
                         disabled={role.built_in}
+                        data-testid={`rbac-role-action-delete-${role.id}`}
                         onClick={() => rbac.openDeleteRoleModal(role)}
                     >
                         {t('common:button.delete')}
@@ -171,6 +173,7 @@ export function AdminRbacContent() {
                     <Button
                         danger
                         size="small"
+                        data-testid={`rbac-binding-action-delete-${binding.id}`}
                         loading={rbac.deleteBindingPending && rbac.deletingBindingId === binding.id}
                     >
                         {t('common:button.delete')}
@@ -218,7 +221,7 @@ export function AdminRbacContent() {
     );
 
     return (
-        <div>
+        <div data-testid="admin-rbac-page">
             {rbac.messageContextHolder}
             <div style={{ marginBottom: 24 }}>
                 <Title level={4} style={{ margin: 0 }}>{t('rbac.title')}</Title>
@@ -238,7 +241,7 @@ export function AdminRbacContent() {
                         }}>
                             {t('common:button.refresh')}
                         </Button>
-                        <Button type="primary" icon={<PlusOutlined />} onClick={rbac.openCreateRoleModal}>
+                        <Button type="primary" icon={<PlusOutlined />} data-testid="rbac-role-create-button" onClick={rbac.openCreateRoleModal}>
                             {t('rbac.roles.add')}
                         </Button>
                     </Space>
@@ -269,7 +272,7 @@ export function AdminRbacContent() {
                         }}>
                             {t('common:button.refresh')}
                         </Button>
-                        <Button type="primary" icon={<PlusOutlined />} onClick={rbac.openAddBindingModal}>
+                        <Button type="primary" icon={<PlusOutlined />} data-testid="rbac-binding-create-button" onClick={rbac.openAddBindingModal}>
                             {t('rbac.bindings.add')}
                         </Button>
                     </Space>
@@ -285,6 +288,7 @@ export function AdminRbacContent() {
                         value={rbac.selectedUserId || undefined}
                         loading={rbac.usersLoading}
                         placeholder={t('rbac.bindings.select_user_placeholder')}
+                        data-testid="rbac-user-selector"
                         onChange={(value) => rbac.setSelectedUserId(value)}
                         options={rbac.users.map((user) => ({
                             value: user.id,
@@ -330,9 +334,10 @@ export function AdminRbacContent() {
                 onCancel={rbac.closeCreateRoleModal}
                 confirmLoading={rbac.createRolePending}
                 destroyOnHidden={true}
+                data-testid="rbac-role-create-modal"
             >
                 <Form form={rbac.roleCreateForm} layout="vertical" preserve={false}>
-                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}> 
+                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
                         <Input />
                     </Form.Item>
                     <Form.Item name="display_name" label={t('common:table.display_name')}>
@@ -341,7 +346,7 @@ export function AdminRbacContent() {
                     <Form.Item name="description" label={t('common:table.description')}>
                         <Input.TextArea rows={3} />
                     </Form.Item>
-                    <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}> 
+                    <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}>
                         <Select mode="multiple" options={rbac.permissionOptions} optionFilterProp="label" />
                     </Form.Item>
                     <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
@@ -359,6 +364,7 @@ export function AdminRbacContent() {
                 onCancel={rbac.closeEditRoleModal}
                 confirmLoading={rbac.updateRolePending}
                 destroyOnHidden={true}
+                data-testid="rbac-role-edit-modal"
             >
                 <Form form={rbac.roleEditForm} layout="vertical" preserve={false}>
                     <Form.Item name="display_name" label={t('common:table.display_name')}>
@@ -367,7 +373,7 @@ export function AdminRbacContent() {
                     <Form.Item name="description" label={t('common:table.description')}>
                         <Input.TextArea rows={3} />
                     </Form.Item>
-                    <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}> 
+                    <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}>
                         <Select mode="multiple" options={rbac.permissionOptions} optionFilterProp="label" />
                     </Form.Item>
                     <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
@@ -396,12 +402,13 @@ export function AdminRbacContent() {
                 onCancel={rbac.closeAddBindingModal}
                 confirmLoading={rbac.createBindingPending}
                 destroyOnHidden={true}
+                data-testid="rbac-binding-add-modal"
             >
                 <Form form={rbac.bindingForm} layout="vertical" preserve={false}>
                     <Form.Item label={t('rbac.bindings.select_user')}>
                         <Input value={rbac.selectedUser?.display_name || rbac.selectedUser?.username || ''} readOnly />
                     </Form.Item>
-                    <Form.Item name="role_id" label={t('rbac.bindings.role')} rules={[{ required: true }]}> 
+                    <Form.Item name="role_id" label={t('rbac.bindings.role')} rules={[{ required: true }]}>
                         <Select options={roleOptions} optionFilterProp="label" showSearch />
                     </Form.Item>
                     <Form.Item name="scope_type" label={t('rbac.bindings.scope_type')} rules={[{ required: true }]} initialValue="global">

--- a/web/src/features/admin-users/components/AdminUsersContent.tsx
+++ b/web/src/features/admin-users/components/AdminUsersContent.tsx
@@ -108,6 +108,7 @@ export function AdminUsersContent() {
                     <Button
                         size="small"
                         icon={<EditOutlined />}
+                        data-testid={`user-action-edit-${record.id}`}
                         onClick={() => users.openEditUserModal(record)}
                     >
                         {t('common:button.edit')}
@@ -122,6 +123,7 @@ export function AdminUsersContent() {
                             size="small"
                             danger
                             icon={<DeleteOutlined />}
+                            data-testid={`user-action-delete-${record.id}`}
                             loading={users.deleteUserPending && users.deletingUserId === record.id}
                         >
                             {t('common:button.delete')}
@@ -161,6 +163,7 @@ export function AdminUsersContent() {
                     value={role}
                     options={memberRoleOptions}
                     style={{ width: 170 }}
+                    data-testid={`member-role-select-${record.user_id}`}
                     onChange={(nextRole) => users.updateMemberRole(
                         record.user_id,
                         nextRole as NonNullable<SystemMemberRoleUpdateRequest['role']>
@@ -180,7 +183,7 @@ export function AdminUsersContent() {
                     okText={t('common:button.confirm')}
                     cancelText={t('common:button.cancel')}
                 >
-                    <Button danger size="small" loading={users.removePending}>
+                    <Button danger size="small" data-testid={`member-action-remove-${record.user_id}`} loading={users.removePending}>
                         {t('common:button.delete')}
                     </Button>
                 </Popconfirm>
@@ -236,6 +239,7 @@ export function AdminUsersContent() {
                 <Space wrap>
                     <Button
                         size="small"
+                        data-testid={`ratelimit-action-exempt-${record.user_id}`}
                         onClick={() => {
                             setSelectedRateLimitUserID(record.user_id);
                             exemptionForm.resetFields();
@@ -246,6 +250,7 @@ export function AdminUsersContent() {
                     </Button>
                     <Button
                         size="small"
+                        data-testid={`ratelimit-action-override-${record.user_id}`}
                         onClick={() => {
                             setSelectedRateLimitUserID(record.user_id);
                             overrideForm.setFieldsValue({
@@ -264,7 +269,7 @@ export function AdminUsersContent() {
                         okText={t('common:button.confirm')}
                         cancelText={t('common:button.cancel')}
                     >
-                        <Button size="small" danger disabled={!record.exempted} loading={users.rateLimitMutationPending}>
+                        <Button size="small" danger data-testid={`ratelimit-action-remove-exempt-${record.user_id}`} disabled={!record.exempted} loading={users.rateLimitMutationPending}>
                             {t('users.rate_limit.remove_exemption')}
                         </Button>
                     </Popconfirm>
@@ -292,7 +297,7 @@ export function AdminUsersContent() {
     }));
 
     return (
-        <div>
+        <div data-testid="admin-users-page">
             {users.messageContextHolder}
             <div style={{ marginBottom: 24 }}>
                 <Title level={4} style={{ margin: 0 }}>{t('users.title')}</Title>
@@ -309,7 +314,7 @@ export function AdminUsersContent() {
                         <Button icon={<ReloadOutlined />} onClick={() => users.refetchUsers()}>
                             {t('common:button.refresh')}
                         </Button>
-                        <Button type="primary" icon={<PlusOutlined />} onClick={users.openCreateUserModal}>
+                        <Button type="primary" icon={<PlusOutlined />} data-testid="user-create-button" onClick={users.openCreateUserModal}>
                             {t('users.directory.add')}
                         </Button>
                     </Space>
@@ -343,6 +348,7 @@ export function AdminUsersContent() {
                 onCancel={users.closeCreateUserModal}
                 confirmLoading={users.createUserPending}
                 destroyOnHidden={true}
+                data-testid="user-create-modal"
             >
                 <Form form={users.createUserForm} layout="vertical" preserve={false}>
                     <Form.Item
@@ -396,6 +402,7 @@ export function AdminUsersContent() {
                 onCancel={users.closeEditUserModal}
                 confirmLoading={users.updateUserPending}
                 destroyOnHidden={true}
+                data-testid="user-edit-modal"
             >
                 <Form form={users.editUserForm} layout="vertical" preserve={false}>
                     <Form.Item name="display_name" label={t('common:table.display_name')}>
@@ -439,6 +446,7 @@ export function AdminUsersContent() {
                         <Button
                             type="primary"
                             icon={<PlusOutlined />}
+                            data-testid="member-add-button"
                             onClick={users.openAddModal}
                             disabled={!users.selectedSystemId}
                         >
@@ -455,6 +463,7 @@ export function AdminUsersContent() {
                         loading={users.systemsLoading}
                         value={users.selectedSystemId}
                         placeholder={t('users.members.select_system_placeholder')}
+                        data-testid="users-system-selector"
                         onChange={(value) => users.setSelectedSystemId(value)}
                         options={users.systems.map((system) => ({ value: system.id, label: system.name }))}
                         showSearch
@@ -503,6 +512,7 @@ export function AdminUsersContent() {
                 onCancel={users.closeAddModal}
                 confirmLoading={users.addPending}
                 destroyOnHidden={true}
+                data-testid="member-add-modal"
             >
                 <Form form={users.addForm} layout="vertical" preserve={false}>
                     <Form.Item
@@ -557,6 +567,7 @@ export function AdminUsersContent() {
                 }}
                 confirmLoading={users.rateLimitMutationPending}
                 destroyOnHidden={true}
+                data-testid="ratelimit-exemption-modal"
             >
                 <Form form={exemptionForm} layout="vertical" preserve={false}>
                     <Form.Item label={t('users.rate_limit.user_id')}>
@@ -594,6 +605,7 @@ export function AdminUsersContent() {
                 }}
                 confirmLoading={users.rateLimitMutationPending}
                 destroyOnHidden={true}
+                data-testid="ratelimit-override-modal"
             >
                 <Form form={overrideForm} layout="vertical" preserve={false}>
                     <Form.Item label={t('users.rate_limit.user_id')}>


### PR DESCRIPTION
## Summary

Add `data-testid` attributes to five admin page components that completely lacked testability coverage. Enables Playwright's `getByTestId()` locator strategy for stable, resilient E2E testing.

## Problem

All five admin components had zero `data-testid` attributes, blocking E2E test coverage for critical master-flow stages:

| Stage | Component |
|-------|-----------|
| Stage 1 – Cluster Registration | `AdminClustersContent` |
| Stage 2 – Namespace Management | `AdminNamespacesContent` |
| Stage 3 – RBAC Management | `AdminRbacContent` |
| Stage 3 – User Management | `AdminUsersContent` |
| Stage 5.B – Approval Workflows | `AdminApprovalsContent` |

## Changes

| Component | `data-testid` Count | Key Elements |
|-----------|---------------------|--------------|
| `AdminApprovalsContent` | 8 | approve/reject/cancel row actions, status filter, refresh, 2 modals |
| `AdminClustersContent` | 5 | env selector per row, refresh, create button, create modal |
| `AdminNamespacesContent` | 10 | edit/delete row actions, env filter, refresh, create button, 3 modals, delete confirm input |
| `AdminRbacContent` | 10 | role edit/delete, binding delete, user selector, 2 create buttons, 3 modals |
| `AdminUsersContent` | 16 | user/member/ratelimit row actions, system selector, create buttons, 6 modals |

**Total: 49 `data-testid` attributes added across 5 files (+53/-18 lines)**

## Naming Convention

Follows existing project patterns from `AdminTemplatesContent`, `SystemsManagementContent`, `ServicesManagementContent`:

```
{feature}-action-{action}-${record.id}   # row-level actions
{feature}-create-button                   # page-level create
{feature}-{type}-modal                    # dialogs
{feature}-{control}                       # toolbar controls
```

## Verification

- [x] `npx tsc --noEmit` passes in `web/`
- [x] No functional behavior changes (attributes only)
- [x] Naming convention consistent with existing well-tested components

## Related

Closes #250