### PR TITLE
chore(gitignore): ignore .run workspace artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ coverage.html
 *.log
 tmp/
 server
+.run/
 
 # Configuration (only commit .example)
 config/config.yaml


### PR DESCRIPTION
## Summary
- add `.run/` to `.gitignore`
- keep local live/e2e runtime artifacts out of version control

## Verification
- confirmed `.gitignore` contains `.run/`
- no source code or test logic changes

Refs #163