### PR TITLE
test(e2e): harden live e2e selectors and response matching

### DIFF
--- a/web/tests/e2e/admin-extended-live.spec.ts
+++ b/web/tests/e2e/admin-extended-live.spec.ts
@@ -39,6 +39,7 @@
 
 import { expect, test, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
+import {urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -54,7 +55,7 @@ async function login(page: Page): Promise<void> {
     await page.getByPlaceholder('Password').fill(e2ePassword);
     // operationId: login
     const loginRespPromise = page.waitForResponse(
-        (r) => r.url().endsWith('/api/v1/auth/login') && r.request().method() === 'POST'
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
     );
     await page.getByRole('button', { name: 'Login' }).click();
     const loginResp = await loginRespPromise;
@@ -83,15 +84,27 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     });
 
     // ── listPermissions: GET /admin/permissions → PermissionList ──────────────
+    //
+    // NOTE: The /admin/permissions page uses STATIC_PERMISSIONS (hardcoded data)
+    // and does NOT call the API. We test the API directly using request context.
 
-    test('listPermissions – GET /admin/permissions conforms to PermissionList schema', async ({ page }) => {
+    test('listPermissions – GET /admin/permissions conforms to PermissionList schema', async ({ request }) => {
         // operationId: listPermissions
-        const respPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/permissions') && r.request().method() === 'GET'
-        );
-        await page.goto('/admin/permissions');
-        await expect(page.locator('body')).toBeVisible();
-        await expectSchema(respPromise, 'PermissionList', 200);
+        // The frontend page is static — test the API endpoint directly.
+        const loginResp = await request.post('/api/v1/auth/login', {
+            data: { username: e2eUsername, password: e2ePassword },
+        });
+        expect(loginResp.ok(), 'API login failed').toBeTruthy();
+        const { token } = await loginResp.json() as { token: string };
+
+        const resp = await request.get('/api/v1/admin/permissions', {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        expect(resp.status(), `GET /admin/permissions returned ${resp.status()}`).toBe(200);
+        const body = await resp.json();
+        // Validate against PermissionList schema using validateResponse (non-Playwright)
+        const { validateResponse } = await import('./lib/schema-validator');
+        validateResponse('PermissionList', body);
     });
 
     // ── updateRole: PATCH /admin/roles/{id} → Role ───────────────────────────
@@ -104,10 +117,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         const roleName = `e2e-upd-role-${Date.now().toString(36).slice(-5)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/roles') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'POST'
         );
         await page.getByTestId('rbac-role-create-button').click();
-        const createModal = page.locator('.ant-modal-content').filter({ hasText: /role/i }).last();
+        const createModal = getAntModal(page, 'rbac-role-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(roleName);
         await createModal.getByRole('button', { name: 'OK' }).click();
@@ -118,10 +131,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PATCH /admin/roles/{id} → Role ────────────────────────────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/roles/${roleID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/roles/${roleID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`rbac-role-action-edit-${roleID}`).click();
-        const editModal = page.locator('.ant-modal-content').filter({ hasText: /edit.*role/i }).last();
+        const editModal = getAntModal(page, 'rbac-role-edit-modal');
         await expect(editModal).toBeVisible();
         await editModal.locator('textarea').first().fill('Updated by live e2e test');
         await editModal.getByRole('button', { name: 'OK' }).click();
@@ -130,7 +143,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // Cleanup
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/roles/${roleID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/roles/${roleID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`rbac-role-action-delete-${roleID}`).click();
         const confirmBtn = page.getByRole('button', { name: /ok|confirm|delete/i }).last();
@@ -148,10 +161,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         const username = `e2eupd${Date.now().toString(36).slice(-5)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'POST'
         );
         await page.getByTestId('user-create-button').click();
-        const createModal = page.getByTestId('user-create-modal');
+        const createModal = getAntModal(page, 'user-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').nth(0).fill(username);
         await createModal.locator('input[type="password"]').fill('Secure@Pass123');
@@ -163,10 +176,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PATCH /admin/users/{id} → User ───────────────────────────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/users/${userID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/users/${userID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`user-action-edit-${userID}`).click();
-        const editModal = page.getByTestId('user-edit-modal');
+        const editModal = getAntModal(page, 'user-edit-modal');
         await expect(editModal).toBeVisible();
         // Update display name or email
         const displayNameInput = editModal.getByRole('textbox').first();
@@ -177,7 +190,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // Cleanup
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/users/${userID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/users/${userID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`user-action-delete-${userID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm/i }).last();
@@ -189,7 +202,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         // operationId: listUserRoleBindings
         // Get first user from list
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
@@ -202,7 +215,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── GET /admin/users/{id}/role-bindings → GlobalRoleBindingList ───────────
         const bindingsRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/users/${userID}/role-bindings`) && r.request().method() === 'GET'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/users/${userID}/role-bindings`) && r.request().method() === 'GET'
         );
         await page.getByTestId(`user-action-role-bindings-${userID}`).click();
         await expectSchema(bindingsRespPromise, 'GlobalRoleBindingList', 200);
@@ -212,7 +225,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         // operationId: createUserRoleBinding, deleteUserRoleBinding
         // Get first user (use validateApiResponse for single-read safety)
         const usersRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
@@ -227,14 +240,13 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── POST /admin/users/{id}/role-bindings → GlobalRoleBinding ─────────────
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/users/${userID}/role-bindings`) && r.request().method() === 'POST'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/users/${userID}/role-bindings`) && r.request().method() === 'POST'
         );
         await page.getByTestId('role-binding-create-button').click();
-        const createModal = page.getByTestId('role-binding-create-modal');
+        const createModal = getAntModal(page, 'role-binding-create-modal');
         await expect(createModal).toBeVisible();
         // Select a role from dropdown
-        await createModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').first().click();
+        await selectAntOption(page, createModal.locator('.ant-select-selector').first());
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'GlobalRoleBinding', 201);
@@ -243,7 +255,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── DELETE /admin/users/{id}/role-bindings/{id} → 204 ────────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/users/${userID}/role-bindings/${bindingID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/users/${userID}/role-bindings/${bindingID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`role-binding-action-delete-${bindingID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok/i }).last();
@@ -261,10 +273,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         const tplName = `e2e-tpl-${Date.now().toString(36).slice(-5)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/templates') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'POST'
         );
         await page.getByTestId('template-create-button').click();
-        const createModal = page.getByTestId('template-create-modal');
+        const createModal = getAntModal(page, 'template-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(tplName);
         // Fill minimal required YAML
@@ -278,10 +290,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PATCH /admin/templates/{id} → Template ────────────────────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/templates/${tplID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/templates/${tplID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`template-action-edit-${tplID}`).click();
-        const editModal = page.getByTestId('template-edit-modal');
+        const editModal = getAntModal(page, 'template-edit-modal');
         await expect(editModal).toBeVisible();
         await editModal.locator('textarea').first().fill('Updated by live e2e test');
         await editModal.getByRole('button', { name: 'OK' }).click();
@@ -290,7 +302,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── DELETE /admin/templates/{id} → 204 ───────────────────────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/templates/${tplID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/templates/${tplID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`template-action-delete-${tplID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok|delete/i }).last();
@@ -307,15 +319,15 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         const sizeName = `e2e-size-${Date.now().toString(36).slice(-5)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/instance-sizes') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'POST'
         );
         await page.getByTestId('instance-size-create-button').click();
-        const createModal = page.getByTestId('instance-size-create-modal');
+        const createModal = getAntModal(page, 'instance-size-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(sizeName);
-        // Fill CPU and memory fields
-        await createModal.locator('input[type="number"]').nth(0).fill('2');
-        await createModal.locator('input[type="number"]').nth(1).fill('4');
+        // Fill CPU and memory fields (Ant Design InputNumber uses role="spinbutton")
+        await createModal.getByRole('spinbutton').nth(1).fill('2');  // cpu_cores
+        await createModal.getByRole('spinbutton').nth(2).fill('4096');  // memory_mb
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'InstanceSize', 201);
@@ -324,19 +336,19 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PATCH /admin/instance-sizes/{id} → InstanceSize ──────────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/instance-sizes/${sizeID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/instance-sizes/${sizeID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`instance-size-action-edit-${sizeID}`).click();
-        const editModal = page.getByTestId('instance-size-edit-modal');
+        const editModal = getAntModal(page, 'instance-size-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.locator('input[type="number"]').nth(0).fill('4');
+        await editModal.getByRole('spinbutton').nth(1).fill('4');  // cpu_cores
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'InstanceSize', 200);
 
         // ── DELETE /admin/instance-sizes/{id} → 204 ──────────────────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/instance-sizes/${sizeID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/instance-sizes/${sizeID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`instance-size-action-delete-${sizeID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok|delete/i }).last();
@@ -350,7 +362,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         // operationId: updateAuthProvider
         // Get first provider (use validateApiResponse for single-read safety)
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
         );
         await page.goto('/admin/auth-providers');
         await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
@@ -362,10 +374,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PATCH /admin/auth-providers/{id} → AuthProvider ──────────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/auth-providers/${providerID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`auth-provider-action-edit-${providerID}`).click();
-        const editModal = page.locator('.ant-modal-content').filter({ hasText: /edit.*provider|update.*provider/i }).last();
+        const editModal = getAntModal(page, 'auth-provider-edit-modal');
         await expect(editModal).toBeVisible();
         await editModal.locator('textarea').first().fill('{"issuer":"https://updated-idp.example.com"}');
         await editModal.getByRole('button', { name: 'OK' }).click();
@@ -376,7 +388,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('testAuthProviderConnection – POST /admin/auth-providers/{id}/test-connection conforms to AuthProviderConnectionTestResult schema', async ({ page }) => {
         // operationId: testAuthProviderConnection
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
         );
         await page.goto('/admin/auth-providers');
         await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
@@ -386,7 +398,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── POST /admin/auth-providers/{id}/test-connection ───────────────────────
         const testRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/admin/auth-providers/${providerID}/test-connection`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/admin/auth-providers/${providerID}/test-connection`) && r.request().method() === 'POST'
         );
         await page.getByTestId(`auth-provider-action-test-${providerID}`).click();
         await expectSchema(testRespPromise, 'AuthProviderConnectionTestResult', 200);
