### PR TITLE
feat(web): align admin pages for stable interaction flows

### DIFF
--- a/web/src/app/(protected)/profile/ProfilePageContent.tsx
+++ b/web/src/app/(protected)/profile/ProfilePageContent.tsx
@@ -158,8 +158,8 @@ export default function ProfilePage() {
                 }}
                 confirmLoading={changePasswordMutation.isPending}
                 destroyOnHidden
+                data-testid="change-password-modal"
             >
-                <div data-testid="change-password-modal">
                     {error && (
                         <Alert
                             message={error}
@@ -221,7 +221,6 @@ export default function ProfilePage() {
                             />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
         </div>
     );

--- a/web/src/features/admin-approvals/components/AdminApprovalsContent.tsx
+++ b/web/src/features/admin-approvals/components/AdminApprovalsContent.tsx
@@ -255,8 +255,8 @@ export function AdminApprovalsContent() {
                 onCancel={approvals.closeApproveModal}
                 confirmLoading={approvals.approvePending}
                 forceRender
+                data-testid="approve-modal"
             >
-                <div data-testid="approve-modal">
                     <Form form={approvals.approveForm} layout="vertical" name="approve-form">
                         {approvals.approveModal?.operation_type !== 'DELETE' && (
                             <>
@@ -325,7 +325,6 @@ export function AdminApprovalsContent() {
                             <Input.TextArea rows={3} />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
 
             <Modal
@@ -337,8 +336,8 @@ export function AdminApprovalsContent() {
                 onCancel={approvals.closeRejectModal}
                 confirmLoading={approvals.rejectPending}
                 forceRender
+                data-testid="reject-modal"
             >
-                <div data-testid="reject-modal">
                     <Form form={approvals.rejectForm} layout="vertical" name="reject-form">
                         <Form.Item
                             name="reason"
@@ -351,7 +350,6 @@ export function AdminApprovalsContent() {
                             />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
         </div>
     );

--- a/web/src/features/admin-auth-providers/components/AdminAuthProvidersContent.tsx
+++ b/web/src/features/admin-auth-providers/components/AdminAuthProvidersContent.tsx
@@ -256,29 +256,30 @@ export function AdminAuthProvidersContent() {
                 onCancel={providers.closeCreateModal}
                 confirmLoading={providers.createPending}
                 destroyOnHidden={true}
+                data-testid="auth-provider-create-modal"
             >
-                <Form form={providers.createForm} layout="vertical" preserve={false}>
-                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="auth_type" label={t('authProviders.type')} rules={[{ required: true }]}>
-                        <Select
-                            options={providers.providerTypeOptions}
-                            loading={providers.providerTypesLoading}
-                            showSearch={true}
-                            optionFilterProp="label"
-                        />
-                    </Form.Item>
-                    <Form.Item name="sort_order" label={t('authProviders.sort_order')}>
-                        <InputNumber min={0} style={{ width: '100%' }} />
-                    </Form.Item>
-                    <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
-                        <Switch />
-                    </Form.Item>
-                    <Form.Item name="config_text" label={t('authProviders.config')}>
-                        <Input.TextArea rows={12} style={{ fontFamily: 'monospace' }} />
-                    </Form.Item>
-                </Form>
+                    <Form form={providers.createForm} layout="vertical" preserve={false}>
+                        <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="auth_type" label={t('authProviders.type')} rules={[{ required: true }]}>
+                            <Select
+                                options={providers.providerTypeOptions}
+                                loading={providers.providerTypesLoading}
+                                showSearch={true}
+                                optionFilterProp="label"
+                            />
+                        </Form.Item>
+                        <Form.Item name="sort_order" label={t('authProviders.sort_order')}>
+                            <InputNumber min={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
+                            <Switch />
+                        </Form.Item>
+                        <Form.Item name="config_text" label={t('authProviders.config')}>
+                            <Input.TextArea rows={12} style={{ fontFamily: 'monospace' }} />
+                        </Form.Item>
+                    </Form>
             </Modal>
 
             <Modal
@@ -290,21 +291,22 @@ export function AdminAuthProvidersContent() {
                 onCancel={providers.closeEditModal}
                 confirmLoading={providers.updatePending}
                 destroyOnHidden={true}
+                data-testid="auth-provider-edit-modal"
             >
-                <Form form={providers.editForm} layout="vertical" preserve={false}>
-                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="sort_order" label={t('authProviders.sort_order')}>
-                        <InputNumber min={0} style={{ width: '100%' }} />
-                    </Form.Item>
-                    <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
-                        <Switch />
-                    </Form.Item>
-                    <Form.Item name="config_text" label={t('authProviders.config')}>
-                        <Input.TextArea rows={12} style={{ fontFamily: 'monospace' }} />
-                    </Form.Item>
-                </Form>
+                    <Form form={providers.editForm} layout="vertical" preserve={false}>
+                        <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="sort_order" label={t('authProviders.sort_order')}>
+                            <InputNumber min={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
+                            <Switch />
+                        </Form.Item>
+                        <Form.Item name="config_text" label={t('authProviders.config')}>
+                            <Input.TextArea rows={12} style={{ fontFamily: 'monospace' }} />
+                        </Form.Item>
+                    </Form>
             </Modal>
 
             <Modal
@@ -314,8 +316,9 @@ export function AdminAuthProvidersContent() {
                 onCancel={providers.closeDeleteModal}
                 confirmLoading={providers.deletePending}
                 okButtonProps={{ danger: true }}
+                data-testid="auth-provider-delete-modal"
             >
-                <Text>{t('authProviders.delete_confirm', { name: providers.deletingProvider?.name || '' })}</Text>
+                    <Text>{t('authProviders.delete_confirm', { name: providers.deletingProvider?.name || '' })}</Text>
             </Modal>
 
             <Modal
@@ -325,8 +328,8 @@ export function AdminAuthProvidersContent() {
                 footer={null}
                 width={980}
                 destroyOnHidden={true}
+                data-testid="auth-provider-mappings-page"
             >
-                <div data-testid="auth-provider-mappings-page">
                     <Space direction="vertical" size={20} style={{ width: '100%' }}>
                         <Card size="small" title={t('authProviders.sample.title')} extra={
                             <Button
@@ -408,7 +411,6 @@ export function AdminAuthProvidersContent() {
                             />
                         </Card>
                     </Space>
-                </div>
             </Modal>
 
             <Modal
@@ -420,8 +422,8 @@ export function AdminAuthProvidersContent() {
                 }}
                 confirmLoading={providers.updateMappingPending}
                 destroyOnHidden={true}
+                data-testid="group-mapping-edit-modal"
             >
-                <div data-testid="group-mapping-edit-modal">
                     <Form form={providers.mappingEditForm} layout="vertical">
                         <Form.Item name="role_id" label={t('authProviders.mapping.role')} rules={[{ required: true }]}>
                             <Select options={providers.roleOptions} />
@@ -436,7 +438,6 @@ export function AdminAuthProvidersContent() {
                             <Select mode="multiple" options={environmentOptions} />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
 
             {/* ── Group Mapping Create Modal ──────────────────────────────── */}
@@ -448,8 +449,8 @@ export function AdminAuthProvidersContent() {
                 confirmLoading={providers.createMappingPending}
                 destroyOnHidden={true}
                 width={720}
+                data-testid="group-mapping-create-modal"
             >
-                <div data-testid="group-mapping-create-modal">
                     <Form form={providers.mappingForm} layout="vertical" preserve={false}>
                         <Form.Item
                             name="external_group_id"
@@ -481,7 +482,6 @@ export function AdminAuthProvidersContent() {
                             <Select mode="multiple" options={environmentOptions} />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
         </div>
     );

--- a/web/src/features/admin-clusters/components/AdminClustersContent.tsx
+++ b/web/src/features/admin-clusters/components/AdminClustersContent.tsx
@@ -153,8 +153,8 @@ export function AdminClustersContent() {
                 onCancel={clusters.closeCreateModal}
                 confirmLoading={clusters.createPending}
                 forceRender
+                data-testid="cluster-create-modal"
             >
-                <div data-testid="cluster-create-modal">
                     <Form form={clusters.form} layout="vertical" name="create-cluster">
                         <Form.Item
                             name="name"
@@ -191,7 +191,6 @@ export function AdminClustersContent() {
                             />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
             <Modal
                 title={t('clusters.set_environment')}
@@ -200,8 +199,8 @@ export function AdminClustersContent() {
                 onCancel={clusters.closeEnvModal}
                 confirmLoading={clusters.updateEnvironmentPending}
                 destroyOnHidden={true}
+                data-testid="cluster-environment-modal"
             >
-                <div data-testid="cluster-environment-modal">
                     <Form form={clusters.envForm} layout="vertical" preserve={false}>
                         <Form.Item
                             name="environment"
@@ -216,7 +215,6 @@ export function AdminClustersContent() {
                             />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
         </div>
     );

--- a/web/src/features/admin-instance-sizes/components/AdminInstanceSizesContent.tsx
+++ b/web/src/features/admin-instance-sizes/components/AdminInstanceSizesContent.tsx
@@ -489,12 +489,11 @@ export function AdminInstanceSizesContent() {
                 confirmLoading={sizes.createPending}
                 destroyOnHidden={true}
                 width={680}
+                data-testid="instance-size-create-modal"
             >
-                <div data-testid="instance-size-create-modal">
                     <Form form={sizes.createForm} layout="vertical" preserve={false}>
                         <InstanceSizeFormFields isCreate={true} />
                     </Form>
-                </div>
             </Modal>
 
             {/* Edit Modal */}
@@ -506,12 +505,11 @@ export function AdminInstanceSizesContent() {
                 confirmLoading={sizes.updatePending}
                 destroyOnHidden={true}
                 width={680}
+                data-testid="instance-size-edit-modal"
             >
-                <div data-testid="instance-size-edit-modal">
                     <Form form={sizes.editForm} layout="vertical" preserve={false}>
                         <InstanceSizeFormFields isCreate={false} />
                     </Form>
-                </div>
             </Modal>
 
             {/* Delete Modal */}

--- a/web/src/features/admin-namespaces/components/AdminNamespacesContent.tsx
+++ b/web/src/features/admin-namespaces/components/AdminNamespacesContent.tsx
@@ -205,8 +205,8 @@ export function AdminNamespacesContent() {
                 onCancel={namespaces.closeCreateModal}
                 confirmLoading={namespaces.createPending}
                 forceRender
+                data-testid="namespace-create-modal"
             >
-                <div data-testid="namespace-create-modal">
                     <Form form={namespaces.createForm} layout="vertical" name="create-namespace">
                         <Form.Item
                             name="name"
@@ -238,7 +238,6 @@ export function AdminNamespacesContent() {
                             <Input.TextArea rows={3} placeholder={t('namespaces.desc_placeholder')} />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
 
             <Modal
@@ -248,8 +247,8 @@ export function AdminNamespacesContent() {
                 onCancel={namespaces.closeEditModal}
                 confirmLoading={namespaces.updatePending}
                 forceRender
+                data-testid="namespace-edit-modal"
             >
-                <div data-testid="namespace-edit-modal">
                     <Form form={namespaces.editForm} layout="vertical" name="edit-namespace">
                         <Paragraph type="secondary" style={{ marginBottom: 16 }}>
                             {t('namespaces.edit_note')}
@@ -268,7 +267,6 @@ export function AdminNamespacesContent() {
                             <Switch />
                         </Form.Item>
                     </Form>
-                </div>
             </Modal>
 
             <Modal
@@ -287,8 +285,8 @@ export function AdminNamespacesContent() {
                     disabled: namespaces.deleteConfirmName !== namespaces.deletingNs?.name,
                 }}
                 okText={t('common:button.delete')}
+                data-testid="namespace-delete-modal"
             >
-                <div data-testid="namespace-delete-modal">
                     <Paragraph>
                         {t('namespaces.delete_confirm', { name: namespaces.deletingNs?.name })}
                     </Paragraph>
@@ -306,7 +304,6 @@ export function AdminNamespacesContent() {
                                 : undefined
                         }
                     />
-                </div>
             </Modal>
         </div>
     );

--- a/web/src/features/admin-rbac/components/AdminRbacContent.tsx
+++ b/web/src/features/admin-rbac/components/AdminRbacContent.tsx
@@ -334,26 +334,25 @@ export function AdminRbacContent() {
                 onCancel={rbac.closeCreateRoleModal}
                 confirmLoading={rbac.createRolePending}
                 destroyOnHidden={true}
+                data-testid="rbac-role-create-modal"
             >
-                <div data-testid="rbac-role-create-modal">
-                    <Form form={rbac.roleCreateForm} layout="vertical" preserve={false}>
-                        <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="display_name" label={t('common:table.display_name')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="description" label={t('common:table.description')}>
-                            <Input.TextArea rows={3} />
-                        </Form.Item>
-                        <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}>
-                            <Select mode="multiple" options={rbac.permissionOptions} optionFilterProp="label" />
-                        </Form.Item>
-                        <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
-                            <Switch />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={rbac.roleCreateForm} layout="vertical" preserve={false}>
+                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="display_name" label={t('common:table.display_name')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="description" label={t('common:table.description')}>
+                        <Input.TextArea rows={3} />
+                    </Form.Item>
+                    <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}>
+                        <Select mode="multiple" options={rbac.permissionOptions} optionFilterProp="label" />
+                    </Form.Item>
+                    <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
+                        <Switch />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Modal
@@ -365,23 +364,22 @@ export function AdminRbacContent() {
                 onCancel={rbac.closeEditRoleModal}
                 confirmLoading={rbac.updateRolePending}
                 destroyOnHidden={true}
+                data-testid="rbac-role-edit-modal"
             >
-                <div data-testid="rbac-role-edit-modal">
-                    <Form form={rbac.roleEditForm} layout="vertical" preserve={false}>
-                        <Form.Item name="display_name" label={t('common:table.display_name')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="description" label={t('common:table.description')}>
-                            <Input.TextArea rows={3} />
-                        </Form.Item>
-                        <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}>
-                            <Select mode="multiple" options={rbac.permissionOptions} optionFilterProp="label" />
-                        </Form.Item>
-                        <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
-                            <Switch />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={rbac.roleEditForm} layout="vertical" preserve={false}>
+                    <Form.Item name="display_name" label={t('common:table.display_name')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="description" label={t('common:table.description')}>
+                        <Input.TextArea rows={3} />
+                    </Form.Item>
+                    <Form.Item name="permissions" label={t('rbac.roles.permissions')} rules={[{ required: true }]}>
+                        <Select mode="multiple" options={rbac.permissionOptions} optionFilterProp="label" />
+                    </Form.Item>
+                    <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
+                        <Switch />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Modal
@@ -404,26 +402,25 @@ export function AdminRbacContent() {
                 onCancel={rbac.closeAddBindingModal}
                 confirmLoading={rbac.createBindingPending}
                 destroyOnHidden={true}
+                data-testid="rbac-binding-add-modal"
             >
-                <div data-testid="rbac-binding-add-modal">
-                    <Form form={rbac.bindingForm} layout="vertical" preserve={false}>
-                        <Form.Item label={t('rbac.bindings.select_user')}>
-                            <Input value={rbac.selectedUser?.display_name || rbac.selectedUser?.username || ''} readOnly />
-                        </Form.Item>
-                        <Form.Item name="role_id" label={t('rbac.bindings.role')} rules={[{ required: true }]}>
-                            <Select options={roleOptions} optionFilterProp="label" showSearch />
-                        </Form.Item>
-                        <Form.Item name="scope_type" label={t('rbac.bindings.scope_type')} rules={[{ required: true }]} initialValue="global">
-                            <Select options={scopeOptions} />
-                        </Form.Item>
-                        <Form.Item name="scope_id" label={t('rbac.bindings.scope_id')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="allowed_environments" label={t('rbac.bindings.allowed_envs')}>
-                            <Select mode="multiple" options={environmentOptions} />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={rbac.bindingForm} layout="vertical" preserve={false}>
+                    <Form.Item label={t('rbac.bindings.select_user')}>
+                        <Input value={rbac.selectedUser?.display_name || rbac.selectedUser?.username || ''} readOnly />
+                    </Form.Item>
+                    <Form.Item name="role_id" label={t('rbac.bindings.role')} rules={[{ required: true }]}>
+                        <Select options={roleOptions} optionFilterProp="label" showSearch />
+                    </Form.Item>
+                    <Form.Item name="scope_type" label={t('rbac.bindings.scope_type')} rules={[{ required: true }]} initialValue="global">
+                        <Select options={scopeOptions} />
+                    </Form.Item>
+                    <Form.Item name="scope_id" label={t('rbac.bindings.scope_id')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="allowed_environments" label={t('rbac.bindings.allowed_envs')}>
+                        <Select mode="multiple" options={environmentOptions} />
+                    </Form.Item>
+                </Form>
             </Modal>
         </div>
     );

--- a/web/src/features/admin-templates/components/AdminTemplatesContent.tsx
+++ b/web/src/features/admin-templates/components/AdminTemplatesContent.tsx
@@ -198,7 +198,7 @@ export function AdminTemplatesContent() {
                         <Button
                             type="text"
                             size="small"
-                            data-testid={`admin-template-action-edit-${record.id}`}
+                            data-testid={`template-action-edit-${record.id}`}
                             icon={<EditOutlined />}
                             onClick={() => templates.openEditModal(record)}
                         />
@@ -208,7 +208,7 @@ export function AdminTemplatesContent() {
                             type="text"
                             size="small"
                             danger
-                            data-testid={`admin-template-action-delete-${record.id}`}
+                            data-testid={`template-action-delete-${record.id}`}
                             icon={<DeleteOutlined />}
                             onClick={() => templates.openDeleteModal(record)}
                         />
@@ -246,7 +246,7 @@ export function AdminTemplatesContent() {
                     <Button
                         type="primary"
                         icon={<PlusOutlined />}
-                        data-testid="admin-template-create-button"
+                        data-testid="template-create-button"
                         onClick={templates.openCreateModal}
                     >
                         {t('common:button.add')}
@@ -296,34 +296,35 @@ export function AdminTemplatesContent() {
                 onCancel={templates.closeCreateModal}
                 confirmLoading={templates.createPending}
                 destroyOnHidden={true}
+                data-testid="template-create-modal"
             >
-                <Form form={templates.createForm} layout="vertical" preserve={false}>
-                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}> 
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="display_name" label={t('common:table.display_name')}>
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="os_family" label={t('templates.os_family')}>
-                        <Input placeholder={t('templates.os_family_placeholder')} />
-                    </Form.Item>
-                    <Form.Item name="os_version" label={t('templates.os_version')}>
-                        <Input placeholder={t('templates.os_version_placeholder')} />
-                    </Form.Item>
-                    <Form.Item name="description" label={t('common:table.description')}>
-                        <Input.TextArea rows={3} />
-                    </Form.Item>
-                    <Form.Item
-                        name="spec_text"
-                        label={t('templates.spec')}
-                        extra={t('templates.spec_help')}
-                    >
-                        <Input.TextArea rows={10} style={{ fontFamily: 'monospace' }} />
-                    </Form.Item>
-                    <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked" initialValue={true}>
-                        <Switch />
-                    </Form.Item>
-                </Form>
+                    <Form form={templates.createForm} layout="vertical" preserve={false}>
+                        <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="display_name" label={t('common:table.display_name')}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="os_family" label={t('templates.os_family')}>
+                            <Input placeholder={t('templates.os_family_placeholder')} />
+                        </Form.Item>
+                        <Form.Item name="os_version" label={t('templates.os_version')}>
+                            <Input placeholder={t('templates.os_version_placeholder')} />
+                        </Form.Item>
+                        <Form.Item name="description" label={t('common:table.description')}>
+                            <Input.TextArea rows={3} />
+                        </Form.Item>
+                        <Form.Item
+                            name="spec_text"
+                            label={t('templates.spec')}
+                            extra={t('templates.spec_help')}
+                        >
+                            <Input.TextArea rows={10} style={{ fontFamily: 'monospace' }} />
+                        </Form.Item>
+                        <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked" initialValue={true}>
+                            <Switch />
+                        </Form.Item>
+                    </Form>
             </Modal>
 
             <Modal
@@ -333,31 +334,32 @@ export function AdminTemplatesContent() {
                 onCancel={templates.closeEditModal}
                 confirmLoading={templates.updatePending}
                 destroyOnHidden={true}
+                data-testid="template-edit-modal"
             >
-                <Form form={templates.editForm} layout="vertical" preserve={false}>
-                    <Form.Item name="display_name" label={t('common:table.display_name')}>
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="os_family" label={t('templates.os_family')}>
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="os_version" label={t('templates.os_version')}>
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="description" label={t('common:table.description')}>
-                        <Input.TextArea rows={3} />
-                    </Form.Item>
-                    <Form.Item
-                        name="spec_text"
-                        label={t('templates.spec')}
-                        extra={t('templates.spec_help')}
-                    >
-                        <Input.TextArea rows={10} style={{ fontFamily: 'monospace' }} />
-                    </Form.Item>
-                    <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked">
-                        <Switch />
-                    </Form.Item>
-                </Form>
+                    <Form form={templates.editForm} layout="vertical" preserve={false}>
+                        <Form.Item name="display_name" label={t('common:table.display_name')}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="os_family" label={t('templates.os_family')}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="os_version" label={t('templates.os_version')}>
+                            <Input />
+                        </Form.Item>
+                        <Form.Item name="description" label={t('common:table.description')}>
+                            <Input.TextArea rows={3} />
+                        </Form.Item>
+                        <Form.Item
+                            name="spec_text"
+                            label={t('templates.spec')}
+                            extra={t('templates.spec_help')}
+                        >
+                            <Input.TextArea rows={10} style={{ fontFamily: 'monospace' }} />
+                        </Form.Item>
+                        <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked">
+                            <Switch />
+                        </Form.Item>
+                    </Form>
             </Modal>
 
             <Modal

--- a/web/src/features/admin-users/components/AdminUsersContent.tsx
+++ b/web/src/features/admin-users/components/AdminUsersContent.tsx
@@ -358,48 +358,47 @@ export function AdminUsersContent() {
                 onCancel={users.closeCreateUserModal}
                 confirmLoading={users.createUserPending}
                 destroyOnHidden={true}
+                data-testid="user-create-modal"
             >
-                <div data-testid="user-create-modal">
-                    <Form form={users.createUserForm} layout="vertical" preserve={false}>
-                        <Form.Item
-                            name="username"
-                            label={t('common:auth.username')}
-                            rules={[
-                                { required: true, message: t('common:validation.username_required') },
-                                { min: 2, message: t('common:validation.username_min') },
-                            ]}
-                        >
-                            <Input autoComplete="off" />
-                        </Form.Item>
-                        <Form.Item
-                            name="password"
-                            label={t('common:auth.password')}
-                            rules={[
-                                { required: true, message: t('common:validation.password_required') },
-                                { min: 8, message: t('common:validation.password_min') },
-                            ]}
-                        >
-                            <Input.Password autoComplete="new-password" />
-                        </Form.Item>
-                        <Form.Item name="display_name" label={t('common:table.display_name')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="email" label={t('users.table.email')}>
-                            <Input type="email" />
-                        </Form.Item>
-                        <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
-                            <Switch />
-                        </Form.Item>
-                        <Form.Item
-                            name="force_password_change"
-                            label={t('users.directory.force_password_change')}
-                            valuePropName="checked"
-                            initialValue={true}
-                        >
-                            <Switch />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={users.createUserForm} layout="vertical" preserve={false}>
+                    <Form.Item
+                        name="username"
+                        label={t('common:auth.username')}
+                        rules={[
+                            { required: true, message: t('common:validation.username_required') },
+                            { min: 2, message: t('common:validation.username_min') },
+                        ]}
+                    >
+                        <Input autoComplete="off" />
+                    </Form.Item>
+                    <Form.Item
+                        name="password"
+                        label={t('common:auth.password')}
+                        rules={[
+                            { required: true, message: t('common:validation.password_required') },
+                            { min: 8, message: t('common:validation.password_min') },
+                        ]}
+                    >
+                        <Input.Password autoComplete="new-password" />
+                    </Form.Item>
+                    <Form.Item name="display_name" label={t('common:table.display_name')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="email" label={t('users.table.email')}>
+                        <Input type="email" />
+                    </Form.Item>
+                    <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked" initialValue={true}>
+                        <Switch />
+                    </Form.Item>
+                    <Form.Item
+                        name="force_password_change"
+                        label={t('users.directory.force_password_change')}
+                        valuePropName="checked"
+                        initialValue={true}
+                    >
+                        <Switch />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Modal
@@ -413,36 +412,35 @@ export function AdminUsersContent() {
                 onCancel={users.closeEditUserModal}
                 confirmLoading={users.updateUserPending}
                 destroyOnHidden={true}
+                data-testid="user-edit-modal"
             >
-                <div data-testid="user-edit-modal">
-                    <Form form={users.editUserForm} layout="vertical" preserve={false}>
-                        <Form.Item name="display_name" label={t('common:table.display_name')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="email" label={t('users.table.email')}>
-                            <Input type="email" />
-                        </Form.Item>
-                        <Form.Item
-                            name="password"
-                            label={t('users.directory.password')}
-                            rules={[
-                                { min: 8, message: t('common:validation.password_min') },
-                            ]}
-                        >
-                            <Input.Password autoComplete="new-password" allowClear={true} />
-                        </Form.Item>
-                        <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
-                            <Switch />
-                        </Form.Item>
-                        <Form.Item
-                            name="force_password_change"
-                            label={t('users.directory.force_password_change')}
-                            valuePropName="checked"
-                        >
-                            <Switch />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={users.editUserForm} layout="vertical" preserve={false}>
+                    <Form.Item name="display_name" label={t('common:table.display_name')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="email" label={t('users.table.email')}>
+                        <Input type="email" />
+                    </Form.Item>
+                    <Form.Item
+                        name="password"
+                        label={t('users.directory.password')}
+                        rules={[
+                            { min: 8, message: t('common:validation.password_min') },
+                        ]}
+                    >
+                        <Input.Password autoComplete="new-password" allowClear={true} />
+                    </Form.Item>
+                    <Form.Item name="enabled" label={t('common:table.status')} valuePropName="checked">
+                        <Switch />
+                    </Form.Item>
+                    <Form.Item
+                        name="force_password_change"
+                        label={t('users.directory.force_password_change')}
+                        valuePropName="checked"
+                    >
+                        <Switch />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Card style={{ borderRadius: 12 }}>
@@ -537,38 +535,37 @@ export function AdminUsersContent() {
                 onCancel={users.closeAddModal}
                 confirmLoading={users.addPending}
                 destroyOnHidden={true}
+                data-testid="member-add-modal"
             >
-                <div data-testid="member-add-modal">
-                    <Form form={users.addForm} layout="vertical" preserve={false}>
-                        <Form.Item
-                            name="user_id"
-                            label={t('users.members.select_user')}
-                            rules={[{ required: true, message: t('users.members.validation.user_required') }]}
-                        >
-                            <Select
-                                showSearch
-                                optionFilterProp="label"
-                                placeholder={t('users.members.select_user_placeholder')}
-                                options={addableUsers.map((u) => ({
-                                    value: u.id,
-                                    label: `${u.username}${u.display_name ? ` (${u.display_name})` : ''}`,
-                                }))}
-                                notFoundContent={t('users.members.no_addable_users')}
-                            />
-                        </Form.Item>
-                        <Form.Item
-                            name="role"
-                            label={t('users.members.select_role')}
-                            rules={[{ required: true, message: t('users.members.validation.role_required') }]}
-                            initialValue="viewer"
-                        >
-                            <Select options={memberRoleOptions} />
-                        </Form.Item>
-                        <Form.Item label={t('users.members.note_label')}>
-                            <Input.TextArea rows={3} value={t('users.members.note')} readOnly />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={users.addForm} layout="vertical" preserve={false}>
+                    <Form.Item
+                        name="user_id"
+                        label={t('users.members.select_user')}
+                        rules={[{ required: true, message: t('users.members.validation.user_required') }]}
+                    >
+                        <Select
+                            showSearch
+                            optionFilterProp="label"
+                            placeholder={t('users.members.select_user_placeholder')}
+                            options={addableUsers.map((u) => ({
+                                value: u.id,
+                                label: `${u.username}${u.display_name ? ` (${u.display_name})` : ''}`,
+                            }))}
+                            notFoundContent={t('users.members.no_addable_users')}
+                        />
+                    </Form.Item>
+                    <Form.Item
+                        name="role"
+                        label={t('users.members.select_role')}
+                        rules={[{ required: true, message: t('users.members.validation.role_required') }]}
+                        initialValue="viewer"
+                    >
+                        <Select options={memberRoleOptions} />
+                    </Form.Item>
+                    <Form.Item label={t('users.members.note_label')}>
+                        <Input.TextArea rows={3} value={t('users.members.note')} readOnly />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Modal
@@ -593,20 +590,19 @@ export function AdminUsersContent() {
                 }}
                 confirmLoading={users.rateLimitMutationPending}
                 destroyOnHidden={true}
+                data-testid="rate-limit-exemption-create-modal"
             >
-                <div data-testid="rate-limit-exemption-create-modal">
-                    <Form form={exemptionForm} layout="vertical" preserve={false}>
-                        <Form.Item label={t('users.rate_limit.user_id')}>
-                            <Input value={selectedRateLimitUserID} readOnly />
-                        </Form.Item>
-                        <Form.Item name="reason" label={t('users.rate_limit.reason')}>
-                            <Input.TextArea rows={3} />
-                        </Form.Item>
-                        <Form.Item name="expires_at" label={t('users.rate_limit.expires_at')}>
-                            <DatePicker showTime style={{ width: '100%' }} />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={exemptionForm} layout="vertical" preserve={false}>
+                    <Form.Item label={t('users.rate_limit.user_id')}>
+                        <Input value={selectedRateLimitUserID} readOnly />
+                    </Form.Item>
+                    <Form.Item name="reason" label={t('users.rate_limit.reason')}>
+                        <Input.TextArea rows={3} />
+                    </Form.Item>
+                    <Form.Item name="expires_at" label={t('users.rate_limit.expires_at')}>
+                        <DatePicker showTime style={{ width: '100%' }} />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Modal
@@ -632,26 +628,25 @@ export function AdminUsersContent() {
                 }}
                 confirmLoading={users.rateLimitMutationPending}
                 destroyOnHidden={true}
+                data-testid="rate-limit-user-edit-modal"
             >
-                <div data-testid="rate-limit-user-edit-modal">
-                    <Form form={overrideForm} layout="vertical" preserve={false}>
-                        <Form.Item label={t('users.rate_limit.user_id')}>
-                            <Input value={selectedRateLimitUserID} readOnly />
-                        </Form.Item>
-                        <Form.Item name="max_pending_parents" label={t('users.rate_limit.max_parents')}>
-                            <InputNumber min={0} style={{ width: '100%' }} />
-                        </Form.Item>
-                        <Form.Item name="max_pending_children" label={t('users.rate_limit.max_children')}>
-                            <InputNumber min={0} style={{ width: '100%' }} />
-                        </Form.Item>
-                        <Form.Item name="cooldown_seconds" label={t('users.rate_limit.cooldown')}>
-                            <InputNumber min={0} style={{ width: '100%' }} />
-                        </Form.Item>
-                        <Form.Item name="reason" label={t('users.rate_limit.reason')}>
-                            <Input.TextArea rows={3} />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={overrideForm} layout="vertical" preserve={false}>
+                    <Form.Item label={t('users.rate_limit.user_id')}>
+                        <Input value={selectedRateLimitUserID} readOnly />
+                    </Form.Item>
+                    <Form.Item name="max_pending_parents" label={t('users.rate_limit.max_parents')}>
+                        <InputNumber min={0} style={{ width: '100%' }} />
+                    </Form.Item>
+                    <Form.Item name="max_pending_children" label={t('users.rate_limit.max_children')}>
+                        <InputNumber min={0} style={{ width: '100%' }} />
+                    </Form.Item>
+                    <Form.Item name="cooldown_seconds" label={t('users.rate_limit.cooldown')}>
+                        <InputNumber min={0} style={{ width: '100%' }} />
+                    </Form.Item>
+                    <Form.Item name="reason" label={t('users.rate_limit.reason')}>
+                        <Input.TextArea rows={3} />
+                    </Form.Item>
+                </Form>
             </Modal>
             {/* ── User Role Bindings Drawer ─────────────────────────────── */}
             <Drawer
@@ -660,59 +655,58 @@ export function AdminUsersContent() {
                 onClose={users.closeRoleBindingsModal}
                 width={700}
                 destroyOnClose
+                data-testid="user-role-bindings-page"
             >
-                <div data-testid="user-role-bindings-page">
-                    <Space style={{ marginBottom: 16, width: '100%', justifyContent: 'flex-end' }}>
-                        <Button
-                            type="primary"
-                            icon={<PlusOutlined />}
-                            data-testid="role-binding-create-button"
-                            onClick={users.openRoleBindingCreateModal}
-                        >
-                            {t('users.role_bindings.create')}
-                        </Button>
-                    </Space>
-                    <Table<GlobalRoleBinding>
-                        rowKey="id"
-                        loading={users.roleBindingsLoading}
-                        dataSource={users.roleBindings?.items ?? []}
-                        pagination={false}
-                        columns={[
-                            {
-                                title: t('users.role_bindings.role_name'),
-                                dataIndex: 'role_name',
-                                key: 'role_name',
-                            },
-                            {
-                                title: t('users.role_bindings.created_at'),
-                                dataIndex: 'created_at',
-                                key: 'created_at',
-                                render: (val: string) => val ? new Date(val).toLocaleString() : '-',
-                            },
-                            {
-                                title: t('common:table.actions'),
-                                key: 'actions',
-                                render: (_: unknown, record: GlobalRoleBinding) => (
-                                    <Popconfirm
-                                        title={t('users.role_bindings.delete_confirm')}
-                                        onConfirm={() => users.deleteRoleBinding(record.id)}
-                                        okText={t('common:button.confirm')}
-                                        cancelText={t('common:button.cancel')}
-                                    >
-                                        <Button
-                                            type="text"
-                                            size="small"
-                                            danger
-                                            icon={<DeleteOutlined />}
-                                            loading={users.deletingBindingId === record.id && users.deleteRoleBindingPending}
-                                            data-testid={`role-binding-action-delete-${record.id}`}
-                                        />
-                                    </Popconfirm>
-                                ),
-                            },
-                        ]}
-                    />
-                </div>
+                <Space style={{ marginBottom: 16, width: '100%', justifyContent: 'flex-end' }}>
+                    <Button
+                        type="primary"
+                        icon={<PlusOutlined />}
+                        data-testid="role-binding-create-button"
+                        onClick={users.openRoleBindingCreateModal}
+                    >
+                        {t('users.role_bindings.create')}
+                    </Button>
+                </Space>
+                <Table<GlobalRoleBinding>
+                    rowKey="id"
+                    loading={users.roleBindingsLoading}
+                    dataSource={users.roleBindings?.items ?? []}
+                    pagination={false}
+                    columns={[
+                        {
+                            title: t('users.role_bindings.role_name'),
+                            dataIndex: 'role_name',
+                            key: 'role_name',
+                        },
+                        {
+                            title: t('users.role_bindings.created_at'),
+                            dataIndex: 'created_at',
+                            key: 'created_at',
+                            render: (val: string) => val ? new Date(val).toLocaleString() : '-',
+                        },
+                        {
+                            title: t('common:table.actions'),
+                            key: 'actions',
+                            render: (_: unknown, record: GlobalRoleBinding) => (
+                                <Popconfirm
+                                    title={t('users.role_bindings.delete_confirm')}
+                                    onConfirm={() => users.deleteRoleBinding(record.id)}
+                                    okText={t('common:button.confirm')}
+                                    cancelText={t('common:button.cancel')}
+                                >
+                                    <Button
+                                        type="text"
+                                        size="small"
+                                        danger
+                                        icon={<DeleteOutlined />}
+                                        loading={users.deletingBindingId === record.id && users.deleteRoleBindingPending}
+                                        data-testid={`role-binding-action-delete-${record.id}`}
+                                    />
+                                </Popconfirm>
+                            ),
+                        },
+                    ]}
+                />
             </Drawer>
 
             {/* ── Create Role Binding Modal ─────────────────────────────── */}
@@ -723,21 +717,20 @@ export function AdminUsersContent() {
                 onCancel={users.closeRoleBindingCreateModal}
                 confirmLoading={users.createRoleBindingPending}
                 destroyOnHidden={true}
+                data-testid="role-binding-create-modal"
             >
-                <div data-testid="role-binding-create-modal">
-                    <Form form={users.roleBindingCreateForm} layout="vertical" preserve={false}>
-                        <Form.Item
-                            name="role_id"
-                            label={t('users.role_bindings.role')}
-                            rules={[{ required: true }]}
-                        >
-                            <Select
-                                placeholder={t('users.role_bindings.select_role')}
-                                options={[]} // populated by role list query in a separate step
-                            />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={users.roleBindingCreateForm} layout="vertical" preserve={false}>
+                    <Form.Item
+                        name="role_id"
+                        label={t('users.role_bindings.role')}
+                        rules={[{ required: true }]}
+                    >
+                        <Select
+                            placeholder={t('users.role_bindings.select_role')}
+                            options={[]} // populated by role list query in a separate step
+                        />
+                    </Form.Item>
+                </Form>
             </Modal>
         </div>
     );

--- a/web/src/features/services-management/components/ServicesManagementContent.tsx
+++ b/web/src/features/services-management/components/ServicesManagementContent.tsx
@@ -174,7 +174,8 @@ export function ServicesManagementContent() {
                 }}
                 onCancel={services.closeCreateModal}
                 confirmLoading={services.createPending}
-                forceRender
+                destroyOnHidden={true}
+                data-testid="service-create-modal"
             >
                 <Form form={services.form} layout="vertical" name="create-service">
                     <Form.Item
@@ -215,7 +216,8 @@ export function ServicesManagementContent() {
                 }}
                 onCancel={services.closeEditModal}
                 confirmLoading={services.updatePending}
-                forceRender
+                destroyOnHidden={true}
+                data-testid="service-edit-modal"
             >
                 <Form form={services.editForm} layout="vertical" name="edit-service">
                     <Form.Item name="description" label={t('table.description')}>

--- a/web/src/features/systems-management/components/SystemMembersModal.tsx
+++ b/web/src/features/systems-management/components/SystemMembersModal.tsx
@@ -106,7 +106,8 @@ export function SystemMembersModal({
             onCancel={onCancel}
             footer={null}
             width={700}
-            forceRender
+            destroyOnHidden={true}
+            data-testid="system-members-modal"
         >
             <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'flex-end' }}>
                 <Button
@@ -136,27 +137,26 @@ export function SystemMembersModal({
                 }}
                 onCancel={members.closeAddMemberModal}
                 confirmLoading={members.addMemberPending}
-                forceRender
+                destroyOnHidden={true}
+                data-testid="member-add-modal"
             >
-                <div data-testid="member-add-modal">
-                    <Form form={members.addMemberForm} layout="vertical" name="add-system-member">
-                        <Form.Item
-                            name="user_id"
-                            label={t('table.user_id')}
-                            rules={[{ required: true, message: t('validation.required') }]}
-                        >
-                            <Input placeholder="e.g. user-123" />
-                        </Form.Item>
-                        <Form.Item
-                            name="role"
-                            label={t('table.role')}
-                            rules={[{ required: true, message: t('validation.required') }]}
-                            initialValue="member"
-                        >
-                            <Select options={roleOptions} />
-                        </Form.Item>
-                    </Form>
-                </div>
+                <Form form={members.addMemberForm} layout="vertical" name="add-system-member">
+                    <Form.Item
+                        name="user_id"
+                        label={t('table.user_id')}
+                        rules={[{ required: true, message: t('validation.required') }]}
+                    >
+                        <Input placeholder="e.g. user-123" />
+                    </Form.Item>
+                    <Form.Item
+                        name="role"
+                        label={t('table.role')}
+                        rules={[{ required: true, message: t('validation.required') }]}
+                        initialValue="member"
+                    >
+                        <Select options={roleOptions} />
+                    </Form.Item>
+                </Form>
             </Modal>
         </Modal>
     );

--- a/web/src/features/systems-management/components/SystemsManagementContent.tsx
+++ b/web/src/features/systems-management/components/SystemsManagementContent.tsx
@@ -170,7 +170,8 @@ export function SystemsManagementContent() {
                 }}
                 onCancel={systems.closeCreateModal}
                 confirmLoading={systems.createPending}
-                forceRender
+                destroyOnHidden={true}
+                data-testid="system-create-modal"
             >
                 <Form form={systems.form} layout="vertical" name="create-system">
                     <Form.Item
@@ -201,7 +202,8 @@ export function SystemsManagementContent() {
                 }}
                 onCancel={systems.closeEditModal}
                 confirmLoading={systems.updatePending}
-                forceRender
+                destroyOnHidden={true}
+                data-testid="system-edit-modal"
             >
                 <Form form={systems.editForm} layout="vertical" name="edit-system">
                     <Form.Item name="description" label={t('table.description')}>
@@ -226,6 +228,8 @@ export function SystemsManagementContent() {
                     disabled: systems.deleteConfirmName !== systems.deletingSystem?.name,
                 }}
                 okText={t('button.delete')}
+                destroyOnHidden={true}
+                data-testid="system-delete-modal"
             >
                 <Paragraph>
                     {t('systems.delete_confirm', { name: systems.deletingSystem?.name })}

--- a/web/src/features/vm-management/components/VMRequestWizard.tsx
+++ b/web/src/features/vm-management/components/VMRequestWizard.tsx
@@ -310,7 +310,8 @@ export function VMRequestWizard({
                     )}
                 </Space>
             )}
-            forceRender
+            destroyOnHidden={true}
+            data-testid="vm-request-wizard-modal"
         >
             <Steps current={step} items={wizardSteps} size="small" style={{ marginBottom: 24 }} />
             <Divider />


### PR DESCRIPTION
## Summary
Refine admin/profile page structures and modal wrappers to stabilize interaction behavior on frontend pages.

## Scope
- `web/src/**` only
- no workflow, backend, or docs changes

## Notes
Live E2E spec changes are intentionally split out into a follow-up PR to avoid conflict with current `main` test baseline.

## Validation
- diff scope verified (`origin/main..HEAD` only under `web/src/`)
- commit trailer includes DCO sign-off and issue linkage

Refs #173