### PR TITLE
refactor(ent): align template schema with ADR-0036

### DIFF
--- a/ent/approvalticket.go
+++ b/ent/approvalticket.go
@@ -38,8 +38,6 @@ type ApprovalTicket struct {
 	RejectReason string `json:"reject_reason,omitempty"`
 	// SelectedClusterID holds the value of the "selected_cluster_id" field.
 	SelectedClusterID string `json:"selected_cluster_id,omitempty"`
-	// SelectedTemplateVersion holds the value of the "selected_template_version" field.
-	SelectedTemplateVersion int `json:"selected_template_version,omitempty"`
 	// SelectedStorageClass holds the value of the "selected_storage_class" field.
 	SelectedStorageClass string `json:"selected_storage_class,omitempty"`
 	// TemplateSnapshot holds the value of the "template_snapshot" field.
@@ -60,8 +58,6 @@ func (*ApprovalTicket) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case approvalticket.FieldTemplateSnapshot, approvalticket.FieldInstanceSizeSnapshot, approvalticket.FieldModifiedSpec:
 			values[i] = new([]byte)
-		case approvalticket.FieldSelectedTemplateVersion:
-			values[i] = new(sql.NullInt64)
 		case approvalticket.FieldID, approvalticket.FieldEventID, approvalticket.FieldOperationType, approvalticket.FieldStatus, approvalticket.FieldRequester, approvalticket.FieldApprover, approvalticket.FieldReason, approvalticket.FieldRejectReason, approvalticket.FieldSelectedClusterID, approvalticket.FieldSelectedStorageClass, approvalticket.FieldParentTicketID:
 			values[i] = new(sql.NullString)
 		case approvalticket.FieldCreatedAt, approvalticket.FieldUpdatedAt:
@@ -146,12 +142,6 @@ func (_m *ApprovalTicket) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field selected_cluster_id", values[i])
 			} else if value.Valid {
 				_m.SelectedClusterID = value.String
-			}
-		case approvalticket.FieldSelectedTemplateVersion:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field selected_template_version", values[i])
-			} else if value.Valid {
-				_m.SelectedTemplateVersion = int(value.Int64)
 			}
 		case approvalticket.FieldSelectedStorageClass:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -254,9 +244,6 @@ func (_m *ApprovalTicket) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("selected_cluster_id=")
 	builder.WriteString(_m.SelectedClusterID)
-	builder.WriteString(", ")
-	builder.WriteString("selected_template_version=")
-	builder.WriteString(fmt.Sprintf("%v", _m.SelectedTemplateVersion))
 	builder.WriteString(", ")
 	builder.WriteString("selected_storage_class=")
 	builder.WriteString(_m.SelectedStorageClass)

--- a/ent/approvalticket/approvalticket.go
+++ b/ent/approvalticket/approvalticket.go
@@ -34,8 +34,6 @@ const (
 	FieldRejectReason = "reject_reason"
 	// FieldSelectedClusterID holds the string denoting the selected_cluster_id field in the database.
 	FieldSelectedClusterID = "selected_cluster_id"
-	// FieldSelectedTemplateVersion holds the string denoting the selected_template_version field in the database.
-	FieldSelectedTemplateVersion = "selected_template_version"
 	// FieldSelectedStorageClass holds the string denoting the selected_storage_class field in the database.
 	FieldSelectedStorageClass = "selected_storage_class"
 	// FieldTemplateSnapshot holds the string denoting the template_snapshot field in the database.
@@ -63,7 +61,6 @@ var Columns = []string{
 	FieldReason,
 	FieldRejectReason,
 	FieldSelectedClusterID,
-	FieldSelectedTemplateVersion,
 	FieldSelectedStorageClass,
 	FieldTemplateSnapshot,
 	FieldInstanceSizeSnapshot,
@@ -208,11 +205,6 @@ func ByRejectReason(opts ...sql.OrderTermOption) OrderOption {
 // BySelectedClusterID orders the results by the selected_cluster_id field.
 func BySelectedClusterID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSelectedClusterID, opts...).ToFunc()
-}
-
-// BySelectedTemplateVersion orders the results by the selected_template_version field.
-func BySelectedTemplateVersion(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldSelectedTemplateVersion, opts...).ToFunc()
 }
 
 // BySelectedStorageClass orders the results by the selected_storage_class field.

--- a/ent/approvalticket/where.go
+++ b/ent/approvalticket/where.go
@@ -104,11 +104,6 @@ func SelectedClusterID(v string) predicate.ApprovalTicket {
 	return predicate.ApprovalTicket(sql.FieldEQ(FieldSelectedClusterID, v))
 }
 
-// SelectedTemplateVersion applies equality check predicate on the "selected_template_version" field. It's identical to SelectedTemplateVersionEQ.
-func SelectedTemplateVersion(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldEQ(FieldSelectedTemplateVersion, v))
-}
-
 // SelectedStorageClass applies equality check predicate on the "selected_storage_class" field. It's identical to SelectedStorageClassEQ.
 func SelectedStorageClass(v string) predicate.ApprovalTicket {
 	return predicate.ApprovalTicket(sql.FieldEQ(FieldSelectedStorageClass, v))
@@ -667,56 +662,6 @@ func SelectedClusterIDEqualFold(v string) predicate.ApprovalTicket {
 // SelectedClusterIDContainsFold applies the ContainsFold predicate on the "selected_cluster_id" field.
 func SelectedClusterIDContainsFold(v string) predicate.ApprovalTicket {
 	return predicate.ApprovalTicket(sql.FieldContainsFold(FieldSelectedClusterID, v))
-}
-
-// SelectedTemplateVersionEQ applies the EQ predicate on the "selected_template_version" field.
-func SelectedTemplateVersionEQ(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldEQ(FieldSelectedTemplateVersion, v))
-}
-
-// SelectedTemplateVersionNEQ applies the NEQ predicate on the "selected_template_version" field.
-func SelectedTemplateVersionNEQ(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldNEQ(FieldSelectedTemplateVersion, v))
-}
-
-// SelectedTemplateVersionIn applies the In predicate on the "selected_template_version" field.
-func SelectedTemplateVersionIn(vs ...int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldIn(FieldSelectedTemplateVersion, vs...))
-}
-
-// SelectedTemplateVersionNotIn applies the NotIn predicate on the "selected_template_version" field.
-func SelectedTemplateVersionNotIn(vs ...int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldNotIn(FieldSelectedTemplateVersion, vs...))
-}
-
-// SelectedTemplateVersionGT applies the GT predicate on the "selected_template_version" field.
-func SelectedTemplateVersionGT(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldGT(FieldSelectedTemplateVersion, v))
-}
-
-// SelectedTemplateVersionGTE applies the GTE predicate on the "selected_template_version" field.
-func SelectedTemplateVersionGTE(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldGTE(FieldSelectedTemplateVersion, v))
-}
-
-// SelectedTemplateVersionLT applies the LT predicate on the "selected_template_version" field.
-func SelectedTemplateVersionLT(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldLT(FieldSelectedTemplateVersion, v))
-}
-
-// SelectedTemplateVersionLTE applies the LTE predicate on the "selected_template_version" field.
-func SelectedTemplateVersionLTE(v int) predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldLTE(FieldSelectedTemplateVersion, v))
-}
-
-// SelectedTemplateVersionIsNil applies the IsNil predicate on the "selected_template_version" field.
-func SelectedTemplateVersionIsNil() predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldIsNull(FieldSelectedTemplateVersion))
-}
-
-// SelectedTemplateVersionNotNil applies the NotNil predicate on the "selected_template_version" field.
-func SelectedTemplateVersionNotNil() predicate.ApprovalTicket {
-	return predicate.ApprovalTicket(sql.FieldNotNull(FieldSelectedTemplateVersion))
 }
 
 // SelectedStorageClassEQ applies the EQ predicate on the "selected_storage_class" field.

--- a/ent/approvalticket_create.go
+++ b/ent/approvalticket_create.go
@@ -144,20 +144,6 @@ func (_c *ApprovalTicketCreate) SetNillableSelectedClusterID(v *string) *Approva
 	return _c
 }
 