@@ -395,7 +407,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('syncAuthProviderGroups – POST /admin/auth-providers/{id}/sync conforms to AuthProviderGroupSyncResponse schema', async ({ page }) => {
         // operationId: syncAuthProviderGroups
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
         );
         await page.goto('/admin/auth-providers');
         await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
@@ -405,7 +417,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── POST /admin/auth-providers/{id}/sync ──────────────────────────────────
         const syncRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/admin/auth-providers/${providerID}/sync`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/admin/auth-providers/${providerID}/sync`) && r.request().method() === 'POST'
         );
         await page.getByTestId(`auth-provider-action-sync-${providerID}`).click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
@@ -417,7 +429,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('getAuthProviderSample – GET /admin/auth-providers/{id}/sample returns 200', async ({ page }) => {
         // operationId: getAuthProviderSample
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
         );
         await page.goto('/admin/auth-providers');
         await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
@@ -427,7 +439,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── GET /admin/auth-providers/{id}/sample ─────────────────────────────────
         const sampleRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/admin/auth-providers/${providerID}/sample`) && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/admin/auth-providers/${providerID}/sample`) && r.request().method() === 'GET'
         );
         await page.getByTestId(`auth-provider-action-sample-${providerID}`).click();
         const sampleResp = await sampleRespPromise;
@@ -439,7 +451,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('createAuthProviderGroupMapping + updateAuthProviderGroupMapping + deleteAuthProviderGroupMapping', async ({ page }) => {
         // operationId: createAuthProviderGroupMapping, updateAuthProviderGroupMapping, deleteAuthProviderGroupMapping
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
         );
         await page.goto('/admin/auth-providers');
         await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
@@ -449,19 +461,18 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // Navigate to group mappings
         await page.getByTestId(`auth-provider-action-mappings-${providerID}`).click();
-        const mappingsPage = page.getByTestId('auth-provider-mappings-page');
+        const mappingsPage = getAntModal(page, 'auth-provider-mappings-page');
         await expect(mappingsPage).toBeVisible();
 
         // ── POST /admin/auth-providers/{id}/group-mappings → IdPGroupMapping ──────
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/auth-providers/${providerID}/group-mappings`) && r.request().method() === 'POST'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}/group-mappings`) && r.request().method() === 'POST'
         );
         await page.getByTestId('group-mapping-create-button').click();
-        const createModal = page.getByTestId('group-mapping-create-modal');
+        const createModal = getAntModal(page, 'group-mapping-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(`e2e-group-${Date.now().toString(36).slice(-5)}`);
-        await createModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').first().click();
+        await selectAntOption(page, createModal.locator('.ant-select-selector').first());
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'IdPGroupMapping', 201);
@@ -470,20 +481,19 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PATCH /admin/auth-providers/{id}/group-mappings/{id} → IdPGroupMapping
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/auth-providers/${providerID}/group-mappings/${mappingID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}/group-mappings/${mappingID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`group-mapping-action-edit-${mappingID}`).click();
-        const editModal = page.getByTestId('group-mapping-edit-modal');
+        const editModal = getAntModal(page, 'group-mapping-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').last().click();
+        await selectAntOption(page, editModal.locator('.ant-select-selector').first());
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'IdPGroupMapping', 200);
 
         // ── DELETE /admin/auth-providers/{id}/group-mappings/{id} → 204 ──────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/auth-providers/${providerID}/group-mappings/${mappingID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}/group-mappings/${mappingID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`group-mapping-action-delete-${mappingID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok/i }).last();
@@ -496,8 +506,8 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('listRateLimitExemptions – GET /admin/rate-limits/exemptions conforms to RateLimitExemptionList schema', async ({ page }) => {
         // operationId: listRateLimitExemptions
         const respPromise = page.waitForResponse(
-            (r) => r.url().includes('/api/v1/admin/rate-limits/exemptions') && r.request().method() === 'GET'
-                && !r.url().includes('/status') && !r.url().includes('/users/')
+            (r) => urlPathIncludes(r.url(), '/api/v1/admin/rate-limits/exemptions') && r.request().method() === 'GET'
+                && !urlPathIncludes(r.url(), '/status') && !urlPathIncludes(r.url(), '/users/')
         );
         await page.goto('/admin/rate-limits');
         await expect(page.locator('body')).toBeVisible();
@@ -508,7 +518,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('listRateLimitStatus – GET /admin/rate-limits/status conforms to RateLimitStatusList schema', async ({ page }) => {
         // operationId: listRateLimitStatus
         const respPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/rate-limits/status') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/rate-limits/status') && r.request().method() === 'GET'
         );
         await page.goto('/admin/rate-limits');
         await expect(page.locator('body')).toBeVisible();
@@ -519,7 +529,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         // operationId: createRateLimitExemption, deleteRateLimitExemption
         // Get first user to exempt (use validateApiResponse for single-read safety)
         const usersRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
@@ -533,14 +543,13 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── POST /admin/rate-limits/exemptions ────────────────────────────────────
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/rate-limits/exemptions') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/rate-limits/exemptions') && r.request().method() === 'POST'
         );
         await page.getByTestId('rate-limit-exemption-create-button').click();
-        const createModal = page.getByTestId('rate-limit-exemption-create-modal');
+        const createModal = getAntModal(page, 'rate-limit-exemption-create-modal');
         await expect(createModal).toBeVisible();
         // Select user
-        await createModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').first().click();
+        await selectAntOption(page, createModal.locator('.ant-select-selector').first());
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const createResp = await createRespPromise;
@@ -550,7 +559,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── DELETE /admin/rate-limits/exemptions/{user_id} → 204 ─────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/rate-limits/exemptions/${userID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/rate-limits/exemptions/${userID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`rate-limit-exemption-action-delete-${userID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok/i }).last();
@@ -562,7 +571,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         // operationId: updateRateLimitUserOverrides
         // Get first user (use validateApiResponse for single-read safety)
         const usersRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
@@ -575,10 +584,10 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         await expect(page.locator('body')).toBeVisible();
 
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/rate-limits/users/${userID}`) && r.request().method() === 'PUT'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/rate-limits/users/${userID}`) && r.request().method() === 'PUT'
         );
         await page.getByTestId(`rate-limit-user-action-edit-${userID}`).click();
-        const editModal = page.getByTestId('rate-limit-user-edit-modal');
+        const editModal = getAntModal(page, 'rate-limit-user-edit-modal');
         await expect(editModal).toBeVisible();
         await editModal.locator('input[type="number"]').first().fill('100');
         await editModal.getByRole('button', { name: 'OK' }).click();
@@ -591,7 +600,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('updateClusterEnvironment – PUT /admin/clusters/{id}/environment conforms to Cluster schema', async ({ page }) => {
         // operationId: updateClusterEnvironment
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/clusters') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/clusters') && r.request().method() === 'GET'
         );
         await page.goto('/admin/clusters');
         await expect(page.getByTestId('admin-clusters-page')).toBeVisible();
@@ -603,14 +612,13 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
         // ── PUT /admin/clusters/{id}/environment → Cluster ────────────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/clusters/${clusterID}/environment`) && r.request().method() === 'PUT'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/clusters/${clusterID}/environment`) && r.request().method() === 'PUT'
         );
         await page.getByTestId(`cluster-action-set-environment-${clusterID}`).click();
-        const editModal = page.getByTestId('cluster-environment-modal');
+        const editModal = getAntModal(page, 'cluster-environment-modal');
         await expect(editModal).toBeVisible();
         // Select environment type
-        await editModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').filter({ hasText: /test|staging/i }).first().click();
+        await selectAntOption(page, editModal.locator('.ant-select-selector').first(), /test|staging/i);
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'Cluster', 200);

--- a/web/tests/e2e/admin-flow-live.spec.ts
+++ b/web/tests/e2e/admin-flow-live.spec.ts
@@ -46,6 +46,7 @@
 
 import { expect, test, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
+import {urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -62,7 +63,7 @@ async function login(page: Page): Promise<void> {
     await page.getByPlaceholder('Password').fill(e2ePassword);
 
     const loginRespPromise = page.waitForResponse(
-        (r) => r.url().endsWith('/api/v1/auth/login') && r.request().method() === 'POST'
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
     );
     await page.getByRole('button', { name: 'Login' }).click();
 
@@ -101,7 +102,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // operationId: listRoles, createRole, deleteRole
         // ── CONTRACT CHECK: listRoles → RoleList ──────────────────────────────────
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/roles') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'GET'
         );
         await page.goto('/admin/rbac');
         await expect(page.getByTestId('admin-rbac-page')).toBeVisible();
@@ -110,11 +111,11 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // ── CONTRACT CHECK: createRole → Role ─────────────────────────────────────
         const roleName = `e2e-role-${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/roles') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('rbac-role-create-button').click();
-        const createModal = page.locator('.ant-modal-content').filter({ hasText: /role/i }).last();
+        const createModal = getAntModal(page, 'rbac-role-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(roleName);
         await createModal.getByRole('button', { name: 'OK' }).click();
@@ -127,7 +128,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         // ── CONTRACT CHECK: deleteRole → 204 ──────────────────────────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/roles/${roleID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/roles/${roleID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`rbac-role-action-delete-${roleID}`).click();
         const confirmBtn = page.getByRole('button', { name: /ok|confirm|delete/i }).last();
@@ -145,7 +146,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // operationId: listUsers, createUser, deleteUser
         // ── CONTRACT CHECK: listUsers → UserList ──────────────────────────────────
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
@@ -154,11 +155,11 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // ── CONTRACT CHECK: createUser → User ─────────────────────────────────────
         const username = `e2eu${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('user-create-button').click();
-        const createModal = page.getByTestId('user-create-modal');
+        const createModal = getAntModal(page, 'user-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').nth(0).fill(username);
         await createModal.locator('input[type="password"]').fill('Secure@Pass123');
@@ -172,7 +173,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         // ── CONTRACT CHECK: deleteUser → 204 ──────────────────────────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/admin/users/${userID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/admin/users/${userID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`user-action-delete-${userID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm/i }).last();
@@ -190,7 +191,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // operationId: listAuthProviderTypes, listAuthProviders, createAuthProvider, deleteAuthProvider
         // ── CONTRACT CHECK: listAuthProviderTypes → AuthProviderTypeList ──────────
         const typesRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-provider-types') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-provider-types') && r.request().method() === 'GET'
         );
         await page.goto('/admin/auth-providers');
         await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
