### PR TITLE
docs(master-flow): sync stage 5 status wording with runtime

### DIFF
--- a/docs/design/interaction-flows/master-flow.md
+++ b/docs/design/interaction-flows/master-flow.md
@@ -847,7 +847,7 @@ external systems are integrated as provider plugins without changing approval st
 ├─────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                              │
 │  V1 go-live path (required):                                                                 │
-│    1) User submits request -> approval_tickets=PENDING_APPROVAL                              │
+│    1) User submits request -> approval_tickets=PENDING                                       │
 │    2) Router selects built-in provider (`builtin-default`, only provider in V1)             │
 │    3) Built-in approver decides APPROVED / REJECTED                                          │
 │    4) Shepherd executes decision path and appends audit logs                                 │
@@ -1701,9 +1701,9 @@ execution, and runtime outcomes.
 
 | Stage | Ticket | Domain Event | VM | Worker Job |
 |------|--------|--------------|----|------------|
-| 5.A Submit | created as `PENDING_APPROVAL` | created as `PENDING` | none | none |
-| 5.B Approve | `PENDING_APPROVAL -> APPROVED` | `PENDING -> PROCESSING` | created as `CREATING` | inserted |
-| 5.B Reject | `PENDING_APPROVAL -> REJECTED` | `PENDING -> CANCELLED` | none | none |
+| 5.A Submit | created as `PENDING` | created as `PENDING` | none | none |
+| 5.B Approve | `PENDING -> APPROVED` | `PENDING -> PROCESSING` | created as `CREATING` | inserted |
+| 5.B Reject | `PENDING -> REJECTED` | `PENDING -> CANCELLED` | none | none |
 | 5.C Execute | unchanged | progresses per execution | `CREATING -> RUNNING|FAILED` | consumed/completed |
 
 ### Failure & Edge Cases (Stage 5.A-5.C)
@@ -1751,7 +1751,7 @@ Summarize persistence intent after VM request submission while keeping implement
 │        │                                                                                     │
 │        ▼                                                                                     │
 │  Single transaction writes:                                                                  │
-│    1) approval_tickets: create `PENDING_APPROVAL`                                            │
+│    1) approval_tickets: create `PENDING`                                                     │
 │    2) domain_events: create `PENDING`                                                        │
 │    3) audit_logs: append canonical submission action                                         │
 │        │                                                                                     │
@@ -1765,7 +1765,7 @@ Summarize persistence intent after VM request submission while keeping implement
 
 | Entity | Before | After |
 |------|------|------|
-| `approval_tickets` | none | `PENDING_APPROVAL` |
+| `approval_tickets` | none | `PENDING` |
 | `domain_events` | none | `PENDING` |
 | `vms` | none | none |
 | `river_job` | none | none |
@@ -1806,14 +1806,14 @@ Summarize approval/rejection write outcomes and guarantees for VM creation workf
 │  Approver opens pending ticket                                                               │
 │        │                                                                                     │
 │        ├── Approve path                                                                      │
-│        │      1) ticket: `PENDING_APPROVAL -> APPROVED`                                     │
+│        │      1) ticket: `PENDING -> APPROVED`                                              │
 │        │      2) domain_event: `PENDING -> PROCESSING`                                      │
 │        │      3) vms: insert with `CREATING`                                                │
 │        │      4) river job: enqueue execution task                                           │
 │        │      5) audit_logs: append approval action                                          │
 │        │                                                                                     │
 │        └── Reject path                                                                       │
-│               1) ticket: `PENDING_APPROVAL -> REJECTED`                                     │
+│               1) ticket: `PENDING -> REJECTED`                                              │
 │               2) domain_event: `PENDING -> CANCELLED`                                       │
 │               3) no VM row / no River job                                                   │
 │               4) audit_logs: append rejection action                                         │