-// SetSelectedTemplateVersion sets the "selected_template_version" field.
-func (_c *ApprovalTicketCreate) SetSelectedTemplateVersion(v int) *ApprovalTicketCreate {
-	_c.mutation.SetSelectedTemplateVersion(v)
-	return _c
-}
-
-// SetNillableSelectedTemplateVersion sets the "selected_template_version" field if the given value is not nil.
-func (_c *ApprovalTicketCreate) SetNillableSelectedTemplateVersion(v *int) *ApprovalTicketCreate {
-	if v != nil {
-		_c.SetSelectedTemplateVersion(*v)
-	}
-	return _c
-}
-
 // SetSelectedStorageClass sets the "selected_storage_class" field.
 func (_c *ApprovalTicketCreate) SetSelectedStorageClass(v string) *ApprovalTicketCreate {
 	_c.mutation.SetSelectedStorageClass(v)
@@ -377,10 +363,6 @@ func (_c *ApprovalTicketCreate) createSpec() (*ApprovalTicket, *sqlgraph.CreateS
 	if value, ok := _c.mutation.SelectedClusterID(); ok {
 		_spec.SetField(approvalticket.FieldSelectedClusterID, field.TypeString, value)
 		_node.SelectedClusterID = value
-	}
-	if value, ok := _c.mutation.SelectedTemplateVersion(); ok {
-		_spec.SetField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt, value)
-		_node.SelectedTemplateVersion = value
 	}
 	if value, ok := _c.mutation.SelectedStorageClass(); ok {
 		_spec.SetField(approvalticket.FieldSelectedStorageClass, field.TypeString, value)

--- a/ent/approvalticket_update.go
+++ b/ent/approvalticket_update.go
@@ -142,33 +142,6 @@ func (_u *ApprovalTicketUpdate) ClearSelectedClusterID() *ApprovalTicketUpdate {
 	return _u
 }
 
-// SetSelectedTemplateVersion sets the "selected_template_version" field.
-func (_u *ApprovalTicketUpdate) SetSelectedTemplateVersion(v int) *ApprovalTicketUpdate {
-	_u.mutation.ResetSelectedTemplateVersion()
-	_u.mutation.SetSelectedTemplateVersion(v)
-	return _u
-}
-
-// SetNillableSelectedTemplateVersion sets the "selected_template_version" field if the given value is not nil.
-func (_u *ApprovalTicketUpdate) SetNillableSelectedTemplateVersion(v *int) *ApprovalTicketUpdate {
-	if v != nil {
-		_u.SetSelectedTemplateVersion(*v)
-	}
-	return _u
-}
-
-// AddSelectedTemplateVersion adds value to the "selected_template_version" field.
-func (_u *ApprovalTicketUpdate) AddSelectedTemplateVersion(v int) *ApprovalTicketUpdate {
-	_u.mutation.AddSelectedTemplateVersion(v)
-	return _u
-}
-
-// ClearSelectedTemplateVersion clears the value of the "selected_template_version" field.
-func (_u *ApprovalTicketUpdate) ClearSelectedTemplateVersion() *ApprovalTicketUpdate {
-	_u.mutation.ClearSelectedTemplateVersion()
-	return _u
-}
-
 // SetSelectedStorageClass sets the "selected_storage_class" field.
 func (_u *ApprovalTicketUpdate) SetSelectedStorageClass(v string) *ApprovalTicketUpdate {
 	_u.mutation.SetSelectedStorageClass(v)
@@ -346,15 +319,6 @@ func (_u *ApprovalTicketUpdate) sqlSave(ctx context.Context) (_node int, err err
 	if _u.mutation.SelectedClusterIDCleared() {
 		_spec.ClearField(approvalticket.FieldSelectedClusterID, field.TypeString)
 	}
-	if value, ok := _u.mutation.SelectedTemplateVersion(); ok {
-		_spec.SetField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt, value)
-	}
-	if value, ok := _u.mutation.AddedSelectedTemplateVersion(); ok {
-		_spec.AddField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt, value)
-	}
-	if _u.mutation.SelectedTemplateVersionCleared() {
-		_spec.ClearField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt)
-	}
 	if value, ok := _u.mutation.SelectedStorageClass(); ok {
 		_spec.SetField(approvalticket.FieldSelectedStorageClass, field.TypeString, value)
 	}
@@ -516,33 +480,6 @@ func (_u *ApprovalTicketUpdateOne) SetNillableSelectedClusterID(v *string) *Appr
 // ClearSelectedClusterID clears the value of the "selected_cluster_id" field.
 func (_u *ApprovalTicketUpdateOne) ClearSelectedClusterID() *ApprovalTicketUpdateOne {
 	_u.mutation.ClearSelectedClusterID()
-	return _u
-}
-
-// SetSelectedTemplateVersion sets the "selected_template_version" field.
-func (_u *ApprovalTicketUpdateOne) SetSelectedTemplateVersion(v int) *ApprovalTicketUpdateOne {
-	_u.mutation.ResetSelectedTemplateVersion()
-	_u.mutation.SetSelectedTemplateVersion(v)
-	return _u
-}
-
-// SetNillableSelectedTemplateVersion sets the "selected_template_version" field if the given value is not nil.
-func (_u *ApprovalTicketUpdateOne) SetNillableSelectedTemplateVersion(v *int) *ApprovalTicketUpdateOne {
-	if v != nil {
-		_u.SetSelectedTemplateVersion(*v)
-	}
-	return _u
-}
-
-// AddSelectedTemplateVersion adds value to the "selected_template_version" field.
-func (_u *ApprovalTicketUpdateOne) AddSelectedTemplateVersion(v int) *ApprovalTicketUpdateOne {
-	_u.mutation.AddSelectedTemplateVersion(v)
-	return _u
-}
-
-// ClearSelectedTemplateVersion clears the value of the "selected_template_version" field.
-func (_u *ApprovalTicketUpdateOne) ClearSelectedTemplateVersion() *ApprovalTicketUpdateOne {
-	_u.mutation.ClearSelectedTemplateVersion()
 	return _u
 }
 
@@ -752,15 +689,6 @@ func (_u *ApprovalTicketUpdateOne) sqlSave(ctx context.Context) (_node *Approval
 	}
 	if _u.mutation.SelectedClusterIDCleared() {
 		_spec.ClearField(approvalticket.FieldSelectedClusterID, field.TypeString)
-	}
-	if value, ok := _u.mutation.SelectedTemplateVersion(); ok {
-		_spec.SetField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt, value)
-	}
-	if value, ok := _u.mutation.AddedSelectedTemplateVersion(); ok {
-		_spec.AddField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt, value)
-	}
-	if _u.mutation.SelectedTemplateVersionCleared() {
-		_spec.ClearField(approvalticket.FieldSelectedTemplateVersion, field.TypeInt)
 	}
 	if value, ok := _u.mutation.SelectedStorageClass(); ok {
 		_spec.SetField(approvalticket.FieldSelectedStorageClass, field.TypeString, value)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -46,7 +46,6 @@ var (
 		{Name: "reason", Type: field.TypeString, Nullable: true},
 		{Name: "reject_reason", Type: field.TypeString, Nullable: true},
 		{Name: "selected_cluster_id", Type: field.TypeString, Nullable: true},
-		{Name: "selected_template_version", Type: field.TypeInt, Nullable: true},
 		{Name: "selected_storage_class", Type: field.TypeString, Nullable: true},
 		{Name: "template_snapshot", Type: field.TypeJSON, Nullable: true},
 		{Name: "instance_size_snapshot", Type: field.TypeJSON, Nullable: true},
@@ -77,7 +76,7 @@ var (
 			{
 				Name:    "approvalticket_parent_ticket_id",
 				Unique:  false,
-				Columns: []*schema.Column{ApprovalTicketsColumns[16]},
+				Columns: []*schema.Column{ApprovalTicketsColumns[15]},
 			},
 		},
 	}
@@ -744,8 +743,10 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "display_name", Type: field.TypeString, Nullable: true},
 		{Name: "description", Type: field.TypeString, Nullable: true},
-		{Name: "version", Type: field.TypeInt, Default: 1},
-		{Name: "spec", Type: field.TypeJSON, Nullable: true},
+		{Name: "source_type", Type: field.TypeString, Nullable: true, Default: ""},
+		{Name: "image_url", Type: field.TypeString, Nullable: true},
+		{Name: "pvc_name", Type: field.TypeString, Nullable: true},
+		{Name: "cloud_init", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "os_family", Type: field.TypeString, Nullable: true},
 		{Name: "os_version", Type: field.TypeString, Nullable: true},
 		{Name: "enabled", Type: field.TypeBool, Default: true},