@@ -208,7 +209,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         // ── CONTRACT CHECK: listAuthProviders → AuthProviderList ──────────────────
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
         );
         await page.reload();
         await expectSchema(listRespPromise, 'AuthProviderList', 200);
@@ -216,15 +217,14 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // ── CONTRACT CHECK: createAuthProvider → AuthProvider ─────────────────────
         const providerName = `e2e-auth-${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('auth-provider-create-button').click();
-        const createModal = page.locator('.ant-modal-content').filter({ hasText: 'Create Authentication Provider' });
+        const createModal = getAntModal(page, 'auth-provider-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(providerName);
-        await createModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').filter({ hasText: providerTypeLabel }).first().click();
+        await selectAntOption(page, createModal.locator('.ant-select-selector').first(), providerTypeLabel);
         await createModal.getByRole('textbox').nth(1).fill('{"issuer":"https://idp.example.com"}');
         await createModal.getByRole('button', { name: 'OK' }).click();
 
@@ -238,10 +238,10 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         await page.getByTestId(`auth-provider-action-delete-${providerID}`).click();
         const deleteRespPromise = page.waitForResponse(
             (r) =>
-                r.url().includes(`/api/v1/admin/auth-providers/${providerID}`) &&
+                urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}`) &&
                 r.request().method() === 'DELETE'
         );
-        const deleteModal = page.locator('.ant-modal-content').filter({ hasText: providerName });
+        const deleteModal = getAntModal(page, 'auth-provider-delete-modal');
         await expect(deleteModal).toBeVisible();
         await deleteModal.getByRole('button', { name: 'OK' }).click();
 