@@ -1825,8 +1825,8 @@ Summarize approval/rejection write outcomes and guarantees for VM creation workf
 
 | Path | Ticket | Domain Event | VM | River Job |
 |------|--------|--------------|----|-----------|
-| Approve | `PENDING_APPROVAL -> APPROVED` | `PENDING -> PROCESSING` | created with `CREATING` | inserted (`available`) |
-| Reject | `PENDING_APPROVAL -> REJECTED` | `PENDING -> CANCELLED` | not created | not inserted |
+| Approve | `PENDING -> APPROVED` | `PENDING -> PROCESSING` | created with `CREATING` | inserted (`available`) |
+| Reject | `PENDING -> REJECTED` | `PENDING -> CANCELLED` | not created | not inserted |
 
 #### Failure & Edge Cases
 
@@ -1895,7 +1895,7 @@ Entity rule matrix:
 
 | Flow | Ticket | Resource | Final Persistence Outcome |
 |------|--------|----------|---------------------------|
-| VM delete approved | `PENDING_APPROVAL -> APPROVED` | `RUNNING/STOPPED -> DELETING -> (row removed)` | VM row hard-deleted, records retained separately |
+| VM delete approved | `PENDING -> APPROVED` | `RUNNING/STOPPED -> DELETING -> (row removed)` | VM row hard-deleted, records retained separately |
 | Service delete | no ticket | `ACTIVE -> DELETING -> (row removed)` | Service row hard-deleted after worker cleanup |
 | System delete | no ticket | `ACTIVE -> (row removed)` | System row hard-deleted in validated transaction |
 
@@ -2013,8 +2013,8 @@ UI storyboard (parent-child queue):
 │     • CANCELLED: pending children terminated by user/admin                                       │
 │                                                                                                  │
 │  4. Frontend actions during/after execution:                                                     │
-│     • Retry failed children: POST /api/v1/vms/batch/{id}/retry                                   │
-│     • Terminate pending children: POST /api/v1/vms/batch/{id}/cancel                             │
+│     • Retry failed children: POST /api/v1/vms/batch/{batch_id}/retry                             │
+│     • Terminate pending children: POST /api/v1/vms/batch/{batch_id}/cancel                       │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -2037,8 +2037,8 @@ UI storyboard (parent-child queue):
 
 | Scope | Transition Pattern |
 |------|---------------------|
-| Parent ticket | `PENDING_APPROVAL -> APPROVED/IN_PROGRESS -> COMPLETED|PARTIAL_SUCCESS|FAILED|CANCELLED` |
-| Child ticket | `PENDING -> RUNNING -> SUCCESS|FAILED|CANCELLED` |
+| Parent ticket | `PENDING_APPROVAL -> IN_PROGRESS -> COMPLETED|PARTIAL_SUCCESS|FAILED|CANCELLED` |
+| Child ticket | `PENDING -> APPROVED/REJECTED/CANCELLED -> EXECUTING -> SUCCESS|FAILED` |
 
 #### Failure & Edge Cases
 
@@ -2130,7 +2130,7 @@ Define notification behavior visible to users/admins for request, approval, and 
 │  │  [Mark all as read]  [View all →]                                  │                        │
 │  └─────────────────────────────────────────────────────────────────────┘                        │
 │                                                                                                  │
-│  Mark as read: PATCH /api/v1/notifications/{id}/read                                           │
+│  Mark as read: PATCH /api/v1/notifications/{notification_id}/read                               │
 │  Mark all read: POST /api/v1/notifications/mark-all-read                                       │
 │                                                                                                  │
 │  ⚠️ V1 Constraint: Poll-based only, no WebSocket push                                           │
@@ -2194,7 +2194,7 @@ It consolidates entity states, relationship intent, and audit semantics consumed
 ├─────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                              │
 │                        ┌───────────────────┐                                                 │
-│                        │  PENDING_APPROVAL │                                                 │
+│                        │      PENDING      │                                                 │
 │                        │     (pending)     │                                                 │
 │                        └─────────┬─────────┘                                                 │
 │                                  │                                                           │