@@ -758,14 +759,19 @@ var (
 		PrimaryKey: []*schema.Column{TemplatesColumns[0]},
 		Indexes: []*schema.Index{
 			{
-				Name:    "template_name_version",
+				Name:    "template_name",
 				Unique:  true,
-				Columns: []*schema.Column{TemplatesColumns[3], TemplatesColumns[6]},
+				Columns: []*schema.Column{TemplatesColumns[3]},
 			},
 			{
 				Name:    "template_enabled",
 				Unique:  false,
-				Columns: []*schema.Column{TemplatesColumns[10]},
+				Columns: []*schema.Column{TemplatesColumns[12]},
+			},
+			{
+				Name:    "template_source_type",
+				Unique:  false,
+				Columns: []*schema.Column{TemplatesColumns[6]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -831,30 +831,28 @@ func (m *ApprovalPolicyMutation) ResetEdge(name string) error {
 // ApprovalTicketMutation represents an operation that mutates the ApprovalTicket nodes in the graph.
 type ApprovalTicketMutation struct {
 	config
-	op                           Op
-	typ                          string
-	id                           *string
-	created_at                   *time.Time
-	updated_at                   *time.Time
-	event_id                     *string
-	operation_type               *approvalticket.OperationType
-	status                       *approvalticket.Status
-	requester                    *string
-	approver                     *string
-	reason                       *string
-	reject_reason                *string
-	selected_cluster_id          *string
-	selected_template_version    *int
-	addselected_template_version *int
-	selected_storage_class       *string
-	template_snapshot            *map[string]interface{}
-	instance_size_snapshot       *map[string]interface{}
-	modified_spec                *map[string]interface{}
-	parent_ticket_id             *string
-	clearedFields                map[string]struct{}
-	done                         bool
-	oldValue                     func(context.Context) (*ApprovalTicket, error)
-	predicates                   []predicate.ApprovalTicket
+	op                     Op
+	typ                    string
+	id                     *string
+	created_at             *time.Time
+	updated_at             *time.Time
+	event_id               *string
+	operation_type         *approvalticket.OperationType
+	status                 *approvalticket.Status
+	requester              *string
+	approver               *string
+	reason                 *string
+	reject_reason          *string
+	selected_cluster_id    *string
+	selected_storage_class *string
+	template_snapshot      *map[string]interface{}
+	instance_size_snapshot *map[string]interface{}
+	modified_spec          *map[string]interface{}
+	parent_ticket_id       *string
+	clearedFields          map[string]struct{}
+	done                   bool
+	oldValue               func(context.Context) (*ApprovalTicket, error)
+	predicates             []predicate.ApprovalTicket
 }
 
 var _ ent.Mutation = (*ApprovalTicketMutation)(nil)
@@ -1373,76 +1371,6 @@ func (m *ApprovalTicketMutation) ResetSelectedClusterID() {
 	delete(m.clearedFields, approvalticket.FieldSelectedClusterID)
 }
 
-// SetSelectedTemplateVersion sets the "selected_template_version" field.
-func (m *ApprovalTicketMutation) SetSelectedTemplateVersion(i int) {
-	m.selected_template_version = &i
-	m.addselected_template_version = nil
-}
-
-// SelectedTemplateVersion returns the value of the "selected_template_version" field in the mutation.
-func (m *ApprovalTicketMutation) SelectedTemplateVersion() (r int, exists bool) {
-	v := m.selected_template_version
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldSelectedTemplateVersion returns the old "selected_template_version" field's value of the ApprovalTicket entity.
-// If the ApprovalTicket object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ApprovalTicketMutation) OldSelectedTemplateVersion(ctx context.Context) (v int, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldSelectedTemplateVersion is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldSelectedTemplateVersion requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldSelectedTemplateVersion: %w", err)
-	}
-	return oldValue.SelectedTemplateVersion, nil
-}
-
-// AddSelectedTemplateVersion adds i to the "selected_template_version" field.
-func (m *ApprovalTicketMutation) AddSelectedTemplateVersion(i int) {
-	if m.addselected_template_version != nil {
-		*m.addselected_template_version += i
-	} else {
-		m.addselected_template_version = &i
-	}
-}
-
-// AddedSelectedTemplateVersion returns the value that was added to the "selected_template_version" field in this mutation.
-func (m *ApprovalTicketMutation) AddedSelectedTemplateVersion() (r int, exists bool) {
-	v := m.addselected_template_version
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// ClearSelectedTemplateVersion clears the value of the "selected_template_version" field.
-func (m *ApprovalTicketMutation) ClearSelectedTemplateVersion() {
-	m.selected_template_version = nil
-	m.addselected_template_version = nil
-	m.clearedFields[approvalticket.FieldSelectedTemplateVersion] = struct{}{}
-}
-
-// SelectedTemplateVersionCleared returns if the "selected_template_version" field was cleared in this mutation.
-func (m *ApprovalTicketMutation) SelectedTemplateVersionCleared() bool {
-	_, ok := m.clearedFields[approvalticket.FieldSelectedTemplateVersion]
-	return ok
-}
-
-// ResetSelectedTemplateVersion resets all changes to the "selected_template_version" field.
-func (m *ApprovalTicketMutation) ResetSelectedTemplateVersion() {
-	m.selected_template_version = nil
-	m.addselected_template_version = nil
-	delete(m.clearedFields, approvalticket.FieldSelectedTemplateVersion)
-}
-
 // SetSelectedStorageClass sets the "selected_storage_class" field.
 func (m *ApprovalTicketMutation) SetSelectedStorageClass(s string) {
 	m.selected_storage_class = &s
@@ -1722,7 +1650,7 @@ func (m *ApprovalTicketMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ApprovalTicketMutation) Fields() []string {
-	fields := make([]string, 0, 16)
+	fields := make([]string, 0, 15)
 	if m.created_at != nil {
 		fields = append(fields, approvalticket.FieldCreatedAt)
 	}
@@ -1752,9 +1680,6 @@ func (m *ApprovalTicketMutation) Fields() []string {
 	}
 	if m.selected_cluster_id != nil {
 		fields = append(fields, approvalticket.FieldSelectedClusterID)
-	}
-	if m.selected_template_version != nil {
-		fields = append(fields, approvalticket.FieldSelectedTemplateVersion)
 	}
 	if m.selected_storage_class != nil {
 		fields = append(fields, approvalticket.FieldSelectedStorageClass)
@@ -1799,8 +1724,6 @@ func (m *ApprovalTicketMutation) Field(name string) (ent.Value, bool) {
 		return m.RejectReason()
 	case approvalticket.FieldSelectedClusterID:
 		return m.SelectedClusterID()
-	case approvalticket.FieldSelectedTemplateVersion:
-		return m.SelectedTemplateVersion()
 	case approvalticket.FieldSelectedStorageClass:
 		return m.SelectedStorageClass()
 	case approvalticket.FieldTemplateSnapshot:
@@ -1840,8 +1763,6 @@ func (m *ApprovalTicketMutation) OldField(ctx context.Context, name string) (ent
 		return m.OldRejectReason(ctx)
 	case approvalticket.FieldSelectedClusterID:
 		return m.OldSelectedClusterID(ctx)
-	case approvalticket.FieldSelectedTemplateVersion:
-		return m.OldSelectedTemplateVersion(ctx)
 	case approvalticket.FieldSelectedStorageClass:
 		return m.OldSelectedStorageClass(ctx)
 	case approvalticket.FieldTemplateSnapshot:
@@ -1931,13 +1852,6 @@ func (m *ApprovalTicketMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetSelectedClusterID(v)
 		return nil
-	case approvalticket.FieldSelectedTemplateVersion:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetSelectedTemplateVersion(v)
-		return nil
 	case approvalticket.FieldSelectedStorageClass:
 		v, ok := value.(string)
 		if !ok {
@@ -1980,21 +1894,13 @@ func (m *ApprovalTicketMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *ApprovalTicketMutation) AddedFields() []string {
-	var fields []string
-	if m.addselected_template_version != nil {
-		fields = append(fields, approvalticket.FieldSelectedTemplateVersion)
-	}
-	return fields
+	return nil
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *ApprovalTicketMutation) AddedField(name string) (ent.Value, bool) {
-	switch name {
-	case approvalticket.FieldSelectedTemplateVersion:
-		return m.AddedSelectedTemplateVersion()
-	}
 	return nil, false
 }
 
@@ -2003,13 +1909,6 @@ func (m *ApprovalTicketMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *ApprovalTicketMutation) AddField(name string, value ent.Value) error {
 	switch name {
-	case approvalticket.FieldSelectedTemplateVersion:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.AddSelectedTemplateVersion(v)
-		return nil
 	}
 	return fmt.Errorf("unknown ApprovalTicket numeric field %s", name)
 }
@@ -2029,9 +1928,6 @@ func (m *ApprovalTicketMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(approvalticket.FieldSelectedClusterID) {
 		fields = append(fields, approvalticket.FieldSelectedClusterID)
-	}
-	if m.FieldCleared(approvalticket.FieldSelectedTemplateVersion) {
-		fields = append(fields, approvalticket.FieldSelectedTemplateVersion)
 	}
 	if m.FieldCleared(approvalticket.FieldSelectedStorageClass) {
 		fields = append(fields, approvalticket.FieldSelectedStorageClass)
@@ -2073,9 +1969,6 @@ func (m *ApprovalTicketMutation) ClearField(name string) error {
 		return nil
 	case approvalticket.FieldSelectedClusterID:
 		m.ClearSelectedClusterID()
-		return nil
-	case approvalticket.FieldSelectedTemplateVersion:
-		m.ClearSelectedTemplateVersion()
 		return nil
 	case approvalticket.FieldSelectedStorageClass:
 		m.ClearSelectedStorageClass()
@@ -2129,9 +2022,6 @@ func (m *ApprovalTicketMutation) ResetField(name string) error {
 		return nil
 	case approvalticket.FieldSelectedClusterID:
 		m.ResetSelectedClusterID()
-		return nil
-	case approvalticket.FieldSelectedTemplateVersion:
-		m.ResetSelectedTemplateVersion()
 		return nil
 	case approvalticket.FieldSelectedStorageClass:
 		m.ResetSelectedStorageClass()
@@ -18770,9 +18660,10 @@ type TemplateMutation struct {
 	name          *string
 	display_name  *string
 	description   *string
-	version       *int
-	addversion    *int
-	spec          *map[string]interface{}
+	source_type   *string
+	image_url     *string
+	pvc_name      *string
+	cloud_init    *string
 	os_family     *string
 	os_version    *string
 	enabled       *bool
@@ -19093,109 +18984,200 @@ func (m *TemplateMutation) ResetDescription() {
 	delete(m.clearedFields, template.FieldDescription)
 }
 
-// SetVersion sets the "version" field.
-func (m *TemplateMutation) SetVersion(i int) {
-	m.version = &i
-	m.addversion = nil
+// SetSourceType sets the "source_type" field.
+func (m *TemplateMutation) SetSourceType(s string) {
+	m.source_type = &s
 }
 
-// Version returns the value of the "version" field in the mutation.
-func (m *TemplateMutation) Version() (r int, exists bool) {
-	v := m.version
+// SourceType returns the value of the "source_type" field in the mutation.
+func (m *TemplateMutation) SourceType() (r string, exists bool) {
+	v := m.source_type
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldVersion returns the old "version" field's value of the Template entity.
+// OldSourceType returns the old "source_type" field's value of the Template entity.
 // If the Template object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *TemplateMutation) OldVersion(ctx context.Context) (v int, err error) {
+func (m *TemplateMutation) OldSourceType(ctx context.Context) (v string, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldVersion is only allowed on UpdateOne operations")
+		return v, errors.New("OldSourceType is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldVersion requires an ID field in the mutation")
+		return v, errors.New("OldSourceType requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldVersion: %w", err)
+		return v, fmt.Errorf("querying old value for OldSourceType: %w", err)
 	}
-	return oldValue.Version, nil
+	return oldValue.SourceType, nil
 }
 
-// AddVersion adds i to the "version" field.
-func (m *TemplateMutation) AddVersion(i int) {
-	if m.addversion != nil {
-		*m.addversion += i
-	} else {
-		m.addversion = &i
-	}
+// ClearSourceType clears the value of the "source_type" field.
+func (m *TemplateMutation) ClearSourceType() {
+	m.source_type = nil
+	m.clearedFields[template.FieldSourceType] = struct{}{}
 }
 
-// AddedVersion returns the value that was added to the "version" field in this mutation.
-func (m *TemplateMutation) AddedVersion() (r int, exists bool) {
-	v := m.addversion
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// ResetVersion resets all changes to the "version" field.
-func (m *TemplateMutation) ResetVersion() {
-	m.version = nil
-	m.addversion = nil
-}
-
-// SetSpec sets the "spec" field.
-func (m *TemplateMutation) SetSpec(value map[string]interface{}) {
-	m.spec = &value
-}
-
-// Spec returns the value of the "spec" field in the mutation.
-func (m *TemplateMutation) Spec() (r map[string]interface{}, exists bool) {
-	v := m.spec
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldSpec returns the old "spec" field's value of the Template entity.
-// If the Template object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *TemplateMutation) OldSpec(ctx context.Context) (v map[string]interface{}, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldSpec is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldSpec requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldSpec: %w", err)
-	}
-	return oldValue.Spec, nil
-}
-
-// ClearSpec clears the value of the "spec" field.
-func (m *TemplateMutation) ClearSpec() {
-	m.spec = nil
-	m.clearedFields[template.FieldSpec] = struct{}{}
-}
-
-// SpecCleared returns if the "spec" field was cleared in this mutation.
-func (m *TemplateMutation) SpecCleared() bool {
-	_, ok := m.clearedFields[template.FieldSpec]
+// SourceTypeCleared returns if the "source_type" field was cleared in this mutation.
+func (m *TemplateMutation) SourceTypeCleared() bool {
+	_, ok := m.clearedFields[template.FieldSourceType]
 	return ok
 }
 
-// ResetSpec resets all changes to the "spec" field.
-func (m *TemplateMutation) ResetSpec() {
-	m.spec = nil
-	delete(m.clearedFields, template.FieldSpec)
+// ResetSourceType resets all changes to the "source_type" field.
+func (m *TemplateMutation) ResetSourceType() {
+	m.source_type = nil
+	delete(m.clearedFields, template.FieldSourceType)
+}
+
+// SetImageURL sets the "image_url" field.
+func (m *TemplateMutation) SetImageURL(s string) {
+	m.image_url = &s
+}
+
+// ImageURL returns the value of the "image_url" field in the mutation.
+func (m *TemplateMutation) ImageURL() (r string, exists bool) {
+	v := m.image_url
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldImageURL returns the old "image_url" field's value of the Template entity.
+// If the Template object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TemplateMutation) OldImageURL(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldImageURL is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldImageURL requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldImageURL: %w", err)
+	}
+	return oldValue.ImageURL, nil
+}
+
+// ClearImageURL clears the value of the "image_url" field.
+func (m *TemplateMutation) ClearImageURL() {
+	m.image_url = nil
+	m.clearedFields[template.FieldImageURL] = struct{}{}
+}
+
+// ImageURLCleared returns if the "image_url" field was cleared in this mutation.
+func (m *TemplateMutation) ImageURLCleared() bool {
+	_, ok := m.clearedFields[template.FieldImageURL]
+	return ok
+}
+
+// ResetImageURL resets all changes to the "image_url" field.
+func (m *TemplateMutation) ResetImageURL() {
+	m.image_url = nil
+	delete(m.clearedFields, template.FieldImageURL)
+}
+
+// SetPvcName sets the "pvc_name" field.
+func (m *TemplateMutation) SetPvcName(s string) {
+	m.pvc_name = &s
+}
+
+// PvcName returns the value of the "pvc_name" field in the mutation.
+func (m *TemplateMutation) PvcName() (r string, exists bool) {
+	v := m.pvc_name
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPvcName returns the old "pvc_name" field's value of the Template entity.
+// If the Template object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TemplateMutation) OldPvcName(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPvcName is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPvcName requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPvcName: %w", err)
+	}
+	return oldValue.PvcName, nil
+}
+
+// ClearPvcName clears the value of the "pvc_name" field.
+func (m *TemplateMutation) ClearPvcName() {
+	m.pvc_name = nil
+	m.clearedFields[template.FieldPvcName] = struct{}{}
+}
+
+// PvcNameCleared returns if the "pvc_name" field was cleared in this mutation.
+func (m *TemplateMutation) PvcNameCleared() bool {
+	_, ok := m.clearedFields[template.FieldPvcName]
+	return ok
+}
+
+// ResetPvcName resets all changes to the "pvc_name" field.
+func (m *TemplateMutation) ResetPvcName() {
+	m.pvc_name = nil
+	delete(m.clearedFields, template.FieldPvcName)
+}
+
+// SetCloudInit sets the "cloud_init" field.
+func (m *TemplateMutation) SetCloudInit(s string) {
+	m.cloud_init = &s
+}
+
+// CloudInit returns the value of the "cloud_init" field in the mutation.
+func (m *TemplateMutation) CloudInit() (r string, exists bool) {
+	v := m.cloud_init
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCloudInit returns the old "cloud_init" field's value of the Template entity.
+// If the Template object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TemplateMutation) OldCloudInit(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCloudInit is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCloudInit requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCloudInit: %w", err)
+	}
+	return oldValue.CloudInit, nil
+}
+
+// ClearCloudInit clears the value of the "cloud_init" field.
+func (m *TemplateMutation) ClearCloudInit() {
+	m.cloud_init = nil
+	m.clearedFields[template.FieldCloudInit] = struct{}{}
+}
+
+// CloudInitCleared returns if the "cloud_init" field was cleared in this mutation.
+func (m *TemplateMutation) CloudInitCleared() bool {
+	_, ok := m.clearedFields[template.FieldCloudInit]
+	return ok
+}
+
+// ResetCloudInit resets all changes to the "cloud_init" field.
+func (m *TemplateMutation) ResetCloudInit() {
+	m.cloud_init = nil
+	delete(m.clearedFields, template.FieldCloudInit)
 }
 
 // SetOsFamily sets the "os_family" field.
@@ -19402,7 +19384,7 @@ func (m *TemplateMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TemplateMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 13)
 	if m.created_at != nil {
 		fields = append(fields, template.FieldCreatedAt)
 	}
@@ -19418,11 +19400,17 @@ func (m *TemplateMutation) Fields() []string {
 	if m.description != nil {
 		fields = append(fields, template.FieldDescription)
 	}
-	if m.version != nil {
-		fields = append(fields, template.FieldVersion)
+	if m.source_type != nil {
+		fields = append(fields, template.FieldSourceType)
 	}
-	if m.spec != nil {
-		fields = append(fields, template.FieldSpec)
+	if m.image_url != nil {
+		fields = append(fields, template.FieldImageURL)
+	}
+	if m.pvc_name != nil {
+		fields = append(fields, template.FieldPvcName)
+	}
+	if m.cloud_init != nil {
+		fields = append(fields, template.FieldCloudInit)
 	}
 	if m.os_family != nil {
 		fields = append(fields, template.FieldOsFamily)
@@ -19454,10 +19442,14 @@ func (m *TemplateMutation) Field(name string) (ent.Value, bool) {
 		return m.DisplayName()
 	case template.FieldDescription:
 		return m.Description()
-	case template.FieldVersion:
-		return m.Version()
-	case template.FieldSpec:
-		return m.Spec()
+	case template.FieldSourceType:
+		return m.SourceType()
+	case template.FieldImageURL:
+		return m.ImageURL()
+	case template.FieldPvcName:
+		return m.PvcName()
+	case template.FieldCloudInit:
+		return m.CloudInit()
 	case template.FieldOsFamily:
 		return m.OsFamily()
 	case template.FieldOsVersion:
@@ -19485,10 +19477,14 @@ func (m *TemplateMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldDisplayName(ctx)
 	case template.FieldDescription:
 		return m.OldDescription(ctx)
-	case template.FieldVersion:
-		return m.OldVersion(ctx)
-	case template.FieldSpec:
-		return m.OldSpec(ctx)
+	case template.FieldSourceType:
+		return m.OldSourceType(ctx)
+	case template.FieldImageURL:
+		return m.OldImageURL(ctx)
+	case template.FieldPvcName:
+		return m.OldPvcName(ctx)
+	case template.FieldCloudInit:
+		return m.OldCloudInit(ctx)
 	case template.FieldOsFamily:
 		return m.OldOsFamily(ctx)
 	case template.FieldOsVersion:
@@ -19541,19 +19537,33 @@ func (m *TemplateMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetDescription(v)
 		return nil
-	case template.FieldVersion:
-		v, ok := value.(int)
+	case template.FieldSourceType:
+		v, ok := value.(string)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetVersion(v)
+		m.SetSourceType(v)
 		return nil
-	case template.FieldSpec:
-		v, ok := value.(map[string]interface{})
+	case template.FieldImageURL:
+		v, ok := value.(string)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetSpec(v)
+		m.SetImageURL(v)
+		return nil
+	case template.FieldPvcName:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPvcName(v)
+		return nil
+	case template.FieldCloudInit:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCloudInit(v)
 		return nil
 	case template.FieldOsFamily:
 		v, ok := value.(string)
@@ -19590,21 +19600,13 @@ func (m *TemplateMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *TemplateMutation) AddedFields() []string {
-	var fields []string
-	if m.addversion != nil {
-		fields = append(fields, template.FieldVersion)
-	}
-	return fields
+	return nil
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *TemplateMutation) AddedField(name string) (ent.Value, bool) {
-	switch name {
-	case template.FieldVersion:
-		return m.AddedVersion()
-	}
 	return nil, false
 }
 
@@ -19613,13 +19615,6 @@ func (m *TemplateMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *TemplateMutation) AddField(name string, value ent.Value) error {
 	switch name {
-	case template.FieldVersion:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.AddVersion(v)
-		return nil
 	}
 	return fmt.Errorf("unknown Template numeric field %s", name)
 }
@@ -19634,8 +19629,17 @@ func (m *TemplateMutation) ClearedFields() []string {
 	if m.FieldCleared(template.FieldDescription) {
 		fields = append(fields, template.FieldDescription)
 	}
-	if m.FieldCleared(template.FieldSpec) {
-		fields = append(fields, template.FieldSpec)
+	if m.FieldCleared(template.FieldSourceType) {
+		fields = append(fields, template.FieldSourceType)
+	}
+	if m.FieldCleared(template.FieldImageURL) {
+		fields = append(fields, template.FieldImageURL)
+	}
+	if m.FieldCleared(template.FieldPvcName) {
+		fields = append(fields, template.FieldPvcName)
+	}
+	if m.FieldCleared(template.FieldCloudInit) {
+		fields = append(fields, template.FieldCloudInit)
 	}
 	if m.FieldCleared(template.FieldOsFamily) {
 		fields = append(fields, template.FieldOsFamily)
@@ -19663,8 +19667,17 @@ func (m *TemplateMutation) ClearField(name string) error {
 	case template.FieldDescription:
 		m.ClearDescription()
 		return nil
-	case template.FieldSpec:
-		m.ClearSpec()
+	case template.FieldSourceType:
+		m.ClearSourceType()
+		return nil
+	case template.FieldImageURL:
+		m.ClearImageURL()
+		return nil
+	case template.FieldPvcName:
+		m.ClearPvcName()
+		return nil
+	case template.FieldCloudInit:
+		m.ClearCloudInit()
 		return nil
 	case template.FieldOsFamily:
 		m.ClearOsFamily()
@@ -19695,11 +19708,17 @@ func (m *TemplateMutation) ResetField(name string) error {
 	case template.FieldDescription:
 		m.ResetDescription()
 		return nil
-	case template.FieldVersion:
-		m.ResetVersion()
+	case template.FieldSourceType:
+		m.ResetSourceType()
 		return nil
-	case template.FieldSpec:
-		m.ResetSpec()
+	case template.FieldImageURL:
+		m.ResetImageURL()
+		return nil
+	case template.FieldPvcName:
+		m.ResetPvcName()
+		return nil
+	case template.FieldCloudInit:
+		m.ResetCloudInit()
 		return nil
 	case template.FieldOsFamily:
 		m.ResetOsFamily()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -783,18 +783,16 @@ func init() {
 	templateDescName := templateFields[1].Descriptor()
 	// template.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	template.NameValidator = templateDescName.Validators[0].(func(string) error)
-	// templateDescVersion is the schema descriptor for version field.
-	templateDescVersion := templateFields[4].Descriptor()
-	// template.DefaultVersion holds the default value on creation for the version field.
-	template.DefaultVersion = templateDescVersion.Default.(int)
-	// template.VersionValidator is a validator for the "version" field. It is called by the builders before save.
-	template.VersionValidator = templateDescVersion.Validators[0].(func(int) error)
+	// templateDescSourceType is the schema descriptor for source_type field.
+	templateDescSourceType := templateFields[4].Descriptor()
+	// template.DefaultSourceType holds the default value on creation for the source_type field.
+	template.DefaultSourceType = templateDescSourceType.Default.(string)
 	// templateDescEnabled is the schema descriptor for enabled field.
-	templateDescEnabled := templateFields[8].Descriptor()
+	templateDescEnabled := templateFields[10].Descriptor()
 	// template.DefaultEnabled holds the default value on creation for the enabled field.
 	template.DefaultEnabled = templateDescEnabled.Default.(bool)
 	// templateDescCreatedBy is the schema descriptor for created_by field.
-	templateDescCreatedBy := templateFields[9].Descriptor()
+	templateDescCreatedBy := templateFields[11].Descriptor()
 	// template.CreatedByValidator is a validator for the "created_by" field. It is called by the builders before save.
 	template.CreatedByValidator = templateDescCreatedBy.Validators[0].(func(string) error)
 	userMixin := schema.User{}.Mixin()

--- a/ent/schema/approval_ticket.go
+++ b/ent/schema/approval_ticket.go
@@ -48,8 +48,6 @@ func (ApprovalTicket) Fields() []ent.Field {
 		// Admin-determined fields (ADR-0017)
 		field.String("selected_cluster_id").
 			Optional(),
-		field.Int("selected_template_version").
-			Optional(),
 		field.String("selected_storage_class").
 			Optional(),
 		field.JSON("template_snapshot", map[string]interface{}{}).

--- a/ent/schema/template.go
+++ b/ent/schema/template.go
@@ -8,6 +8,7 @@ import (
 
 // Template holds the schema definition for the Template entity.
 // ADR-0018: Templates stored in PostgreSQL, not as YAML files.
+// ADR-0036: Template contains software-baseline only (source + cloud-init).
 type Template struct {
 	ent.Schema
 }
@@ -31,11 +32,23 @@ func (Template) Fields() []ent.Field {
 			Optional(),
 		field.String("description").
 			Optional(),
-		field.Int("version").
-			Default(1).
-			Positive(),
-		field.JSON("spec", map[string]interface{}{}).
-			Optional(), // Full VM template specification
+		// source_type distinguishes ContainerDisk (image) from DataVolume (pvc) boot sources.
+		// ADR-0036: Two boot source modes; mutually exclusive.
+		field.String("source_type").
+			Optional(). // "image" | "pvc"; empty means not yet configured
+			Default(""),
+		// image_url is the container registry URL for ContainerDisk-based templates.
+		// Used when source_type == "image". Example: "quay.io/containerdisks/ubuntu:22.04"
+		field.String("image_url").
+			Optional(),
+		// pvc_name is the DataVolume / PersistentVolumeClaim name for PVC-based templates.
+		// Used when source_type == "pvc". Example: "ubuntu-22.04-base"
+		field.String("pvc_name").
+			Optional(),
+		// cloud_init stores raw cloud-init YAML configuration (userdata).
+		// Applied to VMs at boot time via cloud-init datasource.
+		field.Text("cloud_init").
+			Optional(),
 		field.String("os_family").
 			Optional(), // e.g. "linux", "windows"
 		field.String("os_version").
@@ -50,7 +63,8 @@ func (Template) Fields() []ent.Field {
 // Indexes of the Template.
 func (Template) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("name", "version").Unique(),
+		index.Fields("name").Unique(),
 		index.Fields("enabled"),
+		index.Fields("source_type"),
 	}
 }

--- a/ent/template.go
+++ b/ent/template.go
@@ -3,7 +3,6 @@
 package ent
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -28,10 +27,14 @@ type Template struct {
 	DisplayName string `json:"display_name,omitempty"`
 	// Description holds the value of the "description" field.
 	Description string `json:"description,omitempty"`
-	// Version holds the value of the "version" field.
-	Version int `json:"version,omitempty"`
-	// Spec holds the value of the "spec" field.
-	Spec map[string]interface{} `json:"spec,omitempty"`
+	// SourceType holds the value of the "source_type" field.
+	SourceType string `json:"source_type,omitempty"`
+	// ImageURL holds the value of the "image_url" field.
+	ImageURL string `json:"image_url,omitempty"`
+	// PvcName holds the value of the "pvc_name" field.
+	PvcName string `json:"pvc_name,omitempty"`
+	// CloudInit holds the value of the "cloud_init" field.
+	CloudInit string `json:"cloud_init,omitempty"`
 	// OsFamily holds the value of the "os_family" field.
 	OsFamily string `json:"os_family,omitempty"`
 	// OsVersion holds the value of the "os_version" field.
@@ -48,13 +51,9 @@ func (*Template) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case template.FieldSpec:
-			values[i] = new([]byte)
 		case template.FieldEnabled:
 			values[i] = new(sql.NullBool)
-		case template.FieldVersion:
-			values[i] = new(sql.NullInt64)
-		case template.FieldID, template.FieldName, template.FieldDisplayName, template.FieldDescription, template.FieldOsFamily, template.FieldOsVersion, template.FieldCreatedBy:
+		case template.FieldID, template.FieldName, template.FieldDisplayName, template.FieldDescription, template.FieldSourceType, template.FieldImageURL, template.FieldPvcName, template.FieldCloudInit, template.FieldOsFamily, template.FieldOsVersion, template.FieldCreatedBy:
 			values[i] = new(sql.NullString)
 		case template.FieldCreatedAt, template.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -109,19 +108,29 @@ func (_m *Template) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.Description = value.String
 			}
-		case template.FieldVersion:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field version", values[i])
+		case template.FieldSourceType:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field source_type", values[i])
 			} else if value.Valid {
-				_m.Version = int(value.Int64)
+				_m.SourceType = value.String
 			}
-		case template.FieldSpec:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field spec", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.Spec); err != nil {
-					return fmt.Errorf("unmarshal field spec: %w", err)
-				}
+		case template.FieldImageURL:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field image_url", values[i])
+			} else if value.Valid {
+				_m.ImageURL = value.String
+			}
+		case template.FieldPvcName:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field pvc_name", values[i])
+			} else if value.Valid {
+				_m.PvcName = value.String
+			}
+		case template.FieldCloudInit:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field cloud_init", values[i])
+			} else if value.Valid {
+				_m.CloudInit = value.String
 			}
 		case template.FieldOsFamily:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -198,11 +207,17 @@ func (_m *Template) String() string {
 	builder.WriteString("description=")
 	builder.WriteString(_m.Description)
 	builder.WriteString(", ")
-	builder.WriteString("version=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Version))
+	builder.WriteString("source_type=")
+	builder.WriteString(_m.SourceType)
 	builder.WriteString(", ")
-	builder.WriteString("spec=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Spec))
+	builder.WriteString("image_url=")
+	builder.WriteString(_m.ImageURL)
+	builder.WriteString(", ")
+	builder.WriteString("pvc_name=")
+	builder.WriteString(_m.PvcName)
+	builder.WriteString(", ")
+	builder.WriteString("cloud_init=")
+	builder.WriteString(_m.CloudInit)
 	builder.WriteString(", ")
 	builder.WriteString("os_family=")
 	builder.WriteString(_m.OsFamily)

--- a/ent/template/template.go
+++ b/ent/template/template.go
@@ -23,10 +23,14 @@ const (
 	FieldDisplayName = "display_name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
-	// FieldVersion holds the string denoting the version field in the database.
-	FieldVersion = "version"
-	// FieldSpec holds the string denoting the spec field in the database.
-	FieldSpec = "spec"
+	// FieldSourceType holds the string denoting the source_type field in the database.
+	FieldSourceType = "source_type"
+	// FieldImageURL holds the string denoting the image_url field in the database.
+	FieldImageURL = "image_url"
+	// FieldPvcName holds the string denoting the pvc_name field in the database.
+	FieldPvcName = "pvc_name"
+	// FieldCloudInit holds the string denoting the cloud_init field in the database.
+	FieldCloudInit = "cloud_init"
 	// FieldOsFamily holds the string denoting the os_family field in the database.
 	FieldOsFamily = "os_family"
 	// FieldOsVersion holds the string denoting the os_version field in the database.
@@ -47,8 +51,10 @@ var Columns = []string{
 	FieldName,
 	FieldDisplayName,
 	FieldDescription,
-	FieldVersion,
-	FieldSpec,
+	FieldSourceType,
+	FieldImageURL,
+	FieldPvcName,
+	FieldCloudInit,
 	FieldOsFamily,
 	FieldOsVersion,
 	FieldEnabled,
@@ -74,10 +80,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
-	// DefaultVersion holds the default value on creation for the "version" field.
-	DefaultVersion int
-	// VersionValidator is a validator for the "version" field. It is called by the builders before save.
-	VersionValidator func(int) error
+	// DefaultSourceType holds the default value on creation for the "source_type" field.
+	DefaultSourceType string
 	// DefaultEnabled holds the default value on creation for the "enabled" field.
 	DefaultEnabled bool
 	// CreatedByValidator is a validator for the "created_by" field. It is called by the builders before save.
@@ -117,9 +121,24 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
 }
 
-// ByVersion orders the results by the version field.
-func ByVersion(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldVersion, opts...).ToFunc()
+// BySourceType orders the results by the source_type field.
+func BySourceType(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSourceType, opts...).ToFunc()
+}
+
+// ByImageURL orders the results by the image_url field.
+func ByImageURL(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldImageURL, opts...).ToFunc()
+}
+
+// ByPvcName orders the results by the pvc_name field.
+func ByPvcName(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPvcName, opts...).ToFunc()
+}
+
+// ByCloudInit orders the results by the cloud_init field.
+func ByCloudInit(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCloudInit, opts...).ToFunc()
 }
 
 // ByOsFamily orders the results by the os_family field.

--- a/ent/template/where.go
+++ b/ent/template/where.go
@@ -89,9 +89,24 @@ func Description(v string) predicate.Template {
 	return predicate.Template(sql.FieldEQ(FieldDescription, v))
 }
 
-// Version applies equality check predicate on the "version" field. It's identical to VersionEQ.
-func Version(v int) predicate.Template {
-	return predicate.Template(sql.FieldEQ(FieldVersion, v))
+// SourceType applies equality check predicate on the "source_type" field. It's identical to SourceTypeEQ.
+func SourceType(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldSourceType, v))
+}
+
+// ImageURL applies equality check predicate on the "image_url" field. It's identical to ImageURLEQ.
+func ImageURL(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldImageURL, v))
+}
+
+// PvcName applies equality check predicate on the "pvc_name" field. It's identical to PvcNameEQ.
+func PvcName(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldPvcName, v))
+}
+
+// CloudInit applies equality check predicate on the "cloud_init" field. It's identical to CloudInitEQ.
+func CloudInit(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldCloudInit, v))
 }
 
 // OsFamily applies equality check predicate on the "os_family" field. It's identical to OsFamilyEQ.
@@ -409,54 +424,304 @@ func DescriptionContainsFold(v string) predicate.Template {
 	return predicate.Template(sql.FieldContainsFold(FieldDescription, v))
 }
 
-// VersionEQ applies the EQ predicate on the "version" field.
-func VersionEQ(v int) predicate.Template {
-	return predicate.Template(sql.FieldEQ(FieldVersion, v))
+// SourceTypeEQ applies the EQ predicate on the "source_type" field.
+func SourceTypeEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldSourceType, v))
 }
 
-// VersionNEQ applies the NEQ predicate on the "version" field.
-func VersionNEQ(v int) predicate.Template {
-	return predicate.Template(sql.FieldNEQ(FieldVersion, v))
+// SourceTypeNEQ applies the NEQ predicate on the "source_type" field.
+func SourceTypeNEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldNEQ(FieldSourceType, v))
 }
 
-// VersionIn applies the In predicate on the "version" field.
-func VersionIn(vs ...int) predicate.Template {
-	return predicate.Template(sql.FieldIn(FieldVersion, vs...))
+// SourceTypeIn applies the In predicate on the "source_type" field.
+func SourceTypeIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldIn(FieldSourceType, vs...))
 }
 
-// VersionNotIn applies the NotIn predicate on the "version" field.
-func VersionNotIn(vs ...int) predicate.Template {
-	return predicate.Template(sql.FieldNotIn(FieldVersion, vs...))
+// SourceTypeNotIn applies the NotIn predicate on the "source_type" field.
+func SourceTypeNotIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldNotIn(FieldSourceType, vs...))
 }
 
-// VersionGT applies the GT predicate on the "version" field.
-func VersionGT(v int) predicate.Template {
-	return predicate.Template(sql.FieldGT(FieldVersion, v))
+// SourceTypeGT applies the GT predicate on the "source_type" field.
+func SourceTypeGT(v string) predicate.Template {
+	return predicate.Template(sql.FieldGT(FieldSourceType, v))
 }
 
-// VersionGTE applies the GTE predicate on the "version" field.
-func VersionGTE(v int) predicate.Template {
-	return predicate.Template(sql.FieldGTE(FieldVersion, v))
+// SourceTypeGTE applies the GTE predicate on the "source_type" field.
+func SourceTypeGTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldGTE(FieldSourceType, v))
 }
 
-// VersionLT applies the LT predicate on the "version" field.
-func VersionLT(v int) predicate.Template {
-	return predicate.Template(sql.FieldLT(FieldVersion, v))
+// SourceTypeLT applies the LT predicate on the "source_type" field.
+func SourceTypeLT(v string) predicate.Template {
+	return predicate.Template(sql.FieldLT(FieldSourceType, v))
 }
 
-// VersionLTE applies the LTE predicate on the "version" field.
-func VersionLTE(v int) predicate.Template {
-	return predicate.Template(sql.FieldLTE(FieldVersion, v))
+// SourceTypeLTE applies the LTE predicate on the "source_type" field.
+func SourceTypeLTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldLTE(FieldSourceType, v))
 }
 
-// SpecIsNil applies the IsNil predicate on the "spec" field.
-func SpecIsNil() predicate.Template {
-	return predicate.Template(sql.FieldIsNull(FieldSpec))
+// SourceTypeContains applies the Contains predicate on the "source_type" field.
+func SourceTypeContains(v string) predicate.Template {
+	return predicate.Template(sql.FieldContains(FieldSourceType, v))
 }
 
-// SpecNotNil applies the NotNil predicate on the "spec" field.
-func SpecNotNil() predicate.Template {
-	return predicate.Template(sql.FieldNotNull(FieldSpec))
+// SourceTypeHasPrefix applies the HasPrefix predicate on the "source_type" field.
+func SourceTypeHasPrefix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasPrefix(FieldSourceType, v))
+}
+
+// SourceTypeHasSuffix applies the HasSuffix predicate on the "source_type" field.
+func SourceTypeHasSuffix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasSuffix(FieldSourceType, v))
+}
+
+// SourceTypeIsNil applies the IsNil predicate on the "source_type" field.
+func SourceTypeIsNil() predicate.Template {
+	return predicate.Template(sql.FieldIsNull(FieldSourceType))
+}
+
+// SourceTypeNotNil applies the NotNil predicate on the "source_type" field.
+func SourceTypeNotNil() predicate.Template {
+	return predicate.Template(sql.FieldNotNull(FieldSourceType))
+}
+
+// SourceTypeEqualFold applies the EqualFold predicate on the "source_type" field.
+func SourceTypeEqualFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldEqualFold(FieldSourceType, v))
+}
+
+// SourceTypeContainsFold applies the ContainsFold predicate on the "source_type" field.
+func SourceTypeContainsFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldContainsFold(FieldSourceType, v))
+}
+
+// ImageURLEQ applies the EQ predicate on the "image_url" field.
+func ImageURLEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldImageURL, v))
+}
+
+// ImageURLNEQ applies the NEQ predicate on the "image_url" field.
+func ImageURLNEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldNEQ(FieldImageURL, v))
+}
+
+// ImageURLIn applies the In predicate on the "image_url" field.
+func ImageURLIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldIn(FieldImageURL, vs...))
+}
+
+// ImageURLNotIn applies the NotIn predicate on the "image_url" field.
+func ImageURLNotIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldNotIn(FieldImageURL, vs...))
+}
+
+// ImageURLGT applies the GT predicate on the "image_url" field.
+func ImageURLGT(v string) predicate.Template {
+	return predicate.Template(sql.FieldGT(FieldImageURL, v))
+}
+
+// ImageURLGTE applies the GTE predicate on the "image_url" field.
+func ImageURLGTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldGTE(FieldImageURL, v))
+}
+
+// ImageURLLT applies the LT predicate on the "image_url" field.
+func ImageURLLT(v string) predicate.Template {
+	return predicate.Template(sql.FieldLT(FieldImageURL, v))
+}
+
+// ImageURLLTE applies the LTE predicate on the "image_url" field.
+func ImageURLLTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldLTE(FieldImageURL, v))
+}
+
+// ImageURLContains applies the Contains predicate on the "image_url" field.
+func ImageURLContains(v string) predicate.Template {
+	return predicate.Template(sql.FieldContains(FieldImageURL, v))
+}
+
+// ImageURLHasPrefix applies the HasPrefix predicate on the "image_url" field.
+func ImageURLHasPrefix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasPrefix(FieldImageURL, v))
+}
+
+// ImageURLHasSuffix applies the HasSuffix predicate on the "image_url" field.
+func ImageURLHasSuffix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasSuffix(FieldImageURL, v))
+}
+
+// ImageURLIsNil applies the IsNil predicate on the "image_url" field.
+func ImageURLIsNil() predicate.Template {
+	return predicate.Template(sql.FieldIsNull(FieldImageURL))
+}
+
+// ImageURLNotNil applies the NotNil predicate on the "image_url" field.
+func ImageURLNotNil() predicate.Template {
+	return predicate.Template(sql.FieldNotNull(FieldImageURL))
+}
+
+// ImageURLEqualFold applies the EqualFold predicate on the "image_url" field.
+func ImageURLEqualFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldEqualFold(FieldImageURL, v))
+}
+
+// ImageURLContainsFold applies the ContainsFold predicate on the "image_url" field.
+func ImageURLContainsFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldContainsFold(FieldImageURL, v))
+}
+
+// PvcNameEQ applies the EQ predicate on the "pvc_name" field.
+func PvcNameEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldPvcName, v))
+}
+
+// PvcNameNEQ applies the NEQ predicate on the "pvc_name" field.
+func PvcNameNEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldNEQ(FieldPvcName, v))
+}
+
+// PvcNameIn applies the In predicate on the "pvc_name" field.
+func PvcNameIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldIn(FieldPvcName, vs...))
+}
+
+// PvcNameNotIn applies the NotIn predicate on the "pvc_name" field.
+func PvcNameNotIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldNotIn(FieldPvcName, vs...))
+}
+
+// PvcNameGT applies the GT predicate on the "pvc_name" field.
+func PvcNameGT(v string) predicate.Template {
+	return predicate.Template(sql.FieldGT(FieldPvcName, v))
+}
+
+// PvcNameGTE applies the GTE predicate on the "pvc_name" field.
+func PvcNameGTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldGTE(FieldPvcName, v))
+}
+
+// PvcNameLT applies the LT predicate on the "pvc_name" field.
+func PvcNameLT(v string) predicate.Template {
+	return predicate.Template(sql.FieldLT(FieldPvcName, v))
+}
+
+// PvcNameLTE applies the LTE predicate on the "pvc_name" field.
+func PvcNameLTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldLTE(FieldPvcName, v))
+}
+
+// PvcNameContains applies the Contains predicate on the "pvc_name" field.
+func PvcNameContains(v string) predicate.Template {
+	return predicate.Template(sql.FieldContains(FieldPvcName, v))
+}
+
+// PvcNameHasPrefix applies the HasPrefix predicate on the "pvc_name" field.
+func PvcNameHasPrefix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasPrefix(FieldPvcName, v))
+}
+
+// PvcNameHasSuffix applies the HasSuffix predicate on the "pvc_name" field.
+func PvcNameHasSuffix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasSuffix(FieldPvcName, v))
+}
+
+// PvcNameIsNil applies the IsNil predicate on the "pvc_name" field.
+func PvcNameIsNil() predicate.Template {
+	return predicate.Template(sql.FieldIsNull(FieldPvcName))
+}
+
+// PvcNameNotNil applies the NotNil predicate on the "pvc_name" field.
+func PvcNameNotNil() predicate.Template {
+	return predicate.Template(sql.FieldNotNull(FieldPvcName))
+}
+
+// PvcNameEqualFold applies the EqualFold predicate on the "pvc_name" field.
+func PvcNameEqualFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldEqualFold(FieldPvcName, v))
+}
+
+// PvcNameContainsFold applies the ContainsFold predicate on the "pvc_name" field.
+func PvcNameContainsFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldContainsFold(FieldPvcName, v))
+}
+
+// CloudInitEQ applies the EQ predicate on the "cloud_init" field.
+func CloudInitEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldCloudInit, v))
+}
+
+// CloudInitNEQ applies the NEQ predicate on the "cloud_init" field.
+func CloudInitNEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldNEQ(FieldCloudInit, v))
+}
+
+// CloudInitIn applies the In predicate on the "cloud_init" field.
+func CloudInitIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldIn(FieldCloudInit, vs...))
+}
+
+// CloudInitNotIn applies the NotIn predicate on the "cloud_init" field.
+func CloudInitNotIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldNotIn(FieldCloudInit, vs...))
+}
+
+// CloudInitGT applies the GT predicate on the "cloud_init" field.
+func CloudInitGT(v string) predicate.Template {
+	return predicate.Template(sql.FieldGT(FieldCloudInit, v))
+}
+
+// CloudInitGTE applies the GTE predicate on the "cloud_init" field.
+func CloudInitGTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldGTE(FieldCloudInit, v))
+}
+
+// CloudInitLT applies the LT predicate on the "cloud_init" field.
+func CloudInitLT(v string) predicate.Template {
+	return predicate.Template(sql.FieldLT(FieldCloudInit, v))
+}
+
+// CloudInitLTE applies the LTE predicate on the "cloud_init" field.
+func CloudInitLTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldLTE(FieldCloudInit, v))
+}
+
+// CloudInitContains applies the Contains predicate on the "cloud_init" field.
+func CloudInitContains(v string) predicate.Template {
+	return predicate.Template(sql.FieldContains(FieldCloudInit, v))
+}
+
+// CloudInitHasPrefix applies the HasPrefix predicate on the "cloud_init" field.
+func CloudInitHasPrefix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasPrefix(FieldCloudInit, v))
+}
+
+// CloudInitHasSuffix applies the HasSuffix predicate on the "cloud_init" field.
+func CloudInitHasSuffix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasSuffix(FieldCloudInit, v))
+}
+
+// CloudInitIsNil applies the IsNil predicate on the "cloud_init" field.
+func CloudInitIsNil() predicate.Template {
+	return predicate.Template(sql.FieldIsNull(FieldCloudInit))
+}
+
+// CloudInitNotNil applies the NotNil predicate on the "cloud_init" field.
+func CloudInitNotNil() predicate.Template {
+	return predicate.Template(sql.FieldNotNull(FieldCloudInit))
+}
+
+// CloudInitEqualFold applies the EqualFold predicate on the "cloud_init" field.
+func CloudInitEqualFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldEqualFold(FieldCloudInit, v))
+}
+
+// CloudInitContainsFold applies the ContainsFold predicate on the "cloud_init" field.
+func CloudInitContainsFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldContainsFold(FieldCloudInit, v))
 }
 
 // OsFamilyEQ applies the EQ predicate on the "os_family" field.