@@ -270,7 +270,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         const mappingsRespPromise = page.waitForResponse(
             (r) =>
-                r.url().includes(`/api/v1/admin/auth-providers/${providerID}/group-mappings`) &&
+                urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}/group-mappings`) &&
                 r.request().method() === 'GET'
         );
         await mappingLink.click();
@@ -287,7 +287,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // operationId: listNamespaces, createNamespace, updateNamespace, deleteNamespace
         // ── CONTRACT CHECK: listNamespaces → NamespaceRegistryList ───────────────
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/namespaces') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
         );
         await page.goto('/admin/namespaces');
         await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
@@ -296,15 +296,14 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // ── CONTRACT CHECK: createNamespace → NamespaceRegistry ──────────────────
         const nsName = `e2e-ns-${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/namespaces') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('namespace-create-button').click();
-        const createModal = page.getByTestId('namespace-create-modal');
+        const createModal = getAntModal(page, 'namespace-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(nsName);
-        await createModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').filter({ hasText: /test/i }).first().click();
+        await selectAntOption(page, createModal.locator('.ant-select-selector').first(), /test/i);
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'NamespaceRegistry', 201);
@@ -317,11 +316,11 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // Note: OpenAPI spec uses PUT for updateNamespace
         const updateRespPromise = page.waitForResponse(
             (r) =>
-                r.url().includes(`/api/v1/admin/namespaces/${nsID}`) &&
+                urlPathIncludes(r.url(), `/api/v1/admin/namespaces/${nsID}`) &&
                 (r.request().method() === 'PUT' || r.request().method() === 'PATCH')
         );
         await page.getByTestId(`namespace-action-edit-${nsID}`).click();
-        const editModal = page.getByTestId('namespace-edit-modal');
+        const editModal = getAntModal(page, 'namespace-edit-modal');
         await expect(editModal).toBeVisible();
         await editModal.locator('textarea').first().fill('Updated by live e2e test');
         await editModal.getByRole('button', { name: 'OK' }).click();
@@ -330,7 +329,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         // ── CONTRACT CHECK: deleteNamespace with confirm_name guard ───────────────
         await page.getByTestId(`namespace-action-delete-${nsID}`).click();
-        const deleteModal = page.getByTestId('namespace-delete-modal');
+        const deleteModal = getAntModal(page, 'namespace-delete-modal');
         await expect(deleteModal).toBeVisible();
 
         const deleteBtn = deleteModal.getByRole('button', { name: /delete/i });
@@ -341,7 +340,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         const deleteRespPromise = page.waitForResponse(
             (r) =>
-                r.url().includes(`/api/v1/admin/namespaces/${nsID}`) &&
+                urlPathIncludes(r.url(), `/api/v1/admin/namespaces/${nsID}`) &&
                 r.request().method() === 'DELETE'
         );
         await deleteBtn.click();
@@ -356,7 +355,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
     test('Stage 3 – listClusters: cluster list conforms to ClusterList schema', async ({ page }) => {
         // operationId: listClusters
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/clusters') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/clusters') && r.request().method() === 'GET'
         );
         await page.goto('/admin/clusters');
         await expect(page.getByTestId('admin-clusters-page')).toBeVisible();
@@ -371,11 +370,11 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         const clusterName = `e2e-cluster-${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/clusters') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/clusters') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('cluster-create-button').click();
-        const createModal = page.getByTestId('cluster-create-modal');
+        const createModal = getAntModal(page, 'cluster-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(clusterName);
         await createModal.locator('textarea').last().fill(e2eKubeconfigB64);
@@ -396,7 +395,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // operationId: listAdminTemplates, createAdminTemplate
         // ── CONTRACT CHECK: listAdminTemplates → TemplateList ────────────────────
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/templates') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'GET'
         );
         await page.goto('/admin/templates');
         await expect(page.getByRole('heading', { name: 'Templates' })).toBeVisible();
@@ -405,11 +404,11 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // ── CONTRACT CHECK: createAdminTemplate → Template ───────────────────────
         const templateName = `e2e-tpl-${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/templates') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('template-create-button').click();
-        const createModal = page.locator('.ant-modal-content').filter({ hasText: /create template/i });
+        const createModal = getAntModal(page, 'template-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(templateName);
         // Fill required fields (image, etc.) with test values
@@ -434,7 +433,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // operationId: listAdminInstanceSizes, createAdminInstanceSize
         // ── CONTRACT CHECK: listAdminInstanceSizes → InstanceSizeList ────────────
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
         );
         await page.goto('/admin/instance-sizes');
         await expect(page.getByRole('heading', { name: 'Instance Sizes' })).toBeVisible();
@@ -443,19 +442,21 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         // ── CONTRACT CHECK: createAdminInstanceSize → InstanceSize ───────────────
         const sizeName = `e2e-size-${Date.now().toString(36).slice(-6)}`;
         const createRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/instance-sizes') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'POST'
         );
 
         await page.getByTestId('instance-size-create-button').click();
-        const createModal = page.locator('.ant-modal-content').filter({ hasText: /create instance size/i });
+        const createModal = getAntModal(page, 'instance-size-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(sizeName);
-        // Fill CPU and memory fields
-        const numberInputs = createModal.locator('input[type="number"]');
+        // Fill CPU and memory fields (Ant Design InputNumber uses role="spinbutton")
+        const numberInputs = createModal.getByRole('spinbutton');
         const inputCount = await numberInputs.count();
         if (inputCount >= 2) {
-            await numberInputs.nth(0).fill('2');
-            await numberInputs.nth(1).fill('4');
+            // First spinbutton after name is sort_order, then cpu_cores, then memory_mb
+            // Find cpu_cores and memory_mb by targeting the required InputNumber fields
+            await numberInputs.nth(1).fill('2');  // cpu_cores
+            await numberInputs.nth(2).fill('4096');  // memory_mb (in MB)
         }
         await createModal.getByRole('button', { name: 'OK' }).click();
 
@@ -472,7 +473,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
     test('Stage 5.B – listApprovals: approval list conforms to ApprovalTicketList schema', async ({ page }) => {
         // operationId: listApprovals
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().includes('/api/v1/approvals') && r.request().method() === 'GET'
+            (r) => urlPathIncludes(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
         );
         await page.goto('/approvals');
         await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
@@ -528,12 +529,12 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         const approveRespPromise = page.waitForResponse(
             (r) =>
-                r.url().includes(`/api/v1/approvals/${ticketID}`) &&
+                urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
                 (r.request().method() === 'PATCH' || r.request().method() === 'POST')
         );
 
         await approveBtn.click();
-        const modal = page.locator('.ant-modal-content').filter({ hasText: /approv/i }).last();
+        const modal = getAntModal(page, 'approve-modal');
         await expect(modal).toBeVisible();
         await modal.getByRole('button', { name: 'OK' }).click();
 
@@ -590,12 +591,12 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         const rejectRespPromise = page.waitForResponse(
             (r) =>
-                r.url().includes(`/api/v1/approvals/${ticketID}`) &&
+                urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
                 (r.request().method() === 'PATCH' || r.request().method() === 'POST')
         );
 
         await rejectBtn.click();
-        const modal = page.locator('.ant-modal-content').filter({ hasText: /reject/i }).last();
+        const modal = getAntModal(page, 'reject-modal');
         await expect(modal).toBeVisible();
         await modal.locator('textarea').first().fill('Rejected by live e2e test');
         await modal.getByRole('button', { name: 'OK' }).click();
@@ -610,7 +611,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
     test('listAuditLogs: audit log list conforms to AuditLogList schema', async ({ page }) => {
         // operationId: listAuditLogs
         const auditRespPromise = page.waitForResponse(
-            (r) => (r.url().includes('/api/v1/audit-logs') || r.url().includes('/api/v1/admin/audit-logs')) && r.request().method() === 'GET'
+            (r) => (urlPathIncludes(r.url(), '/api/v1/audit-logs') || urlPathIncludes(r.url(), '/api/v1/admin/audit-logs')) && r.request().method() === 'GET'
         );
 
         await page.goto('/admin/audit-logs');

--- a/web/tests/e2e/lib/helpers.ts
+++ b/web/tests/e2e/lib/helpers.ts
@@ -1,0 +1,169 @@
+/**
+ * E2E Test Helpers — Ant Design + URL matching utilities
+ *
+ * ── Problem ──────────────────────────────────────────────────────────────────
+ * 1. `url.endsWith('/api/v1/admin/users')` fails when query params are present
+ *    (e.g. `/api/v1/admin/users?page=1&per_page=20`).
+ * 2. Ant Design Select dropdowns are prone to race conditions where the
+ *    dropdown opens and then immediately closes due to React re-renders.
+ *
+ * ── Solution (per Playwright best practices) ──────────────────────────────────
+ * 1. `urlPathEndsWith(url, path)` — strips query string before matching.
+ * 2. `urlPathIncludes(url, path)` — strips query string before matching.
+ * 3. `selectAntOption(page, combobox, optionFilter?)` — stable Select interaction
+ *    using web-first assertions (`expect().toBeVisible()`) before clicking.
+ *
+ * Reference: https://playwright.dev/docs/best-practices
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+// ── URL Path Matching (query-param safe) ─────────────────────────────────────
+
+/**
+ * Check if the pathname portion of `url` ends with `path`.
+ * Unlike `url.endsWith(path)`, this is safe for URLs with query strings.
+ *
+ * @example
+ *   urlPathEndsWith('http://localhost/api/v1/admin/users?page=1', '/api/v1/admin/users')
+ *   // → true (endsWith would return false!)
+ */
+export function urlPathEndsWith(url: string, path: string): boolean {
+    try {
+        const { pathname } = new URL(url);
+        return pathname.endsWith(path);
+    } catch {
+        // Fallback for non-absolute URLs: strip query string manually
+        const pathPart = url.split('?')[0];
+        return pathPart.endsWith(path);
+    }
+}
+
+/**
+ * Check if the pathname portion of `url` includes `path`.
+ * Unlike `url.includes(path)`, this does NOT match query-string content.
+ *
+ * @example
+ *   urlPathIncludes('http://localhost/api/v1/systems/123/members', '/systems/')
+ *   // → true
+ */
+export function urlPathIncludes(url: string, path: string): boolean {
+    try {
+        const { pathname } = new URL(url);
+        return pathname.includes(path);
+    } catch {
+        const pathPart = url.split('?')[0];
+        return pathPart.includes(path);
+    }
+}
+
+/**
+ * Safely select an option from an Ant Design Select (combobox) component.
+ *
+ * Per Playwright best practices (Context7: /microsoft/playwright.dev):
+ * 1. Click the combobox to open the dropdown
+ * 2. Wait for any OLD dropdown leave-animations to finish (prevents strict mode violation)
+ * 3. Wait for the ACTIVE dropdown to be visible (web-first assertion)
+ * 4. Wait for the first matching option to be visible and stable
+ * 5. Click the option
+ *
+ * Problem solved:
+ * Ant Design's Select dropdown uses CSS animation classes:
+ *   - Opening: `.ant-slide-up-appear` / `.ant-slide-up-appear-prepare`
+ *   - Closing: `.ant-slide-up-leave` / `.ant-slide-up-leave-active`
+ * During the leave animation, the old dropdown is still `:visible` in the DOM.
+ * If a new dropdown opens before the old one finishes closing,
+ * `page.locator('.ant-select-dropdown:visible')` matches 2 elements → strict mode violation.
+ *
+ * Fix (based on Context7 best practices):
+ *   - Use `.filter({ visible: true })` (Playwright recommended) instead of CSS `:visible`
+ *   - Exclude dropdowns with leave-animation classes using `:not()` CSS pseudo-class
+ *   - Use `.last()` to always target the most recently opened dropdown
+ *
+ * @param page - Playwright Page instance
+ * @param combobox - Locator for the combobox trigger element
+ * @param optionFilter - Optional: filter options by text content (regex or string)
+ * @param timeout - Max time to wait for option visibility (default: 5000ms)
+ */
+export async function selectAntOption(
+    page: Page,
+    combobox: Locator,
+    optionFilter?: string | RegExp,
+    timeout = 5000
+): Promise<void> {
+    // Step 1: Click to open dropdown
+    await combobox.click();
+
+    // Step 2: Wait for any OLD dropdown leave-animations to finish.
+    // Ant Design adds `.ant-slide-up-leave` during close animation.
+    // We must wait for these to disappear before locating the active dropdown,
+    // otherwise `.ant-select-dropdown:visible` may resolve to 2 elements.
+    await expect(
+        page.locator('.ant-select-dropdown.ant-slide-up-leave')
+    ).toHaveCount(0, { timeout });
+
+    // Step 3: Locate the ACTIVE dropdown (exclude any lingering leave-animations).
+    // Use Playwright visibility filtering instead of CSS :visible pseudo selectors.
+    const dropdown = page
+        .locator('.ant-select-dropdown:not(.ant-slide-up-leave):not(.ant-slide-up-leave-active)')
+        .filter({ visible: true })
+        .last();
+    await expect(dropdown).toBeVisible({ timeout });
+
+    // Step 4: Find the target option within the active dropdown
+    let option: Locator;
+    if (optionFilter) {
+        option = dropdown.locator('.ant-select-item-option').filter({ hasText: optionFilter }).first();
+    } else {
+        option = dropdown.locator('.ant-select-item-option').first();
+    }
+
+    // Step 5: Wait for option to be visible and stable before clicking
+    await expect(option).toBeVisible({ timeout });
+    await option.click();
+}
+
+// ── Ant Design Modal Locator Helper ──────────────────────────────────────────
+
+/**
+ * Get a stable Playwright locator for an Ant Design Modal identified by data-testid.
+ *
+ * ── Problem ────────────────────────────────────────────────────────────────
+ * Ant Design Modal's DOM structure (from rc-dialog source):
+ *
+ *   <div class="ant-modal-root" data-testid="xxx">     ← getByTestId lands HERE
+ *     <div class="ant-modal-mask" />                    ← backdrop overlay
+ *     <div class="ant-modal-wrap" style="display:...">  ← VISIBILITY CONTROLLED HERE
+ *       <div class="ant-modal" role="dialog">           ← actual dialog content
+ *         <div class="ant-modal-content">
+ *           <div class="ant-modal-body"> ... </div>
+ *           <div class="ant-modal-footer"> OK | Cancel </div>
+ *   ...
+ *
+ * The `.ant-modal-root` is a zero-height wrapper div. Even when the Modal is
+ * open, its bounding box may read as empty → Playwright `toBeVisible()` returns
+ * false ("hidden").
+ *
+ * The actual visibility is controlled by `.ant-modal-wrap`'s inline style:
+ *   - Modal closed: `display: none`   (rc-dialog: `!animatedVisible ? 'none' : null`)
+ *   - Modal open:   `display: null`   → block (default)
+ *
+ * ── Solution (per Playwright best practices via Context7) ──────────────────
+ * Locate the `.ant-modal-wrap` *inside* the testid root. This element:
+ *   1. Has a non-empty bounding box when visible (full-screen overlay)
+ *   2. Correctly responds to toBeVisible() / toBeHidden()
+ *   3. Contains the `role="dialog"` element with all buttons (OK, Cancel)
+ *
+ * @param page     Playwright Page instance
+ * @param testId   The data-testid value set on the <Modal> component
+ * @returns        Locator pointing to .ant-modal-wrap (visible when modal is open)
+ *
+ * @example
+ *   const modal = getAntModal(page, 'rbac-role-create-modal');
+ *   await expect(modal).toBeVisible();
+ *   await modal.getByRole('textbox').first().fill('admin');
+ *   await modal.getByRole('button', { name: 'OK' }).click();
+ */
+export function getAntModal(page: Page, testId: string): Locator {
+    return page.getByTestId(testId).locator('.ant-modal-wrap');
+}

--- a/web/tests/e2e/master-flow-live.spec.ts
+++ b/web/tests/e2e/master-flow-live.spec.ts
@@ -48,6 +48,7 @@
 
 import { expect, test, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
+import {urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -67,7 +68,7 @@ async function login(page: Page): Promise<void> {
   await page.getByPlaceholder('Password').fill(e2ePassword);
 
   const loginRespPromise = page.waitForResponse(
-    (r) => r.url().endsWith('/api/v1/auth/login') && r.request().method() === 'POST'
+    (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
   );
   await page.getByRole('button', { name: 'Login' }).click();
 
@@ -112,7 +113,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // login() in beforeEach already validates LoginResponse schema.
     // This test additionally verifies /auth/me returns UserInfo schema.
     const meRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/auth/me') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/auth/me') && r.request().method() === 'GET'
     );
     await page.goto('/dashboard');
 
@@ -129,7 +130,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
       console.warn('[getCurrentUser] /auth/me not called on dashboard load – trigger manually');
       // Trigger explicitly via navigation to profile page
       const explicitRespPromise = page.waitForResponse(
-        (r) => r.url().endsWith('/api/v1/auth/me') && r.request().method() === 'GET'
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/me') && r.request().method() === 'GET'
       );
       await page.goto('/profile');
       const explicitResp = await Promise.race([
@@ -154,7 +155,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // Per Playwright best practice: register Promise BEFORE the action that
     // triggers the network request, to avoid missing a fast response.
     const listRespPromise = page.waitForResponse(
-      (r) => r.url().includes('/api/v1/systems') && r.request().method() === 'GET' && !r.url().includes('/members')
+      (r) => urlPathIncludes(r.url(), '/api/v1/systems') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/members')
     );
     await page.goto('/systems');
     await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
@@ -166,11 +167,11 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // ── CONTRACT CHECK: createSystem → System ────────────────────────────────
     const systemName = `e2es${Date.now().toString(36).slice(-6)}`;
     const createRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'POST'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
     );
 
     await page.getByTestId('system-create-button').click();
-    const createModal = page.locator('.ant-modal-content').filter({ hasText: /create system/i });
+    const createModal = getAntModal(page, 'system-create-modal');
     await expect(createModal).toBeVisible();
     await createModal.locator('input[maxlength="15"]').first().fill(systemName);
     await createModal.locator('textarea').first().fill('created by live e2e');
@@ -184,10 +185,10 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     // ── CONTRACT CHECK: updateSystem → System ────────────────────────────────
     const updateRespPromise = page.waitForResponse(
-      (r) => r.url().includes(`/api/v1/systems/${systemID}`) && r.request().method() === 'PATCH'
+      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'PATCH'
     );
     await page.getByTestId(`system-action-edit-${systemID}`).click();
-    const editModal = page.locator('.ant-modal-content').filter({ hasText: /edit system/i });
+    const editModal = getAntModal(page, 'system-edit-modal');
     await expect(editModal).toBeVisible();
     await editModal.locator('textarea').first().fill('updated by live e2e');
     await editModal.getByRole('button', { name: 'OK' }).click();
@@ -196,7 +197,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     // ── CONTRACT CHECK: deleteSystem with confirm_name guard ──────────────────
     await page.getByTestId(`system-action-delete-${systemID}`).click();
-    const deleteModal = page.locator('.ant-modal-content').filter({ hasText: /delete system/i });
+    const deleteModal = getAntModal(page, 'system-delete-modal');
     await expect(deleteModal).toBeVisible();
 
     const deleteBtn = deleteModal.getByRole('button', { name: /delete/i });
@@ -211,7 +212,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     await expect(deleteBtn).toBeEnabled();
 
     const deleteRespPromise = page.waitForResponse(
-      (r) => r.url().includes(`/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
     );
     await deleteBtn.click();
 
@@ -233,10 +234,10 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     const systemName = `e2em${Date.now().toString(36).slice(-6)}`;
     const createRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'POST'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
     );
     await page.getByTestId('system-create-button').click();
-    const createModal = page.locator('.ant-modal-content').filter({ hasText: /create system/i });
+    const createModal = getAntModal(page, 'system-create-modal');
     await expect(createModal).toBeVisible();
     await createModal.locator('input[maxlength="15"]').first().fill(systemName);
     await createModal.getByRole('button', { name: 'OK' }).click();
@@ -247,10 +248,10 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     // ── CONTRACT CHECK: listSystemMembers → SystemMemberList ──────────────────
     const membersRespPromise = page.waitForResponse(
-      (r) => r.url().includes(`/api/v1/systems/${systemID}/members`) && r.request().method() === 'GET'
+      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members`) && r.request().method() === 'GET'
     );
     await page.getByTestId(`system-action-members-${systemID}`).click();
-    const membersModal = page.locator('.ant-modal-content:visible');
+    const membersModal = getAntModal(page, 'system-members-modal');
     await expect(membersModal).toBeVisible();
 
     const membersResp = await membersRespPromise;
@@ -263,11 +264,11 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     // Delete the temp system
     await page.getByTestId(`system-action-delete-${systemID}`).click();
-    const deleteModal = page.locator('.ant-modal-content').filter({ hasText: /delete system/i });
+    const deleteModal = getAntModal(page, 'system-delete-modal');
     await expect(deleteModal).toBeVisible();
     await deleteModal.getByRole('textbox').first().fill(systemName);
     const deleteRespPromise = page.waitForResponse(
-      (r) => r.url().includes(`/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
     );
     await deleteModal.getByRole('button', { name: /delete/i }).click();
     const deleteResp = await deleteRespPromise;
@@ -282,10 +283,10 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     await page.goto('/systems');
     const systemName = `e2esvc${Date.now().toString(36).slice(-5)}`;
     const createSysRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'POST'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
     );
     await page.getByTestId('system-create-button').click();
-    const createSysModal = page.locator('.ant-modal-content').filter({ hasText: /create system/i });
+    const createSysModal = getAntModal(page, 'system-create-modal');
     await expect(createSysModal).toBeVisible();
     await createSysModal.locator('input[maxlength="15"]').first().fill(systemName);
     await createSysModal.getByRole('button', { name: 'OK' }).click();
@@ -297,18 +298,17 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // Navigate to services and select the new system
     await page.goto('/services');
     await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
-    await page.getByTestId('services-system-selector').click();
-    await page.locator('.ant-select-item-option').filter({ hasText: systemName }).first().click();
+    await selectAntOption(page, page.getByTestId('services-system-selector'), systemName);
 
     // ── CONTRACT CHECK: createService → Service ───────────────────────────────
     const serviceName = `e2e-svc-${Date.now().toString(36).slice(-5)}`;
     const createSvcRespPromise = page.waitForResponse(
       (r) =>
-        r.url().includes(`/api/v1/systems/${systemID}/services`) &&
+        urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) &&
         r.request().method() === 'POST'
     );
     await page.getByTestId('service-create-button').click();
-    const createSvcModal = page.locator('.ant-modal-content').filter({ hasText: /create service/i });
+    const createSvcModal = getAntModal(page, 'service-create-modal');
     await expect(createSvcModal).toBeVisible();
     await createSvcModal.getByPlaceholder('e.g. web, api-gateway').fill(serviceName);
     await createSvcModal.locator('textarea').first().fill('service created by live e2e');
@@ -323,11 +323,11 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // ── CONTRACT CHECK: updateService → Service ───────────────────────────────
     const updateSvcRespPromise = page.waitForResponse(
       (r) =>
-        r.url().includes(`/api/v1/systems/${systemID}/services/${serviceID}`) &&
+        urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
         r.request().method() === 'PATCH'
     );
     await page.getByTestId(`service-action-edit-${serviceID}`).click();
-    const editSvcModal = page.locator('.ant-modal-content').filter({ hasText: /edit service/i });
+    const editSvcModal = getAntModal(page, 'service-edit-modal');
     await expect(editSvcModal).toBeVisible();
     await editSvcModal.locator('textarea').first().fill('updated by live e2e');
     await editSvcModal.getByRole('button', { name: 'OK' }).click();
@@ -337,7 +337,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // ── CONTRACT CHECK: deleteService with confirm=true ───────────────────────
     const deleteSvcRespPromise = page.waitForResponse(
       (r) =>
-        r.url().includes(`/api/v1/systems/${systemID}/services/${serviceID}`) &&
+        urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
         r.request().method() === 'DELETE'
     );
     await page.getByTestId(`service-action-delete-${serviceID}`).click();
@@ -355,11 +355,11 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // Clean up: delete the system
     await page.goto('/systems');
     await page.getByTestId(`system-action-delete-${systemID}`).click();
-    const deleteModal = page.locator('.ant-modal-content').filter({ hasText: /delete system/i });
+    const deleteModal = getAntModal(page, 'system-delete-modal');
     await expect(deleteModal).toBeVisible();
     await deleteModal.getByRole('textbox').first().fill(systemName);
     const deleteSysRespPromise = page.waitForResponse(
-      (r) => r.url().includes(`/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
     );
     await deleteModal.getByRole('button', { name: /delete/i }).click();
     expect((await deleteSysRespPromise).status()).toBe(204);
@@ -372,16 +372,15 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     await page.goto('/services');
     await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
 
-    await page.getByTestId('services-system-selector').click();
-    await page.locator('.ant-select-item-option').filter({ hasText: e2eSystemName }).first().click();
+    await selectAntOption(page, page.getByTestId('services-system-selector'), e2eSystemName);
 
     const serviceRow = page.locator('tr').filter({ hasText: e2eServiceName }).first();
     await expect(serviceRow).toBeVisible();
 
     const deleteRespPromise = page.waitForResponse(
       (r) =>
-        r.url().includes('/api/v1/systems/') &&
-        r.url().includes('/services/') &&
+        urlPathIncludes(r.url(), '/api/v1/systems/') &&
+        urlPathIncludes(r.url(), '/services/') &&
         r.request().method() === 'DELETE'
     );
     await serviceRow.locator('[data-testid^="service-action-delete-"]').first().click();
@@ -403,7 +402,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     // operationId: getVMRequestContext, createVMRequest
     // First get the VM request context to validate schema
     const contextRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/vms/request-context') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request-context') && r.request().method() === 'GET'
     );
 
     await page.goto('/vms');
@@ -420,48 +419,36 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     }
 
     // Step 0: Select System
-    const systemSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-    await systemSelect.click();
-    const sysOption = page.locator('.ant-select-dropdown:visible .ant-select-item-option').first();
-    await expect(sysOption).toBeVisible({ timeout: 5000 });
-    await sysOption.click();
+    const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+    await selectAntOption(page, systemSelect);
 
     // Select Service
-    const serviceSelect = page.locator('.ant-modal-content:visible [role="combobox"]').nth(1);
-    await serviceSelect.click();
-    const svcOption = page.locator('.ant-select-dropdown:visible .ant-select-item-option').first();
-    await expect(svcOption).toBeVisible({ timeout: 5000 });
-    await svcOption.click();
+    const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
+    await selectAntOption(page, serviceSelect);
 
-    await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
     // Step 1: Template
-    const templateSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-    await templateSelect.click();
-    const tplOption = page.locator('.ant-select-dropdown:visible .ant-select-item-option').first();
-    await expect(tplOption).toBeVisible({ timeout: 5000 });
-    await tplOption.click();
-    await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+    const templateSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+    await selectAntOption(page, templateSelect);
+    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
     // Step 2: Instance Size
-    const sizeSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-    await sizeSelect.click();
-    const sizeOption = page.locator('.ant-select-dropdown:visible .ant-select-item-option').first();
-    await expect(sizeOption).toBeVisible({ timeout: 5000 });
-    await sizeOption.click();
-    await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+    const sizeSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+    await selectAntOption(page, sizeSelect);
+    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
     // Step 3: Namespace + Reason
-    await page.locator('.ant-modal-content:visible input').first().fill('test-ns');
-    await page.locator('.ant-modal-content:visible textarea').first().fill('live e2e test request');
-    await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+    await getAntModal(page, 'vm-request-wizard-modal').locator('input').first().fill('test-ns');
+    await getAntModal(page, 'vm-request-wizard-modal').locator('textarea').first().fill('live e2e test request');
+    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
     // Step 4: Submit
-    const submitBtn = page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Submit' });
+    const submitBtn = getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Submit' });
     await expect(submitBtn).toBeVisible({ timeout: 5000 });
 
     const submitRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/vms/request') && r.request().method() === 'POST'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request') && r.request().method() === 'POST'
     );
     await submitBtn.click();
 
@@ -478,7 +465,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 5 – listVMs: VM list conforms to VMList schema', async ({ page }) => {
     // operationId: listVMs
     const vmListRespPromise = page.waitForResponse(
-      (r) => r.url().includes('/api/v1/vms') && r.request().method() === 'GET' && !r.url().includes('/batch') && !r.url().includes('/request') && !r.url().includes('/console')
+      (r) => urlPathIncludes(r.url(), '/api/v1/vms') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/batch') && !urlPathIncludes(r.url(), '/request') && !urlPathIncludes(r.url(), '/console')
     );
     await page.goto('/vms');
     await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
@@ -495,7 +482,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 5.B – listApprovals: approval list conforms to ApprovalTicketList schema', async ({ page }) => {
     // operationId: listApprovals
     const listRespPromise = page.waitForResponse(
-      (r) => r.url().includes('/api/v1/approvals') && r.request().method() === 'GET'
+      (r) => urlPathIncludes(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
     );
 
     await page.goto('/approvals');
@@ -553,12 +540,12 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     const approveRespPromise = page.waitForResponse(
       (r) =>
-        r.url().includes(`/api/v1/approvals/${ticketID}`) &&
+        urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
         (r.request().method() === 'PATCH' || r.request().method() === 'POST')
     );
 
     await approveBtn.click();
-    const modal = page.locator('.ant-modal-content').filter({ hasText: /approv/i }).last();
+    const modal = getAntModal(page, 'approve-modal');
     await expect(modal).toBeVisible();
     await modal.getByRole('button', { name: 'OK' }).click();
 
@@ -613,12 +600,12 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     const rejectRespPromise = page.waitForResponse(
       (r) =>
-        r.url().includes(`/api/v1/approvals/${ticketID}`) &&
+        urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
         (r.request().method() === 'PATCH' || r.request().method() === 'POST')
     );
 
     await rejectBtn.click();
-    const modal = page.locator('.ant-modal-content').filter({ hasText: /reject/i }).last();
+    const modal = getAntModal(page, 'reject-modal');
     await expect(modal).toBeVisible();
     await modal.locator('textarea').first().fill('Rejected by live e2e test');
     await modal.getByRole('button', { name: 'OK' }).click();
@@ -647,7 +634,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     await stoppedRow.getByRole('checkbox').check();
 
     const batchRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/vms/batch/power') && r.request().method() === 'POST'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch/power') && r.request().method() === 'POST'
     );
     await page.getByRole('button', { name: 'Start Selected', exact: true }).click();
 
@@ -662,7 +649,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 5.F – listNotifications: notification list conforms to NotificationList schema', async ({ page }) => {
     // operationId: listNotifications
     const notifRespPromise = page.waitForResponse(
-      (r) => r.url().includes('/api/v1/notifications') && r.request().method() === 'GET' && !r.url().includes('unread')
+      (r) => urlPathIncludes(r.url(), '/api/v1/notifications') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), 'unread')
     );
 
     await page.goto('/notifications');
@@ -677,7 +664,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 5.F – getUnreadCount: unread count endpoint returns valid integer', async ({ page }) => {
     // operationId: getUnreadCount
     const countRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/notifications/unread-count') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/notifications/unread-count') && r.request().method() === 'GET'
     );
 
     await page.goto('/dashboard');
