### PR TITLE
docs(adr): mark ADR-0036 as accepted

### DIFF
--- a/docs/adr/ADR-0036-template-instancesize-boundary-enforcement.md
+++ b/docs/adr/ADR-0036-template-instancesize-boundary-enforcement.md
@@ -1,7 +1,7 @@
 ---
-status: "proposed"
+status: "accepted"
 date: 2026-02-20
-deciders: []
+deciders: ["@jindyzhao"]
 consulted: []
 informed: []
 ---
@@ -137,3 +137,4 @@ Replace the Template `spec_text` TextArea with semantic form fields, preventing 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-20 | jindyzhao | Initial draft |
+| 2026-02-22 | jindyzhao | Status changed from proposed to accepted after review period |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,7 +45,7 @@
 | [ADR-0033](./ADR-0033-realtime-notification-acceleration.md) | Realtime Notification Acceleration with PostgreSQL LISTEN/NOTIFY | **Proposed** | - |
 | [ADR-0034](./ADR-0034-master-flow-spec-driven-test-first.md) | Master-Flow Spec-Driven Test-First Execution Standard | **Accepted** | - |
 | [ADR-0035](./ADR-0035-auth-provider-plugin-boundary.md) | Auth Provider Plugin Boundary and Type Discovery | **Accepted** | - |
-| [ADR-0036](./ADR-0036-template-instancesize-boundary-enforcement.md) | Template / InstanceSize Boundary Enforcement | **Proposed** | - |
+| [ADR-0036](./ADR-0036-template-instancesize-boundary-enforcement.md) | Template / InstanceSize Boundary Enforcement | **Accepted** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:
 >


### PR DESCRIPTION
## Summary
Mark ADR-0036 as accepted after the review window ended on 2026-02-22.

## Changes
- update ADR-0036 frontmatter: `status: proposed -> accepted`
- update ADR index status in `docs/adr/README.md`
- set governance metadata (`deciders/consulted/informed`)

## Scope Guard
- docs only
- no runtime or schema changes

Closes #252