### PR TITLE
chore(gitignore): ignore local e2e-seed binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ kubeconfig.*
 # OS files
 Thumbs.db
 k8s-admin.yaml
+e2e-seed


### PR DESCRIPTION
## Summary
Ignore local `e2e-seed` build artifact to prevent accidental commits.

## Scope
- `.gitignore` only

## Validation
- diff scope verified (`origin/main..HEAD` only touches `.gitignore`)
- commit trailer includes DCO sign-off and issue linkage

Refs #163