@@ -702,7 +689,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
       console.warn('[requestVMConsoleAccess/openVMVNC] E2E_VM_RUNNING_ID not set – console flow not exercised');
       // Verify the VM list loads correctly at minimum
       const vmListRespPromise = page.waitForResponse(
-        (r) => r.url().includes('/api/v1/vms') && r.request().method() === 'GET' && !r.url().includes('/batch')
+        (r) => urlPathIncludes(r.url(), '/api/v1/vms') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/batch')
       );
       await page.goto('/vms');
       await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
@@ -718,12 +705,12 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
 
     const consoleRespPromise = page.waitForResponse(
       (r) =>
-        r.url().endsWith(`/api/v1/vms/${runningVMID}/console/request`) &&
+        urlPathEndsWith(r.url(), `/api/v1/vms/${runningVMID}/console/request`) &&
         r.request().method() === 'POST'
     );
     const vncRespPromise = page.waitForResponse(
       (r) =>
-        r.url().endsWith(`/api/v1/vms/${runningVMID}/vnc`) &&
+        urlPathEndsWith(r.url(), `/api/v1/vms/${runningVMID}/vnc`) &&
         r.request().method() === 'GET'
     );
 
@@ -745,7 +732,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 3 – listAdminTemplates: admin template list conforms to TemplateList schema', async ({ page }) => {
     // operationId: listAdminTemplates
     const tplRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/templates') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/templates');