@@ -2253,6 +2253,11 @@ It consolidates entity states, relationship intent, and audit semantics consumed
 │                                                                                              │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
+
+Compatibility note:
+- Runtime/provider compatibility statuses may also appear in API responses:
+  `PENDING`, `MIGRATING`, `PAUSED`, `UNKNOWN`.
+  These are non-canonical transition helpers and must be rendered safely by frontend views.
 
 ---
 
@@ -2520,8 +2525,8 @@ Key persisted data (schema authority remains in phase/database docs):
 
 | Domain | Canonical States |
 |--------|------------------|
-| Approval ticket | `PENDING_APPROVAL`, `APPROVED`, `REJECTED`, `CANCELLED`, `EXECUTING`, `SUCCESS`, `FAILED` |
-| VM runtime | `CREATING`, `RUNNING`, `STOPPING`, `STOPPED`, `FAILED`, `DELETING` |
+| Approval ticket | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`, `EXECUTING`, `SUCCESS`, `FAILED` |
+| VM runtime | `CREATING`, `RUNNING`, `STOPPING`, `STOPPED`, `FAILED`, `DELETING`, `PENDING`, `MIGRATING`, `PAUSED`, `UNKNOWN` |
 | Audit record lifecycle | append-only write, retained/archived per policy |
 
 ### Failure & Edge Cases (Part 4 Reference)

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -264,7 +264,8 @@
       "adrs": [
         "docs/adr/ADR-0005-workflow-extensibility.md",
         "docs/adr/ADR-0006-unified-async-model.md",
-        "docs/adr/ADR-0009-domain-event-pattern.md"
+        "docs/adr/ADR-0009-domain-event-pattern.md",
+        "docs/adr/ADR-0017-vm-request-flow-clarification.md"
       ],
       "examples": [
         "docs/design/examples/worker/pool.go"

--- a/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
+++ b/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
@@ -842,7 +842,7 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 ├─────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                              │
 │  V1 上线路径（必需）：                                                                          │
-│    1) 用户提交请求 -> approval_tickets=PENDING_APPROVAL                                       │
+│    1) 用户提交请求 -> approval_tickets=PENDING                                                │
 │    2) 路由层选择内置 Provider（`builtin-default`，V1 唯一实现）                                │
 │    3) 内置审批人做 APPROVED / REJECTED 决策                                                    │
 │    4) Shepherd 执行后续路径并记录审计                                                          │
@@ -1634,9 +1634,9 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 
 | 阶段 | 工单 | 领域事件 | VM | Worker Job |
 |------|------|----------|----|------------|
-| 5.A 提交 | 创建为 `PENDING_APPROVAL` | 创建为 `PENDING` | 无 | 无 |
-| 5.B 批准 | `PENDING_APPROVAL -> APPROVED` | `PENDING -> PROCESSING` | 创建为 `CREATING` | 插入 |
-| 5.B 拒绝 | `PENDING_APPROVAL -> REJECTED` | `PENDING -> CANCELLED` | 无 | 无 |
+| 5.A 提交 | 创建为 `PENDING` | 创建为 `PENDING` | 无 | 无 |
+| 5.B 批准 | `PENDING -> APPROVED` | `PENDING -> PROCESSING` | 创建为 `CREATING` | 插入 |
+| 5.B 拒绝 | `PENDING -> REJECTED` | `PENDING -> CANCELLED` | 无 | 无 |
 | 5.C 执行 | 不变 | 随执行推进 | `CREATING -> RUNNING|FAILED` | 消费并完成 |
 
 ### Failure & Edge Cases (阶段 5.A-5.C)
@@ -1683,7 +1683,7 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │        │                                                                                     │
 │        ▼                                                                                     │
 │  单事务写入：                                                                                │
-│    1) approval_tickets: 创建 `PENDING_APPROVAL`                                              │
+│    1) approval_tickets: 创建 `PENDING`                                                       │
 │    2) domain_events: 创建 `PENDING`                                                          │
 │    3) audit_logs: 追加规范提交动作                                                           │
 │        │                                                                                     │
@@ -1697,7 +1697,7 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 
 | 实体 | 之前 | 之后 |
 |------|------|------|
-| `approval_tickets` | 无 | `PENDING_APPROVAL` |
+| `approval_tickets` | 无 | `PENDING` |
 | `domain_events` | 无 | `PENDING` |
 | `vms` | 无 | 无 |
 | `river_job` | 无 | 无 |
@@ -1738,14 +1738,14 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │  审批人打开待审批工单                                                                          │
 │        │                                                                                     │
 │        ├── 批准路径                                                                            │
-│        │      1) 工单：`PENDING_APPROVAL -> APPROVED`                                        │
+│        │      1) 工单：`PENDING -> APPROVED`                                                 │
 │        │      2) 事件：`PENDING -> PROCESSING`                                               │
 │        │      3) VM：插入并置为 `CREATING`                                                   │
 │        │      4) River：入队执行任务                                                         │
 │        │      5) 审计：记录批准动作                                                          │
 │        │                                                                                     │
 │        └── 拒绝路径                                                                            │
-│               1) 工单：`PENDING_APPROVAL -> REJECTED`                                        │
+│               1) 工单：`PENDING -> REJECTED`                                                 │
 │               2) 事件：`PENDING -> CANCELLED`                                                │
 │               3) 不创建 VM / 不入队 River                                                    │
 │               4) 审计：记录拒绝动作                                                          │
@@ -1757,8 +1757,8 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 
 | 路径 | 工单 | 领域事件 | VM | River Job |
 |------|------|----------|----|-----------|
-| 批准 | `PENDING_APPROVAL -> APPROVED` | `PENDING -> PROCESSING` | 创建并置为 `CREATING` | 插入（`available`） |
-| 拒绝 | `PENDING_APPROVAL -> REJECTED` | `PENDING -> CANCELLED` | 不创建 | 不插入 |
+| 批准 | `PENDING -> APPROVED` | `PENDING -> PROCESSING` | 创建并置为 `CREATING` | 插入（`available`） |
+| 拒绝 | `PENDING -> REJECTED` | `PENDING -> CANCELLED` | 不创建 | 不插入 |
 
 #### Failure & Edge Cases
 
@@ -1826,7 +1826,7 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 
 | 流程 | 工单 | 资源 | 最终持久化结果 |
 |------|------|------|----------------|
-| VM 删除（审批通过） | `PENDING_APPROVAL -> APPROVED` | `RUNNING/STOPPED -> DELETING -> (主表删除)` | VM 主记录硬删除，审计/工单/事件独立保留 |
+| VM 删除（审批通过） | `PENDING -> APPROVED` | `RUNNING/STOPPED -> DELETING -> (主表删除)` | VM 主记录硬删除，审计/工单/事件独立保留 |
 | Service 删除 | 无工单 | `ACTIVE -> DELETING -> (主表删除)` | 清理完成后硬删除 Service 主记录 |
 | System 删除 | 无工单 | `ACTIVE -> (主表删除)` | 校验通过后事务内硬删除 |
 
@@ -1930,8 +1930,8 @@ UI 故事板（父子队列）：
 │     • PARTIAL_SUCCESS: 部分成功                                                                    │
 │     • CANCELLED: 未开始子任务被终止                                                                │
 │  4. 前端可操作:                                                                                   │
-│     • POST /api/v1/vms/batch/{id}/retry  （仅重试失败子项）                                      │
-│     • POST /api/v1/vms/batch/{id}/cancel （终止待执行子项）                                       │
+│     • POST /api/v1/vms/batch/{batch_id}/retry  （仅重试失败子项）                                │
+│     • POST /api/v1/vms/batch/{batch_id}/cancel （终止待执行子项）                                 │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -1954,8 +1954,8 @@ UI 故事板（父子队列）：
 
 | 范围 | 状态变化模式 |
 |------|-------------|
-| 父工单 | `PENDING_APPROVAL -> APPROVED/IN_PROGRESS -> COMPLETED|PARTIAL_SUCCESS|FAILED|CANCELLED` |
-| 子工单 | `PENDING -> RUNNING -> SUCCESS|FAILED|CANCELLED` |
+| 父工单 | `PENDING_APPROVAL -> IN_PROGRESS -> COMPLETED|PARTIAL_SUCCESS|FAILED|CANCELLED` |
+| 子工单 | `PENDING -> APPROVED/REJECTED/CANCELLED -> EXECUTING -> SUCCESS|FAILED` |
 
 #### Failure & Edge Cases
 
@@ -2046,7 +2046,7 @@ UI 故事板（父子队列）：
 │  │  [全部标为已读]  [查看全部 →]                                         │                        │
 │  └─────────────────────────────────────────────────────────────────────┘                        │
 │                                                                                                  │
-│  标记已读: PATCH /api/v1/notifications/{id}/read                                                │
+│  标记已读: PATCH /api/v1/notifications/{notification_id}/read                                   │
 │  全部已读: POST /api/v1/notifications/mark-all-read                                             │
 │                                                                                                  │
 │  ⚠️ V1 限制: 仅支持轮询，不支持 WebSocket 推送                                                     │
@@ -2108,7 +2108,7 @@ Part 4 属于参考视图，不是用户操作流程。
 ├─────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                              │
 │                        ┌───────────────────┐                                                 │
-│                        │  PENDING_APPROVAL │                                                 │
+│                        │      PENDING      │                                                 │
 │                        │     (待审批)       │                                                 │
 │                        └─────────┬─────────┘                                                 │
 │                                  │                                                           │
@@ -2167,6 +2167,10 @@ Part 4 属于参考视图，不是用户操作流程。
 │                                                                                              │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
+
+兼容性说明：
+- API 响应中可能出现额外运行态：`PENDING`、`MIGRATING`、`PAUSED`、`UNKNOWN`。
+  这些用于兼容运行时/Provider 状态，不改变本节的规范主流程语义，前端需安全渲染。
 
 ---
 
@@ -2434,8 +2438,8 @@ Part 4 属于参考视图，不是用户操作流程。
 
 | 领域 | 规范状态集合 |
 |------|-------------|
-| 审批工单 | `PENDING_APPROVAL`, `APPROVED`, `REJECTED`, `CANCELLED`, `EXECUTING`, `SUCCESS`, `FAILED` |
-| VM 运行态 | `CREATING`, `RUNNING`, `STOPPING`, `STOPPED`, `FAILED`, `DELETING` |
+| 审批工单 | `PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`, `EXECUTING`, `SUCCESS`, `FAILED` |
+| VM 运行态 | `CREATING`, `RUNNING`, `STOPPING`, `STOPPED`, `FAILED`, `DELETING`, `PENDING`, `MIGRATING`, `PAUSED`, `UNKNOWN` |
 | 审计记录生命周期 | 仅追加写入，按策略保留/归档 |
 
 ### Failure & Edge Cases (Part 4 参考)


### PR DESCRIPTION
## Summary
- update Stage 5 wording in `master-flow` docs to align with current runtime status semantics
- keep i18n master-flow document aligned with canonical design document
- update `docs/design/traceability/master-flow.json` in the same PR to satisfy traceability governance linkage

## Scope
- `docs/design/interaction-flows/master-flow.md`
- `docs/i18n/zh-CN/design/interaction-flows/master-flow.md`
- `docs/design/traceability/master-flow.json`

## Verification
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`

Refs #264