--- a/ent/template_create.go
+++ b/ent/template_create.go
@@ -82,23 +82,59 @@ func (_c *TemplateCreate) SetNillableDescription(v *string) *TemplateCreate {
 	return _c
 }
 
-// SetVersion sets the "version" field.
-func (_c *TemplateCreate) SetVersion(v int) *TemplateCreate {
-	_c.mutation.SetVersion(v)
+// SetSourceType sets the "source_type" field.
+func (_c *TemplateCreate) SetSourceType(v string) *TemplateCreate {
+	_c.mutation.SetSourceType(v)
 	return _c
 }
 
-// SetNillableVersion sets the "version" field if the given value is not nil.
-func (_c *TemplateCreate) SetNillableVersion(v *int) *TemplateCreate {
+// SetNillableSourceType sets the "source_type" field if the given value is not nil.
+func (_c *TemplateCreate) SetNillableSourceType(v *string) *TemplateCreate {
 	if v != nil {
-		_c.SetVersion(*v)
+		_c.SetSourceType(*v)
 	}
 	return _c
 }
 
-// SetSpec sets the "spec" field.
-func (_c *TemplateCreate) SetSpec(v map[string]interface{}) *TemplateCreate {
-	_c.mutation.SetSpec(v)
+// SetImageURL sets the "image_url" field.
+func (_c *TemplateCreate) SetImageURL(v string) *TemplateCreate {
+	_c.mutation.SetImageURL(v)
+	return _c
+}
+
+// SetNillableImageURL sets the "image_url" field if the given value is not nil.
+func (_c *TemplateCreate) SetNillableImageURL(v *string) *TemplateCreate {
+	if v != nil {
+		_c.SetImageURL(*v)
+	}
+	return _c
+}
+
+// SetPvcName sets the "pvc_name" field.
+func (_c *TemplateCreate) SetPvcName(v string) *TemplateCreate {
+	_c.mutation.SetPvcName(v)
+	return _c
+}
+
+// SetNillablePvcName sets the "pvc_name" field if the given value is not nil.
+func (_c *TemplateCreate) SetNillablePvcName(v *string) *TemplateCreate {
+	if v != nil {
+		_c.SetPvcName(*v)
+	}
+	return _c
+}
+
+// SetCloudInit sets the "cloud_init" field.
+func (_c *TemplateCreate) SetCloudInit(v string) *TemplateCreate {
+	_c.mutation.SetCloudInit(v)
+	return _c
+}
+
+// SetNillableCloudInit sets the "cloud_init" field if the given value is not nil.
+func (_c *TemplateCreate) SetNillableCloudInit(v *string) *TemplateCreate {
+	if v != nil {
+		_c.SetCloudInit(*v)
+	}
 	return _c
 }
 
@@ -199,9 +235,9 @@ func (_c *TemplateCreate) defaults() {
 		v := template.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
-	if _, ok := _c.mutation.Version(); !ok {
-		v := template.DefaultVersion
-		_c.mutation.SetVersion(v)
+	if _, ok := _c.mutation.SourceType(); !ok {
+		v := template.DefaultSourceType
+		_c.mutation.SetSourceType(v)
 	}
 	if _, ok := _c.mutation.Enabled(); !ok {
 		v := template.DefaultEnabled
@@ -223,14 +259,6 @@ func (_c *TemplateCreate) check() error {
 	if v, ok := _c.mutation.Name(); ok {
 		if err := template.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Template.name": %w`, err)}
-		}
-	}
-	if _, ok := _c.mutation.Version(); !ok {
-		return &ValidationError{Name: "version", err: errors.New(`ent: missing required field "Template.version"`)}
-	}
-	if v, ok := _c.mutation.Version(); ok {
-		if err := template.VersionValidator(v); err != nil {
-			return &ValidationError{Name: "version", err: fmt.Errorf(`ent: validator failed for field "Template.version": %w`, err)}
 		}
 	}
 	if _, ok := _c.mutation.Enabled(); !ok {
@@ -299,13 +327,21 @@ func (_c *TemplateCreate) createSpec() (*Template, *sqlgraph.CreateSpec) {
 		_spec.SetField(template.FieldDescription, field.TypeString, value)
 		_node.Description = value
 	}
-	if value, ok := _c.mutation.Version(); ok {
-		_spec.SetField(template.FieldVersion, field.TypeInt, value)
-		_node.Version = value
+	if value, ok := _c.mutation.SourceType(); ok {
+		_spec.SetField(template.FieldSourceType, field.TypeString, value)
+		_node.SourceType = value
 	}
-	if value, ok := _c.mutation.Spec(); ok {
-		_spec.SetField(template.FieldSpec, field.TypeJSON, value)
-		_node.Spec = value
+	if value, ok := _c.mutation.ImageURL(); ok {
+		_spec.SetField(template.FieldImageURL, field.TypeString, value)
+		_node.ImageURL = value
+	}
+	if value, ok := _c.mutation.PvcName(); ok {
+		_spec.SetField(template.FieldPvcName, field.TypeString, value)
+		_node.PvcName = value
+	}
+	if value, ok := _c.mutation.CloudInit(); ok {
+		_spec.SetField(template.FieldCloudInit, field.TypeString, value)
+		_node.CloudInit = value
 	}
 	if value, ok := _c.mutation.OsFamily(); ok {
 		_spec.SetField(template.FieldOsFamily, field.TypeString, value)

--- a/ent/template_update.go
+++ b/ent/template_update.go
@@ -88,36 +88,83 @@ func (_u *TemplateUpdate) ClearDescription() *TemplateUpdate {
 	return _u
 }
 
-// SetVersion sets the "version" field.
-func (_u *TemplateUpdate) SetVersion(v int) *TemplateUpdate {
-	_u.mutation.ResetVersion()
-	_u.mutation.SetVersion(v)
+// SetSourceType sets the "source_type" field.
+func (_u *TemplateUpdate) SetSourceType(v string) *TemplateUpdate {
+	_u.mutation.SetSourceType(v)
 	return _u
 }
 
-// SetNillableVersion sets the "version" field if the given value is not nil.
-func (_u *TemplateUpdate) SetNillableVersion(v *int) *TemplateUpdate {
+// SetNillableSourceType sets the "source_type" field if the given value is not nil.
+func (_u *TemplateUpdate) SetNillableSourceType(v *string) *TemplateUpdate {
 	if v != nil {
-		_u.SetVersion(*v)
+		_u.SetSourceType(*v)
 	}
 	return _u
 }
 
-// AddVersion adds value to the "version" field.
-func (_u *TemplateUpdate) AddVersion(v int) *TemplateUpdate {
-	_u.mutation.AddVersion(v)
+// ClearSourceType clears the value of the "source_type" field.
+func (_u *TemplateUpdate) ClearSourceType() *TemplateUpdate {
+	_u.mutation.ClearSourceType()
 	return _u
 }
 
-// SetSpec sets the "spec" field.
-func (_u *TemplateUpdate) SetSpec(v map[string]interface{}) *TemplateUpdate {
-	_u.mutation.SetSpec(v)
+// SetImageURL sets the "image_url" field.
+func (_u *TemplateUpdate) SetImageURL(v string) *TemplateUpdate {
+	_u.mutation.SetImageURL(v)
 	return _u
 }
 
-// ClearSpec clears the value of the "spec" field.
-func (_u *TemplateUpdate) ClearSpec() *TemplateUpdate {
-	_u.mutation.ClearSpec()
+// SetNillableImageURL sets the "image_url" field if the given value is not nil.
+func (_u *TemplateUpdate) SetNillableImageURL(v *string) *TemplateUpdate {
+	if v != nil {
+		_u.SetImageURL(*v)
+	}
+	return _u
+}
+
+// ClearImageURL clears the value of the "image_url" field.
+func (_u *TemplateUpdate) ClearImageURL() *TemplateUpdate {
+	_u.mutation.ClearImageURL()
+	return _u
+}
+
+// SetPvcName sets the "pvc_name" field.
+func (_u *TemplateUpdate) SetPvcName(v string) *TemplateUpdate {
+	_u.mutation.SetPvcName(v)
+	return _u
+}
+
+// SetNillablePvcName sets the "pvc_name" field if the given value is not nil.
+func (_u *TemplateUpdate) SetNillablePvcName(v *string) *TemplateUpdate {
+	if v != nil {
+		_u.SetPvcName(*v)
+	}
+	return _u
+}
+
+// ClearPvcName clears the value of the "pvc_name" field.
+func (_u *TemplateUpdate) ClearPvcName() *TemplateUpdate {
+	_u.mutation.ClearPvcName()
+	return _u
+}
+
+// SetCloudInit sets the "cloud_init" field.
+func (_u *TemplateUpdate) SetCloudInit(v string) *TemplateUpdate {
+	_u.mutation.SetCloudInit(v)
+	return _u
+}
+
+// SetNillableCloudInit sets the "cloud_init" field if the given value is not nil.
+func (_u *TemplateUpdate) SetNillableCloudInit(v *string) *TemplateUpdate {
+	if v != nil {
+		_u.SetCloudInit(*v)
+	}
+	return _u
+}
+
+// ClearCloudInit clears the value of the "cloud_init" field.
+func (_u *TemplateUpdate) ClearCloudInit() *TemplateUpdate {
+	_u.mutation.ClearCloudInit()
 	return _u
 }
 
@@ -237,11 +284,6 @@ func (_u *TemplateUpdate) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Template.name": %w`, err)}
 		}
 	}
-	if v, ok := _u.mutation.Version(); ok {
-		if err := template.VersionValidator(v); err != nil {
-			return &ValidationError{Name: "version", err: fmt.Errorf(`ent: validator failed for field "Template.version": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.CreatedBy(); ok {
 		if err := template.CreatedByValidator(v); err != nil {
 			return &ValidationError{Name: "created_by", err: fmt.Errorf(`ent: validator failed for field "Template.created_by": %w`, err)}
@@ -280,17 +322,29 @@ func (_u *TemplateUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(template.FieldDescription, field.TypeString)
 	}
-	if value, ok := _u.mutation.Version(); ok {
-		_spec.SetField(template.FieldVersion, field.TypeInt, value)
+	if value, ok := _u.mutation.SourceType(); ok {
+		_spec.SetField(template.FieldSourceType, field.TypeString, value)
 	}
-	if value, ok := _u.mutation.AddedVersion(); ok {
-		_spec.AddField(template.FieldVersion, field.TypeInt, value)
+	if _u.mutation.SourceTypeCleared() {
+		_spec.ClearField(template.FieldSourceType, field.TypeString)
 	}
-	if value, ok := _u.mutation.Spec(); ok {
-		_spec.SetField(template.FieldSpec, field.TypeJSON, value)
+	if value, ok := _u.mutation.ImageURL(); ok {
+		_spec.SetField(template.FieldImageURL, field.TypeString, value)
 	}
-	if _u.mutation.SpecCleared() {
-		_spec.ClearField(template.FieldSpec, field.TypeJSON)
+	if _u.mutation.ImageURLCleared() {
+		_spec.ClearField(template.FieldImageURL, field.TypeString)
+	}
+	if value, ok := _u.mutation.PvcName(); ok {
+		_spec.SetField(template.FieldPvcName, field.TypeString, value)
+	}
+	if _u.mutation.PvcNameCleared() {
+		_spec.ClearField(template.FieldPvcName, field.TypeString)
+	}
+	if value, ok := _u.mutation.CloudInit(); ok {
+		_spec.SetField(template.FieldCloudInit, field.TypeString, value)
+	}
+	if _u.mutation.CloudInitCleared() {
+		_spec.ClearField(template.FieldCloudInit, field.TypeString)
 	}
 	if value, ok := _u.mutation.OsFamily(); ok {
 		_spec.SetField(template.FieldOsFamily, field.TypeString, value)
@@ -390,36 +444,83 @@ func (_u *TemplateUpdateOne) ClearDescription() *TemplateUpdateOne {
 	return _u
 }
 
-// SetVersion sets the "version" field.
-func (_u *TemplateUpdateOne) SetVersion(v int) *TemplateUpdateOne {
-	_u.mutation.ResetVersion()
-	_u.mutation.SetVersion(v)
+// SetSourceType sets the "source_type" field.
+func (_u *TemplateUpdateOne) SetSourceType(v string) *TemplateUpdateOne {
+	_u.mutation.SetSourceType(v)
 	return _u
 }
 
-// SetNillableVersion sets the "version" field if the given value is not nil.
-func (_u *TemplateUpdateOne) SetNillableVersion(v *int) *TemplateUpdateOne {
+// SetNillableSourceType sets the "source_type" field if the given value is not nil.
+func (_u *TemplateUpdateOne) SetNillableSourceType(v *string) *TemplateUpdateOne {
 	if v != nil {
-		_u.SetVersion(*v)
+		_u.SetSourceType(*v)
 	}
 	return _u
 }
 
-// AddVersion adds value to the "version" field.
-func (_u *TemplateUpdateOne) AddVersion(v int) *TemplateUpdateOne {
-	_u.mutation.AddVersion(v)
+// ClearSourceType clears the value of the "source_type" field.
+func (_u *TemplateUpdateOne) ClearSourceType() *TemplateUpdateOne {
+	_u.mutation.ClearSourceType()
 	return _u
 }
 
-// SetSpec sets the "spec" field.
-func (_u *TemplateUpdateOne) SetSpec(v map[string]interface{}) *TemplateUpdateOne {
-	_u.mutation.SetSpec(v)
+// SetImageURL sets the "image_url" field.
+func (_u *TemplateUpdateOne) SetImageURL(v string) *TemplateUpdateOne {
+	_u.mutation.SetImageURL(v)
 	return _u
 }
 
-// ClearSpec clears the value of the "spec" field.
-func (_u *TemplateUpdateOne) ClearSpec() *TemplateUpdateOne {
-	_u.mutation.ClearSpec()
+// SetNillableImageURL sets the "image_url" field if the given value is not nil.
+func (_u *TemplateUpdateOne) SetNillableImageURL(v *string) *TemplateUpdateOne {
+	if v != nil {
+		_u.SetImageURL(*v)
+	}
+	return _u
+}
+
+// ClearImageURL clears the value of the "image_url" field.
+func (_u *TemplateUpdateOne) ClearImageURL() *TemplateUpdateOne {
+	_u.mutation.ClearImageURL()
+	return _u
+}
+
+// SetPvcName sets the "pvc_name" field.
+func (_u *TemplateUpdateOne) SetPvcName(v string) *TemplateUpdateOne {
+	_u.mutation.SetPvcName(v)
+	return _u
+}
+
+// SetNillablePvcName sets the "pvc_name" field if the given value is not nil.
+func (_u *TemplateUpdateOne) SetNillablePvcName(v *string) *TemplateUpdateOne {
+	if v != nil {
+		_u.SetPvcName(*v)
+	}
+	return _u
+}
+
+// ClearPvcName clears the value of the "pvc_name" field.
+func (_u *TemplateUpdateOne) ClearPvcName() *TemplateUpdateOne {
+	_u.mutation.ClearPvcName()
+	return _u
+}
+
+// SetCloudInit sets the "cloud_init" field.
+func (_u *TemplateUpdateOne) SetCloudInit(v string) *TemplateUpdateOne {
+	_u.mutation.SetCloudInit(v)
+	return _u
+}
+
+// SetNillableCloudInit sets the "cloud_init" field if the given value is not nil.
+func (_u *TemplateUpdateOne) SetNillableCloudInit(v *string) *TemplateUpdateOne {
+	if v != nil {
+		_u.SetCloudInit(*v)
+	}
+	return _u
+}
+
+// ClearCloudInit clears the value of the "cloud_init" field.
+func (_u *TemplateUpdateOne) ClearCloudInit() *TemplateUpdateOne {
+	_u.mutation.ClearCloudInit()
 	return _u
 }
 
@@ -552,11 +653,6 @@ func (_u *TemplateUpdateOne) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Template.name": %w`, err)}
 		}
 	}
-	if v, ok := _u.mutation.Version(); ok {
-		if err := template.VersionValidator(v); err != nil {
-			return &ValidationError{Name: "version", err: fmt.Errorf(`ent: validator failed for field "Template.version": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.CreatedBy(); ok {
 		if err := template.CreatedByValidator(v); err != nil {
 			return &ValidationError{Name: "created_by", err: fmt.Errorf(`ent: validator failed for field "Template.created_by": %w`, err)}
@@ -612,17 +708,29 @@ func (_u *TemplateUpdateOne) sqlSave(ctx context.Context) (_node *Template, err 
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(template.FieldDescription, field.TypeString)
 	}
-	if value, ok := _u.mutation.Version(); ok {
-		_spec.SetField(template.FieldVersion, field.TypeInt, value)
+	if value, ok := _u.mutation.SourceType(); ok {
+		_spec.SetField(template.FieldSourceType, field.TypeString, value)
 	}
-	if value, ok := _u.mutation.AddedVersion(); ok {
-		_spec.AddField(template.FieldVersion, field.TypeInt, value)
+	if _u.mutation.SourceTypeCleared() {
+		_spec.ClearField(template.FieldSourceType, field.TypeString)
 	}
-	if value, ok := _u.mutation.Spec(); ok {
-		_spec.SetField(template.FieldSpec, field.TypeJSON, value)
+	if value, ok := _u.mutation.ImageURL(); ok {
+		_spec.SetField(template.FieldImageURL, field.TypeString, value)
 	}
-	if _u.mutation.SpecCleared() {
-		_spec.ClearField(template.FieldSpec, field.TypeJSON)
+	if _u.mutation.ImageURLCleared() {
+		_spec.ClearField(template.FieldImageURL, field.TypeString)
+	}
+	if value, ok := _u.mutation.PvcName(); ok {
+		_spec.SetField(template.FieldPvcName, field.TypeString, value)
+	}
+	if _u.mutation.PvcNameCleared() {
+		_spec.ClearField(template.FieldPvcName, field.TypeString)
+	}
+	if value, ok := _u.mutation.CloudInit(); ok {
+		_spec.SetField(template.FieldCloudInit, field.TypeString, value)
+	}
+	if _u.mutation.CloudInitCleared() {
+		_spec.ClearField(template.FieldCloudInit, field.TypeString)
 	}
 	if value, ok := _u.mutation.OsFamily(); ok {
 		_spec.SetField(template.FieldOsFamily, field.TypeString, value)


### PR DESCRIPTION
## Summary
Align Ent schema and generated artifacts with ADR-0036 template boundary.

## Changes
- replace template version/spec model with semantic source fields
- regenerate Ent artifacts and migration schema
- update approval-related generated artifacts impacted by schema evolution

## Verification
- Ent codegen sync check passes
- package compile passes with generated artifacts committed

Refs #165