@@ -760,7 +747,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 3 – listAdminInstanceSizes: instance-size list conforms to InstanceSizeList schema', async ({ page }) => {
     // operationId: listAdminInstanceSizes
     const sizeRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/instance-sizes');
@@ -775,7 +762,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 3 – listNamespaces: admin namespace list conforms to NamespaceRegistryList schema', async ({ page }) => {
     // operationId: listNamespaces
     const nsRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/namespaces') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/namespaces');
@@ -792,7 +779,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 2.A – listRoles: role list conforms to RoleList schema', async ({ page }) => {
     // operationId: listRoles
     const rolesRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/roles') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/rbac');
@@ -809,7 +796,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 2.B – listAuthProviderTypes: auth provider type list conforms to AuthProviderTypeList schema', async ({ page }) => {
     // operationId: listAuthProviderTypes
     const typesRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/auth-provider-types') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-provider-types') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/auth-providers');
@@ -824,7 +811,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 2.B – listAuthProviders: auth provider list conforms to AuthProviderList schema', async ({ page }) => {
     // operationId: listAuthProviders
     const listRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/auth-providers');
@@ -841,7 +828,7 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
   test('Stage 2.A+ – listUsers: user list conforms to UserList schema', async ({ page }) => {
     // operationId: listUsers
     const usersRespPromise = page.waitForResponse(
-      (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
     );
 
     await page.goto('/admin/users');

--- a/web/tests/e2e/user-selfservice-live.spec.ts
+++ b/web/tests/e2e/user-selfservice-live.spec.ts
@@ -33,6 +33,7 @@
 
 import { expect, test, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
+import {urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -49,7 +50,7 @@ async function login(page: Page, username = e2eUsername, password = e2ePassword)
     await page.getByPlaceholder('Password').fill(password);
     // operationId: login
     const loginRespPromise = page.waitForResponse(
-        (r) => r.url().endsWith('/api/v1/auth/login') && r.request().method() === 'POST'
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
     );
     await page.getByRole('button', { name: 'Login' }).click();
     const loginResp = await loginRespPromise;
@@ -106,7 +107,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: listTemplates
         // User-facing template list (not admin) is loaded in VM request wizard
         const respPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/templates') && !r.url().includes('/admin/') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/templates') && !urlPathIncludes(r.url(), '/admin/') && r.request().method() === 'GET'
         );
         await page.goto('/vms');
         await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
@@ -114,13 +115,11 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await page.getByRole('button', { name: 'Request VM' }).click();
         await expect(page.getByText('Create VM Request')).toBeVisible();
         // Navigate to template step
-        const systemSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-        await systemSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        const serviceSelect = page.locator('.ant-modal-content:visible [role="combobox"]').nth(1);
-        await serviceSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+        await selectAntOption(page, systemSelect);
+        const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
+        await selectAntOption(page, serviceSelect);
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
         // ── CONTRACT CHECK: TemplateList schema ───────────────────────────────────
         await expectSchema(respPromise, 'TemplateList', 200);
@@ -131,25 +130,22 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
     test('listInstanceSizes – GET /instance-sizes conforms to InstanceSizeList schema', async ({ page }) => {
         // operationId: listInstanceSizes
         const respPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/instance-sizes') && !r.url().includes('/admin/') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/instance-sizes') && !urlPathIncludes(r.url(), '/admin/') && r.request().method() === 'GET'
         );
         await page.goto('/vms');
         await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
         await page.getByRole('button', { name: 'Request VM' }).click();
         await expect(page.getByText('Create VM Request')).toBeVisible();
         // Navigate to instance size step (step 2)
-        const systemSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-        await systemSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        const serviceSelect = page.locator('.ant-modal-content:visible [role="combobox"]').nth(1);
-        await serviceSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+        await selectAntOption(page, systemSelect);
+        const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
+        await selectAntOption(page, serviceSelect);
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
         // Select template
-        const templateSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-        await templateSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        const templateSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+        await selectAntOption(page, templateSelect);
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
         // ── CONTRACT CHECK: InstanceSizeList schema ───────────────────────────────
         await expectSchema(respPromise, 'InstanceSizeList', 200);
@@ -161,8 +157,8 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: markNotificationRead
         // Get first notification
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().includes('/api/v1/notifications') && r.request().method() === 'GET'
-                && !r.url().includes('unread-count')
+            (r) => urlPathIncludes(r.url(), '/api/v1/notifications') && r.request().method() === 'GET'
+                && !urlPathIncludes(r.url(), 'unread-count')
         );
         await page.goto('/notifications');
         await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
@@ -175,7 +171,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── PATCH /notifications/{id}/read → 204 ─────────────────────────────────
         const readRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/notifications/${notifID}/read`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/notifications/${notifID}/read`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`notification-action-read-${notifID}`).click();
         const readResp = await readRespPromise;
@@ -189,7 +185,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── POST /notifications/mark-all-read → 204 ───────────────────────────────
         const markAllRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/notifications/mark-all-read') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/notifications/mark-all-read') && r.request().method() === 'POST'
         );
         await page.getByTestId('notifications-mark-all-read-button').click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
@@ -210,32 +206,28 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await page.getByRole('button', { name: 'Request VM' }).click();
         await expect(page.getByText('Create VM Request')).toBeVisible();
 
-        const systemSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-        await systemSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        const serviceSelect = page.locator('.ant-modal-content:visible [role="combobox"]').nth(1);
-        await serviceSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+        await selectAntOption(page, systemSelect);
+        const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
+        await selectAntOption(page, serviceSelect);
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-        const templateSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-        await templateSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        const templateSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+        await selectAntOption(page, templateSelect);
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-        const sizeSelect = page.locator('.ant-modal-content:visible [role="combobox"]').first();
-        await sizeSelect.click();
-        await page.locator('.ant-select-dropdown:visible .ant-select-item-option').first().click();
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        const sizeSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+        await selectAntOption(page, sizeSelect);
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-        await page.locator('.ant-modal-content:visible input').first().fill('test-ns-cancel');
-        await page.locator('.ant-modal-content:visible textarea').first().fill('cancel test request');
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Next' }).click();
+        await getAntModal(page, 'vm-request-wizard-modal').locator('input').first().fill('test-ns-cancel');
+        await getAntModal(page, 'vm-request-wizard-modal').locator('textarea').first().fill('cancel test request');
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
         const submitRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/vms/request') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request') && r.request().method() === 'POST'
         );
-        await page.locator('.ant-modal-content:visible').getByRole('button', { name: 'Submit' }).click();
+        await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Submit' }).click();
         const submitResp = await submitRespPromise;
         expect([202, 400, 409]).toContain(submitResp.status());
 
@@ -252,7 +244,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── POST /approvals/{id}/cancel → 204 ────────────────────────────────────
         const cancelRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/approvals/${ticketID}/cancel`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/approvals/${ticketID}/cancel`) && r.request().method() === 'POST'
         );
         await page.goto('/approvals');
         await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
@@ -278,13 +270,13 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await headerCheckbox.check();
 
         const batchRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/approvals/batch') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/approvals/batch') && r.request().method() === 'POST'
         );
         // Click batch approve button
         const batchApproveBtn = page.getByRole('button', { name: /batch approve|approve all/i }).first();
         await expect(batchApproveBtn, 'Batch approve button not found in approvals page').toBeVisible();
         await batchApproveBtn.click();
-        const confirmBtn = page.locator('.ant-modal-content:visible')
+        const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
             .getByRole('button', { name: /confirm|ok/i }).first();
         if (await confirmBtn.count() > 0) await confirmBtn.click();
 
@@ -298,7 +290,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: getSystem
         // Get first system from list
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'GET'
         );
         await page.goto('/systems');
         await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
@@ -311,7 +303,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── GET /systems/{id} → System ────────────────────────────────────────────
         const getRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/systems/${systemID}`) && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'GET'
         );
         await page.getByTestId(`system-action-detail-${systemID}`).click();
         await expectSchema(getRespPromise, 'System', 200);
@@ -323,7 +315,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: listServices
         // Get first system
         const sysListRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'GET'
         );
         await page.goto('/systems');
         await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
@@ -333,13 +325,12 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // Navigate to services for this system
         const svcListRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/systems/${systemID}/services`) && r.request().method() === 'GET'
-                && !r.url().includes('/services/')
+            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) && r.request().method() === 'GET'
+                && !urlPathIncludes(r.url(), '/services/')
         );
         await page.goto('/services');
         await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
-        await page.getByTestId('services-system-selector').click();
-        await page.locator('.ant-select-item-option').first().click();
+        await selectAntOption(page, page.getByTestId('services-system-selector'));
 
         // ── CONTRACT CHECK: ServiceList schema ────────────────────────────────────
         await expectSchema(svcListRespPromise, 'ServiceList', 200);
@@ -349,7 +340,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: getService
         // Get first system and first service
         const sysListRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'GET'
         );
         await page.goto('/systems');
         await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
@@ -359,12 +350,11 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         await page.goto('/services');
         await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
-        await page.getByTestId('services-system-selector').click();
-        await page.locator('.ant-select-item-option').first().click();
+        await selectAntOption(page, page.getByTestId('services-system-selector'));
 
         const svcListRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/systems/${systemID}/services`) && r.request().method() === 'GET'
-                && !r.url().includes('/services/')
+            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) && r.request().method() === 'GET'
+                && !urlPathIncludes(r.url(), '/services/')
         );
         const svcListBody = await validateApiResponse('ServiceList', await svcListRespPromise) as { items?: Array<{ id?: string }> };
         const serviceID = svcListBody.items?.[0]?.id ?? '';
@@ -372,7 +362,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── GET /systems/{id}/services/{id} → Service ─────────────────────────────
         const getRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/systems/${systemID}/services/${serviceID}`) && r.request().method() === 'GET'
+            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) && r.request().method() === 'GET'
         );
         await page.getByTestId(`service-action-detail-${serviceID}`).click();
         await expectSchema(getRespPromise, 'Service', 200);
@@ -387,10 +377,10 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
         const systemName = `e2emem${Date.now().toString(36).slice(-5)}`;
         const createSysRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/systems') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
         );
         await page.getByTestId('system-create-button').click();
-        const createModal = page.locator('.ant-modal-content').filter({ hasText: /create system/i });
+        const createModal = getAntModal(page, 'system-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.locator('input[maxlength="15"]').first().fill(systemName);
         await createModal.getByRole('button', { name: 'OK' }).click();
@@ -400,12 +390,12 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // Get a user to add as member
         const usersRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/users') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
         const usersResp = await usersRespPromise;
-        const usersBody = await usersResp.json() as { items?: Array<{ id?: string; username?: string }> };
+        const usersBody = await validateApiResponse('UserList', usersResp) as { items?: Array<{ id?: string; username?: string }> };
         const targetUser = usersBody.items?.find((u) => u.username !== e2eUsername);
         expect(targetUser, 'Need at least 2 users for member management test').toBeTruthy();
         const targetUserID = targetUser?.id ?? '';
@@ -413,18 +403,17 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // Navigate to system members
         await page.goto('/systems');
         await page.getByTestId(`system-action-members-${systemID}`).click();
-        const membersModal = page.locator('.ant-modal-content:visible');
+        const membersModal = getAntModal(page, 'system-members-modal');
         await expect(membersModal).toBeVisible();
 
         // ── POST /systems/{id}/members → SystemMember ─────────────────────────────
         const addRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/systems/${systemID}/members`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/systems/${systemID}/members`) && r.request().method() === 'POST'
         );
         await membersModal.getByTestId('member-add-button').click();
-        const addModal = page.getByTestId('member-add-modal');
+        const addModal = getAntModal(page, 'member-add-modal');
         await expect(addModal).toBeVisible();
-        await addModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').filter({ hasText: targetUser?.username ?? '' }).first().click();
+        await selectAntOption(page, addModal.locator('.ant-select-selector').first(), targetUser?.username ?? '');
         await addModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: addedMember } = await expectSchema(addRespPromise, 'SystemMember', 201);
@@ -432,20 +421,19 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── PATCH /systems/{id}/members/{user_id} → SystemMember ─────────────────
         const updateRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/systems/${systemID}/members/${targetUserID}`) && r.request().method() === 'PATCH'
+            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members/${targetUserID}`) && r.request().method() === 'PATCH'
         );
         await page.getByTestId(`member-action-edit-${targetUserID}`).click();
-        const editModal = page.getByTestId('member-edit-modal');
+        const editModal = getAntModal(page, 'member-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.locator('.ant-select-selector').first().click();
-        await page.locator('.ant-select-item-option').last().click();
+        await selectAntOption(page, editModal.locator('.ant-select-selector').first());
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'SystemMember', 200);
 
         // ── DELETE /systems/{id}/members/{user_id} → 204 ──────────────────────────
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/systems/${systemID}/members/${targetUserID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members/${targetUserID}`) && r.request().method() === 'DELETE'
         );
         await page.getByTestId(`member-action-remove-${targetUserID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok/i }).last();
@@ -456,11 +444,11 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await page.keyboard.press('Escape');
         await page.goto('/systems');
         await page.getByTestId(`system-action-delete-${systemID}`).click();
-        const deleteModal = page.locator('.ant-modal-content').filter({ hasText: /delete system/i });
+        const deleteModal = getAntModal(page, 'system-delete-modal');
         await expect(deleteModal).toBeVisible();
         await deleteModal.getByRole('textbox').first().fill(systemName);
         const deleteSysRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
         );
         await deleteModal.getByRole('button', { name: /delete/i }).click();
         expect((await deleteSysRespPromise).status()).toBe(204);
@@ -471,7 +459,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
     test('getNamespace – GET /admin/namespaces/{id} conforms to NamespaceRegistry schema', async ({ page }) => {
         // operationId: getNamespace
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/admin/namespaces') && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
         );
         await page.goto('/admin/namespaces');
         await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
@@ -484,7 +472,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── GET /admin/namespaces/{id} → NamespaceRegistry ───────────────────────
         const getRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/admin/namespaces/${nsID}`) && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/admin/namespaces/${nsID}`) && r.request().method() === 'GET'
         );
         await page.getByTestId(`namespace-action-detail-${nsID}`).click();
         await expectSchema(getRespPromise, 'NamespaceRegistry', 200);
@@ -501,10 +489,10 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── POST /auth/change-password → 204 (change to new password) ────────────
         const changeRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/auth/change-password') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/auth/change-password') && r.request().method() === 'POST'
         );
         await page.getByTestId('change-password-button').click();
-        const changeModal = page.getByTestId('change-password-modal');
+        const changeModal = getAntModal(page, 'change-password-modal');
         await expect(changeModal).toBeVisible();
         await changeModal.locator('input[type="password"]').nth(0).fill(e2ePassword);
         await changeModal.locator('input[type="password"]').nth(1).fill(e2eNewPassword);
@@ -516,10 +504,10 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
         // ── Restore original password ─────────────────────────────────────────────
         const restoreRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/auth/change-password') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/auth/change-password') && r.request().method() === 'POST'
         );
         await page.getByTestId('change-password-button').click();
-        const restoreModal = page.getByTestId('change-password-modal');
+        const restoreModal = getAntModal(page, 'change-password-modal');
         await expect(restoreModal).toBeVisible();
         await restoreModal.locator('input[type="password"]').nth(0).fill(e2eNewPassword);
         await restoreModal.locator('input[type="password"]').nth(1).fill(e2ePassword);

--- a/web/tests/e2e/vm-lifecycle-live.spec.ts
+++ b/web/tests/e2e/vm-lifecycle-live.spec.ts
@@ -35,6 +35,7 @@
 
 import { expect, test, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
+import {urlPathEndsWith, urlPathIncludes} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -51,7 +52,7 @@ async function login(page: Page): Promise<void> {
 
     // operationId: login
     const loginRespPromise = page.waitForResponse(
-        (r) => r.url().endsWith('/api/v1/auth/login') && r.request().method() === 'POST'
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
     );
     await page.getByRole('button', { name: 'Login' }).click();
     const loginResp = await loginRespPromise;
@@ -76,7 +77,7 @@ async function expectSchema(
 
 async function getFirstVMId(page: Page): Promise<string> {
     const listRespPromise = page.waitForResponse(
-        (r) => r.url().includes('/api/v1/vms') && r.request().method() === 'GET' && !r.url().includes('/vms/')
+        (r) => urlPathIncludes(r.url(), '/api/v1/vms') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/vms/')
     );
     await page.goto('/vms');
     await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
@@ -108,8 +109,8 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         const vmId = await getFirstVMId(page);
 
         const getRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/vms/${vmId}`) && r.request().method() === 'GET'
-                && !r.url().includes('/console') && !r.url().includes('/vnc')
+            (r) => urlPathIncludes(r.url(), `/api/v1/vms/${vmId}`) && r.request().method() === 'GET'
+                && !urlPathIncludes(r.url(), '/console') && !urlPathIncludes(r.url(), '/vnc')
         );
         // Navigate to VM detail page (triggers GET /vms/{id})
         await page.getByTestId(`vm-action-detail-${vmId}`).click();
@@ -132,7 +133,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         expect(vmId, 'Could not extract VM id from start button').toBeTruthy();
 
         const startRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/${vmId}/start`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/start`) && r.request().method() === 'POST'
         );
         await stoppedRow.locator(`[data-testid="vm-action-start-${vmId}"]`).click();
         // Confirm dialog if present
@@ -161,7 +162,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         expect(vmId, 'Could not extract VM id from stop button').toBeTruthy();
 
         const stopRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/${vmId}/stop`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/stop`) && r.request().method() === 'POST'
         );
         await runningRow.locator(`[data-testid="vm-action-stop-${vmId}"]`).click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
@@ -187,7 +188,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         expect(vmId, 'Could not extract VM id from restart button').toBeTruthy();
 
         const restartRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/${vmId}/restart`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/restart`) && r.request().method() === 'POST'
         );
         await runningRow.locator(`[data-testid="vm-action-restart-${vmId}"]`).click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
@@ -210,7 +211,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
 
         // The detail page power buttons call POST /vms/{vm_id}/power with action body
         const powerRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/${vmId}/power`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/power`) && r.request().method() === 'POST'
         );
 
         // Click any available power button on the detail page (start, stop, or restart)
@@ -261,7 +262,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         expect(vmName, 'Could not read VM name from table row').toBeTruthy();
 
         const deleteRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/vms/${vmId}`) && r.request().method() === 'DELETE'
+            (r) => urlPathIncludes(r.url(), `/api/v1/vms/${vmId}`) && r.request().method() === 'DELETE'
         );
         await stoppedRow.locator(`[data-testid="vm-action-delete-${vmId}"]`).click();
 
@@ -290,8 +291,8 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
     test('listVMBatches – GET /vms/batch conforms to VMBatchList schema', async ({ page }) => {
         // operationId: listVMBatches
         const listRespPromise = page.waitForResponse(
-            (r) => r.url().includes('/api/v1/vms/batch') && r.request().method() === 'GET'
-                && !r.url().includes('/vms/batch/') // Exclude batch/{id} detail
+            (r) => urlPathIncludes(r.url(), '/api/v1/vms/batch') && r.request().method() === 'GET'
+                && !urlPathIncludes(r.url(), '/vms/batch/') // Exclude batch/{id} detail
         );
         await page.goto('/vms/batch');
         await expect(page.locator('body')).toBeVisible();
@@ -317,7 +318,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         await headerCheckbox.check();
 
         const batchRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith('/api/v1/vms/batch') && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch') && r.request().method() === 'POST'
         );
 
         // Click generic batch submit (not power-specific)
@@ -342,7 +343,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         await headerCheckbox.check();
 
         const submitRespPromise = page.waitForResponse(
-            (r) => r.url().includes('/api/v1/vms/batch') && r.request().method() === 'POST'
+            (r) => urlPathIncludes(r.url(), '/api/v1/vms/batch') && r.request().method() === 'POST'
         );
         const batchBtn = page.getByRole('button', { name: /batch|submit batch/i }).first();
         await expect(batchBtn).toBeVisible();
@@ -364,7 +365,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
 
         // ── CONTRACT CHECK: VMBatchStatusResponse schema ──────────────────────────
         const statusRespPromise = page.waitForResponse(
-            (r) => r.url().includes(`/api/v1/vms/batch/${batchId}`) && r.request().method() === 'GET'
+            (r) => urlPathIncludes(r.url(), `/api/v1/vms/batch/${batchId}`) && r.request().method() === 'GET'
         );
         // Navigate to batch detail page
         await page.goto(`/vms/batch/${batchId}`);
@@ -387,7 +388,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         expect(batchId, 'Could not extract batch_id from retry button').toBeTruthy();
 
         const retryRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/batch/${batchId}/retry`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/batch/${batchId}/retry`) && r.request().method() === 'POST'
         );
         await failedBatchRow.locator(`[data-testid="batch-action-retry-${batchId}"]`).click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
@@ -413,7 +414,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         expect(batchId, 'Could not extract batch_id from cancel button').toBeTruthy();
 
         const cancelRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/batch/${batchId}/cancel`) && r.request().method() === 'POST'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/batch/${batchId}/cancel`) && r.request().method() === 'POST'
         );
         await pendingBatchRow.locator(`[data-testid="batch-action-cancel-${batchId}"]`).click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
@@ -432,7 +433,7 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
 
         // Navigate to VM detail which should show console status
         const statusRespPromise = page.waitForResponse(
-            (r) => r.url().endsWith(`/api/v1/vms/${vmId}/console/status`) && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/console/status`) && r.request().method() === 'GET'
         );
         await page.goto(`/vms/${vmId}`);
         await expect(page.locator('body')).toBeVisible();


### PR DESCRIPTION
## Summary
- Forward-port only the valuable live E2E hardening from `wip/implementation` to `main`.
- Add `web/tests/e2e/lib/helpers.ts` with reusable Playwright helpers:
  - `urlPathEndsWith` / `urlPathIncludes` for query-safe URL matching.
  - `selectAntOption` for stable Ant Design `Select` interaction.
  - `getAntModal` for stable Ant Design modal targeting.
- Update 5 live specs to use the helpers and reduce brittle selectors/network predicates:
  - `web/tests/e2e/admin-extended-live.spec.ts`
  - `web/tests/e2e/admin-flow-live.spec.ts`
  - `web/tests/e2e/master-flow-live.spec.ts`
  - `web/tests/e2e/user-selfservice-live.spec.ts`
  - `web/tests/e2e/vm-lifecycle-live.spec.ts`

## Why
Live E2E had intermittent fragility from:
- `url().endsWith(...)` / `url().includes(...)` checks being affected by query strings.
- Ant Design dropdown leave animations creating transient duplicate visible dropdowns.
- Modal visibility checks targeting unstable wrappers/content nodes.

This change aligns test interactions with Playwright best practices (web-first assertions, stable locators, robust response predicates).

## Scope Guardrails
Included only these 6 live-E2E files.
Excluded on purpose (no forward-port in this PR):
- `docs/design/traceability/master-flow.json`
- `web/src/features/vm-management/hooks/useVMManagementController.ts`
- `web/tests/e2e/admin-flow-smoke.spec.ts`
- `web/tests/e2e/master-flow-smoke.spec.ts`

## Validation
- `cd web && npm run typecheck`
- `cd web && npm run lint -- tests/e2e/admin-extended-live.spec.ts tests/e2e/admin-flow-live.spec.ts tests/e2e/master-flow-live.spec.ts tests/e2e/user-selfservice-live.spec.ts tests/e2e/vm-lifecycle-live.spec.ts tests/e2e/lib/helpers.ts`
- `cd web && PW_WEB_PORT=3100 LIVE_E2E=true npx playwright test --project=live-chromium tests/e2e/admin-extended-live.spec.ts tests/e2e/admin-flow-live.spec.ts tests/e2e/master-flow-live.spec.ts tests/e2e/user-selfservice-live.spec.ts tests/e2e/vm-lifecycle-live.spec.ts --list`

## DCO
- Commit is signed off (`Signed-off-by:` present).
