### PR TITLE
feat(admin): stage-1 schema-driven instance size and ADR-0036 hardening

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -47,6 +47,8 @@ tags:
     description: RBAC role and global binding management
   - name: auth-providers
     description: Pluggable authentication provider management
+  - name: schemas
+    description: Dynamic configuration schemas for entities
 
 paths:
   # ── Health ──────────────────────────────────────────
@@ -83,6 +85,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  # ── Schemas ─────────────────────────────────────────
+  /schemas/{entity_type}:
+    get:
+      tags: [schemas]
+      summary: Retrieve dynamic schema and UI mask for an entity
+      operationId: getDynamicSchema
+      # Public endpoint: schema metadata does not contain sensitive data and
+      # must be accessible before a user logs in (bootstrap scenario, ADR-0023).
+      security: []
+      parameters:
+        - name: entity_type
+          in: path
+          required: true
+          schema:
+            type: string
+            # Only entity types with dynamic schema forms are listed here.
+            # template: excluded — cloud_init is a static YAML textarea, no dynamic schema (master-flow Step 3).
+            # cluster:  excluded — no cluster-level override schema defined yet (ADR-0023 phase 2).
+            enum: [instancesize]
+      responses:
+        '200':
+          description: Dynamic schema retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DynamicSchemaResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # ── Systems ─────────────────────────────────────────
   /systems:
@@ -2094,9 +2127,74 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
 
   # ── Schemas ─────────────────────────────────────────
   schemas:
+    MaskField:
+      type: object
+      required: [path, display_name]
+      properties:
+        path:
+          type: string
+          description: Dot-notation JSON path resolving within the provided unified schema.
+        display_name:
+          type: string
+          description: Desired localized or standardized label for the UI form projection.
+    SchemaMask:
+      type: object
+      required: [quick_fields]
+      properties:
+        quick_fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MaskField'
+        advanced_fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MaskField'
+    DynamicSchemaResponse:
+      type: object
+      required: [schema, mask]
+      properties:
+        schema:
+          type: object
+          description: Full structure representing the requested JSON Schema payload.
+          additionalProperties: {}
+        mask:
+          $ref: '#/components/schemas/SchemaMask'
+        schema_version:
+          type: string
+          description: |
+            Semantic version of the schema (e.g. "1.2.0").
+            Frontend uses this for cache drift detection and audit (ADR-0023).
+          example: "1.2.0"
+        source:
+          type: string
+          enum: [cache, embedded, remote]
+          description: |
+            Data source of the schema response (ADR-0023 degradation strategy):
+            - cache:    Served from server-side schema cache (nominal path).
+            - embedded: Backend fell back to a bundled embedded schema (warn user).
+            - remote:   Fetched live from KubeVirt API (slow path, no cache).
+        degraded:
+          type: boolean
+          default: false
+          description: |
+            When true, the response uses an older or embedded fallback schema.
+            Frontend MUST display a warning banner per ADR-0023 UI Degradation States.
+        fetched_at:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the schema was fetched or last cached.
+
+
+
     # ── Common ──────────────────────────────────────
     Health:
       type: object
@@ -2757,6 +2855,9 @@ components:
         pvc_name:
           type: string
           description: PVC/DataVolume name for PVC mode
+        pvc_namespace:
+          type: string
+          description: Kubernetes namespace where the PVC/DataVolume is located (required when source_type is 'pvc')
         cloud_init:
           type: string
           description: Cloud-init userdata YAML (applied at VM boot)
@@ -2790,6 +2891,11 @@ components:
         pvc_name:
           type: string
           description: Required when source_type is 'pvc'
+        pvc_namespace:
+          type: string
+          description: >-
+            Kubernetes namespace where the PVC/DataVolume is located.
+            Required when source_type is 'pvc'.
         cloud_init:
           type: string
           description: Cloud-init userdata YAML
@@ -2814,6 +2920,9 @@ components:
           type: string
         pvc_name:
           type: string
+        pvc_namespace:
+          type: string
+          description: Kubernetes namespace where the PVC/DataVolume is located
         cloud_init:
           type: string
         os_family:

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -746,6 +746,7 @@ var (
 		{Name: "source_type", Type: field.TypeString, Nullable: true, Default: ""},
 		{Name: "image_url", Type: field.TypeString, Nullable: true},
 		{Name: "pvc_name", Type: field.TypeString, Nullable: true},
+		{Name: "pvc_namespace", Type: field.TypeString, Nullable: true},
 		{Name: "cloud_init", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "os_family", Type: field.TypeString, Nullable: true},
 		{Name: "os_version", Type: field.TypeString, Nullable: true},
@@ -766,7 +767,7 @@ var (
 			{
 				Name:    "template_enabled",
 				Unique:  false,
-				Columns: []*schema.Column{TemplatesColumns[12]},
+				Columns: []*schema.Column{TemplatesColumns[13]},
 			},
 			{
 				Name:    "template_source_type",

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -18663,6 +18663,7 @@ type TemplateMutation struct {
 	source_type   *string
 	image_url     *string
 	pvc_name      *string
+	pvc_namespace *string
 	cloud_init    *string
 	os_family     *string
 	os_version    *string
@@ -19131,6 +19132,55 @@ func (m *TemplateMutation) ResetPvcName() {
 	delete(m.clearedFields, template.FieldPvcName)
 }
 
+// SetPvcNamespace sets the "pvc_namespace" field.
+func (m *TemplateMutation) SetPvcNamespace(s string) {
+	m.pvc_namespace = &s
+}
+
+// PvcNamespace returns the value of the "pvc_namespace" field in the mutation.
+func (m *TemplateMutation) PvcNamespace() (r string, exists bool) {
+	v := m.pvc_namespace
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPvcNamespace returns the old "pvc_namespace" field's value of the Template entity.
+// If the Template object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TemplateMutation) OldPvcNamespace(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPvcNamespace is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPvcNamespace requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPvcNamespace: %w", err)
+	}
+	return oldValue.PvcNamespace, nil
+}
+
+// ClearPvcNamespace clears the value of the "pvc_namespace" field.
+func (m *TemplateMutation) ClearPvcNamespace() {
+	m.pvc_namespace = nil
+	m.clearedFields[template.FieldPvcNamespace] = struct{}{}
+}
+
+// PvcNamespaceCleared returns if the "pvc_namespace" field was cleared in this mutation.
+func (m *TemplateMutation) PvcNamespaceCleared() bool {
+	_, ok := m.clearedFields[template.FieldPvcNamespace]
+	return ok
+}
+
+// ResetPvcNamespace resets all changes to the "pvc_namespace" field.
+func (m *TemplateMutation) ResetPvcNamespace() {
+	m.pvc_namespace = nil
+	delete(m.clearedFields, template.FieldPvcNamespace)
+}
+
 // SetCloudInit sets the "cloud_init" field.
 func (m *TemplateMutation) SetCloudInit(s string) {
 	m.cloud_init = &s
@@ -19384,7 +19434,7 @@ func (m *TemplateMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TemplateMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 14)
 	if m.created_at != nil {
 		fields = append(fields, template.FieldCreatedAt)
 	}
@@ -19408,6 +19458,9 @@ func (m *TemplateMutation) Fields() []string {
 	}
 	if m.pvc_name != nil {
 		fields = append(fields, template.FieldPvcName)
+	}
+	if m.pvc_namespace != nil {
+		fields = append(fields, template.FieldPvcNamespace)
 	}
 	if m.cloud_init != nil {
 		fields = append(fields, template.FieldCloudInit)
@@ -19448,6 +19501,8 @@ func (m *TemplateMutation) Field(name string) (ent.Value, bool) {
 		return m.ImageURL()
 	case template.FieldPvcName:
 		return m.PvcName()
+	case template.FieldPvcNamespace:
+		return m.PvcNamespace()
 	case template.FieldCloudInit:
 		return m.CloudInit()
 	case template.FieldOsFamily:
@@ -19483,6 +19538,8 @@ func (m *TemplateMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldImageURL(ctx)
 	case template.FieldPvcName:
 		return m.OldPvcName(ctx)
+	case template.FieldPvcNamespace:
+		return m.OldPvcNamespace(ctx)
 	case template.FieldCloudInit:
 		return m.OldCloudInit(ctx)
 	case template.FieldOsFamily:
@@ -19557,6 +19614,13 @@ func (m *TemplateMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetPvcName(v)
+		return nil
+	case template.FieldPvcNamespace:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPvcNamespace(v)
 		return nil
 	case template.FieldCloudInit:
 		v, ok := value.(string)
@@ -19638,6 +19702,9 @@ func (m *TemplateMutation) ClearedFields() []string {
 	if m.FieldCleared(template.FieldPvcName) {
 		fields = append(fields, template.FieldPvcName)
 	}
+	if m.FieldCleared(template.FieldPvcNamespace) {
+		fields = append(fields, template.FieldPvcNamespace)
+	}
 	if m.FieldCleared(template.FieldCloudInit) {
 		fields = append(fields, template.FieldCloudInit)
 	}
@@ -19675,6 +19742,9 @@ func (m *TemplateMutation) ClearField(name string) error {
 		return nil
 	case template.FieldPvcName:
 		m.ClearPvcName()
+		return nil
+	case template.FieldPvcNamespace:
+		m.ClearPvcNamespace()
 		return nil
 	case template.FieldCloudInit:
 		m.ClearCloudInit()
@@ -19716,6 +19786,9 @@ func (m *TemplateMutation) ResetField(name string) error {
 		return nil
 	case template.FieldPvcName:
 		m.ResetPvcName()
+		return nil
+	case template.FieldPvcNamespace:
+		m.ResetPvcNamespace()
 		return nil
 	case template.FieldCloudInit:
 		m.ResetCloudInit()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -788,11 +788,11 @@ func init() {
 	// template.DefaultSourceType holds the default value on creation for the source_type field.
 	template.DefaultSourceType = templateDescSourceType.Default.(string)
 	// templateDescEnabled is the schema descriptor for enabled field.
-	templateDescEnabled := templateFields[10].Descriptor()
+	templateDescEnabled := templateFields[11].Descriptor()
 	// template.DefaultEnabled holds the default value on creation for the enabled field.
 	template.DefaultEnabled = templateDescEnabled.Default.(bool)
 	// templateDescCreatedBy is the schema descriptor for created_by field.
-	templateDescCreatedBy := templateFields[11].Descriptor()
+	templateDescCreatedBy := templateFields[12].Descriptor()
 	// template.CreatedByValidator is a validator for the "created_by" field. It is called by the builders before save.
 	template.CreatedByValidator = templateDescCreatedBy.Validators[0].(func(string) error)
 	userMixin := schema.User{}.Mixin()

--- a/ent/schema/template.go
+++ b/ent/schema/template.go
@@ -45,6 +45,11 @@ func (Template) Fields() []ent.Field {
 		// Used when source_type == "pvc". Example: "ubuntu-22.04-base"
 		field.String("pvc_name").
 			Optional(),
+		// pvc_namespace is the Kubernetes namespace where the PVC/DataVolume is located.
+		// Used when source_type == "pvc". Required together with pvc_name.
+		// ADR-0036: Namespace is needed so the VM creation worker can reference the correct PVC.
+		field.String("pvc_namespace").
+			Optional(),
 		// cloud_init stores raw cloud-init YAML configuration (userdata).
 		// Applied to VMs at boot time via cloud-init datasource.
 		field.Text("cloud_init").

--- a/ent/template.go
+++ b/ent/template.go
@@ -33,6 +33,8 @@ type Template struct {
 	ImageURL string `json:"image_url,omitempty"`
 	// PvcName holds the value of the "pvc_name" field.
 	PvcName string `json:"pvc_name,omitempty"`
+	// PvcNamespace holds the value of the "pvc_namespace" field.
+	PvcNamespace string `json:"pvc_namespace,omitempty"`
 	// CloudInit holds the value of the "cloud_init" field.
 	CloudInit string `json:"cloud_init,omitempty"`
 	// OsFamily holds the value of the "os_family" field.
@@ -53,7 +55,7 @@ func (*Template) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case template.FieldEnabled:
 			values[i] = new(sql.NullBool)
-		case template.FieldID, template.FieldName, template.FieldDisplayName, template.FieldDescription, template.FieldSourceType, template.FieldImageURL, template.FieldPvcName, template.FieldCloudInit, template.FieldOsFamily, template.FieldOsVersion, template.FieldCreatedBy:
+		case template.FieldID, template.FieldName, template.FieldDisplayName, template.FieldDescription, template.FieldSourceType, template.FieldImageURL, template.FieldPvcName, template.FieldPvcNamespace, template.FieldCloudInit, template.FieldOsFamily, template.FieldOsVersion, template.FieldCreatedBy:
 			values[i] = new(sql.NullString)
 		case template.FieldCreatedAt, template.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -125,6 +127,12 @@ func (_m *Template) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field pvc_name", values[i])
 			} else if value.Valid {
 				_m.PvcName = value.String
+			}
+		case template.FieldPvcNamespace:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field pvc_namespace", values[i])
+			} else if value.Valid {
+				_m.PvcNamespace = value.String
 			}
 		case template.FieldCloudInit:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -215,6 +223,9 @@ func (_m *Template) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("pvc_name=")
 	builder.WriteString(_m.PvcName)
+	builder.WriteString(", ")
+	builder.WriteString("pvc_namespace=")
+	builder.WriteString(_m.PvcNamespace)
 	builder.WriteString(", ")
 	builder.WriteString("cloud_init=")
 	builder.WriteString(_m.CloudInit)

--- a/ent/template/template.go
+++ b/ent/template/template.go
@@ -29,6 +29,8 @@ const (
 	FieldImageURL = "image_url"
 	// FieldPvcName holds the string denoting the pvc_name field in the database.
 	FieldPvcName = "pvc_name"
+	// FieldPvcNamespace holds the string denoting the pvc_namespace field in the database.
+	FieldPvcNamespace = "pvc_namespace"
 	// FieldCloudInit holds the string denoting the cloud_init field in the database.
 	FieldCloudInit = "cloud_init"
 	// FieldOsFamily holds the string denoting the os_family field in the database.
@@ -54,6 +56,7 @@ var Columns = []string{
 	FieldSourceType,
 	FieldImageURL,
 	FieldPvcName,
+	FieldPvcNamespace,
 	FieldCloudInit,
 	FieldOsFamily,
 	FieldOsVersion,
@@ -134,6 +137,11 @@ func ByImageURL(opts ...sql.OrderTermOption) OrderOption {
 // ByPvcName orders the results by the pvc_name field.
 func ByPvcName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPvcName, opts...).ToFunc()
+}
+
+// ByPvcNamespace orders the results by the pvc_namespace field.
+func ByPvcNamespace(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPvcNamespace, opts...).ToFunc()
 }
 
 // ByCloudInit orders the results by the cloud_init field.

--- a/ent/template/where.go
+++ b/ent/template/where.go
@@ -104,6 +104,11 @@ func PvcName(v string) predicate.Template {
 	return predicate.Template(sql.FieldEQ(FieldPvcName, v))
 }
 
+// PvcNamespace applies equality check predicate on the "pvc_namespace" field. It's identical to PvcNamespaceEQ.
+func PvcNamespace(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldPvcNamespace, v))
+}
+
 // CloudInit applies equality check predicate on the "cloud_init" field. It's identical to CloudInitEQ.
 func CloudInit(v string) predicate.Template {
 	return predicate.Template(sql.FieldEQ(FieldCloudInit, v))
@@ -647,6 +652,81 @@ func PvcNameEqualFold(v string) predicate.Template {
 // PvcNameContainsFold applies the ContainsFold predicate on the "pvc_name" field.
 func PvcNameContainsFold(v string) predicate.Template {
 	return predicate.Template(sql.FieldContainsFold(FieldPvcName, v))
+}
+
+// PvcNamespaceEQ applies the EQ predicate on the "pvc_namespace" field.
+func PvcNamespaceEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldEQ(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceNEQ applies the NEQ predicate on the "pvc_namespace" field.
+func PvcNamespaceNEQ(v string) predicate.Template {
+	return predicate.Template(sql.FieldNEQ(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceIn applies the In predicate on the "pvc_namespace" field.
+func PvcNamespaceIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldIn(FieldPvcNamespace, vs...))
+}
+
+// PvcNamespaceNotIn applies the NotIn predicate on the "pvc_namespace" field.
+func PvcNamespaceNotIn(vs ...string) predicate.Template {
+	return predicate.Template(sql.FieldNotIn(FieldPvcNamespace, vs...))
+}
+
+// PvcNamespaceGT applies the GT predicate on the "pvc_namespace" field.
+func PvcNamespaceGT(v string) predicate.Template {
+	return predicate.Template(sql.FieldGT(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceGTE applies the GTE predicate on the "pvc_namespace" field.
+func PvcNamespaceGTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldGTE(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceLT applies the LT predicate on the "pvc_namespace" field.
+func PvcNamespaceLT(v string) predicate.Template {
+	return predicate.Template(sql.FieldLT(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceLTE applies the LTE predicate on the "pvc_namespace" field.
+func PvcNamespaceLTE(v string) predicate.Template {
+	return predicate.Template(sql.FieldLTE(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceContains applies the Contains predicate on the "pvc_namespace" field.
+func PvcNamespaceContains(v string) predicate.Template {
+	return predicate.Template(sql.FieldContains(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceHasPrefix applies the HasPrefix predicate on the "pvc_namespace" field.
+func PvcNamespaceHasPrefix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasPrefix(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceHasSuffix applies the HasSuffix predicate on the "pvc_namespace" field.
+func PvcNamespaceHasSuffix(v string) predicate.Template {
+	return predicate.Template(sql.FieldHasSuffix(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceIsNil applies the IsNil predicate on the "pvc_namespace" field.
+func PvcNamespaceIsNil() predicate.Template {
+	return predicate.Template(sql.FieldIsNull(FieldPvcNamespace))
+}
+
+// PvcNamespaceNotNil applies the NotNil predicate on the "pvc_namespace" field.
+func PvcNamespaceNotNil() predicate.Template {
+	return predicate.Template(sql.FieldNotNull(FieldPvcNamespace))
+}
+
+// PvcNamespaceEqualFold applies the EqualFold predicate on the "pvc_namespace" field.
+func PvcNamespaceEqualFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldEqualFold(FieldPvcNamespace, v))
+}
+
+// PvcNamespaceContainsFold applies the ContainsFold predicate on the "pvc_namespace" field.
+func PvcNamespaceContainsFold(v string) predicate.Template {
+	return predicate.Template(sql.FieldContainsFold(FieldPvcNamespace, v))
 }
 
 // CloudInitEQ applies the EQ predicate on the "cloud_init" field.

--- a/ent/template_create.go
+++ b/ent/template_create.go
@@ -124,6 +124,20 @@ func (_c *TemplateCreate) SetNillablePvcName(v *string) *TemplateCreate {
 	return _c
 }
 
+// SetPvcNamespace sets the "pvc_namespace" field.
+func (_c *TemplateCreate) SetPvcNamespace(v string) *TemplateCreate {
+	_c.mutation.SetPvcNamespace(v)
+	return _c
+}
+
+// SetNillablePvcNamespace sets the "pvc_namespace" field if the given value is not nil.
+func (_c *TemplateCreate) SetNillablePvcNamespace(v *string) *TemplateCreate {
+	if v != nil {
+		_c.SetPvcNamespace(*v)
+	}
+	return _c
+}
+
 // SetCloudInit sets the "cloud_init" field.
 func (_c *TemplateCreate) SetCloudInit(v string) *TemplateCreate {
 	_c.mutation.SetCloudInit(v)
@@ -338,6 +352,10 @@ func (_c *TemplateCreate) createSpec() (*Template, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.PvcName(); ok {
 		_spec.SetField(template.FieldPvcName, field.TypeString, value)
 		_node.PvcName = value
+	}
+	if value, ok := _c.mutation.PvcNamespace(); ok {
+		_spec.SetField(template.FieldPvcNamespace, field.TypeString, value)
+		_node.PvcNamespace = value
 	}
 	if value, ok := _c.mutation.CloudInit(); ok {
 		_spec.SetField(template.FieldCloudInit, field.TypeString, value)

--- a/ent/template_update.go
+++ b/ent/template_update.go
@@ -148,6 +148,26 @@ func (_u *TemplateUpdate) ClearPvcName() *TemplateUpdate {
 	return _u
 }
 
+// SetPvcNamespace sets the "pvc_namespace" field.
+func (_u *TemplateUpdate) SetPvcNamespace(v string) *TemplateUpdate {
+	_u.mutation.SetPvcNamespace(v)
+	return _u
+}
+
+// SetNillablePvcNamespace sets the "pvc_namespace" field if the given value is not nil.
+func (_u *TemplateUpdate) SetNillablePvcNamespace(v *string) *TemplateUpdate {
+	if v != nil {
+		_u.SetPvcNamespace(*v)
+	}
+	return _u
+}
+
+// ClearPvcNamespace clears the value of the "pvc_namespace" field.
+func (_u *TemplateUpdate) ClearPvcNamespace() *TemplateUpdate {
+	_u.mutation.ClearPvcNamespace()
+	return _u
+}
+
 // SetCloudInit sets the "cloud_init" field.
 func (_u *TemplateUpdate) SetCloudInit(v string) *TemplateUpdate {
 	_u.mutation.SetCloudInit(v)
@@ -340,6 +360,12 @@ func (_u *TemplateUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if _u.mutation.PvcNameCleared() {
 		_spec.ClearField(template.FieldPvcName, field.TypeString)
 	}
+	if value, ok := _u.mutation.PvcNamespace(); ok {
+		_spec.SetField(template.FieldPvcNamespace, field.TypeString, value)
+	}
+	if _u.mutation.PvcNamespaceCleared() {
+		_spec.ClearField(template.FieldPvcNamespace, field.TypeString)
+	}
 	if value, ok := _u.mutation.CloudInit(); ok {
 		_spec.SetField(template.FieldCloudInit, field.TypeString, value)
 	}
@@ -501,6 +527,26 @@ func (_u *TemplateUpdateOne) SetNillablePvcName(v *string) *TemplateUpdateOne {
 // ClearPvcName clears the value of the "pvc_name" field.
 func (_u *TemplateUpdateOne) ClearPvcName() *TemplateUpdateOne {
 	_u.mutation.ClearPvcName()
+	return _u
+}
+
+// SetPvcNamespace sets the "pvc_namespace" field.
+func (_u *TemplateUpdateOne) SetPvcNamespace(v string) *TemplateUpdateOne {
+	_u.mutation.SetPvcNamespace(v)
+	return _u
+}
+
+// SetNillablePvcNamespace sets the "pvc_namespace" field if the given value is not nil.
+func (_u *TemplateUpdateOne) SetNillablePvcNamespace(v *string) *TemplateUpdateOne {
+	if v != nil {
+		_u.SetPvcNamespace(*v)
+	}
+	return _u
+}
+
+// ClearPvcNamespace clears the value of the "pvc_namespace" field.
+func (_u *TemplateUpdateOne) ClearPvcNamespace() *TemplateUpdateOne {
+	_u.mutation.ClearPvcNamespace()
 	return _u
 }
 
@@ -725,6 +771,12 @@ func (_u *TemplateUpdateOne) sqlSave(ctx context.Context) (_node *Template, err 
 	}
 	if _u.mutation.PvcNameCleared() {
 		_spec.ClearField(template.FieldPvcName, field.TypeString)
+	}
+	if value, ok := _u.mutation.PvcNamespace(); ok {
+		_spec.SetField(template.FieldPvcNamespace, field.TypeString, value)
+	}
+	if _u.mutation.PvcNamespaceCleared() {
+		_spec.ClearField(template.FieldPvcNamespace, field.TypeString)
 	}
 	if value, ok := _u.mutation.CloudInit(); ok {
 		_spec.SetField(template.FieldCloudInit, field.TypeString, value)

--- a/internal/api/generated/server.gen.go
+++ b/internal/api/generated/server.gen.go
@@ -95,6 +95,13 @@ const (
 	DeleteVMResponseStatusPENDING DeleteVMResponseStatus = "PENDING"
 )
 
+// Defines values for DynamicSchemaResponseSource.
+const (
+	Cache    DynamicSchemaResponseSource = "cache"
+	Embedded DynamicSchemaResponseSource = "embedded"
+	Remote   DynamicSchemaResponseSource = "remote"
+)
+
 // Defines values for GlobalRoleBindingAllowedEnvironments.
 const (
 	GlobalRoleBindingAllowedEnvironmentsProd GlobalRoleBindingAllowedEnvironments = "prod"
@@ -307,6 +314,11 @@ const (
 	PENDING   ListApprovalsParamsStatus = "PENDING"
 	REJECTED  ListApprovalsParamsStatus = "REJECTED"
 	SUCCESS   ListApprovalsParamsStatus = "SUCCESS"
+)
+
+// Defines values for GetDynamicSchemaParamsEntityType.
+const (
+	Instancesize GetDynamicSchemaParamsEntityType = "instancesize"
 )
 
 // Defines values for ListSystemsParamsSortOrder.
@@ -576,6 +588,36 @@ type DeleteVMResponse struct {
 // DeleteVMResponseStatus defines model for DeleteVMResponse.Status.
 type DeleteVMResponseStatus string
 
+// DynamicSchemaResponse defines model for DynamicSchemaResponse.
+type DynamicSchemaResponse struct {
+	// Degraded When true, the response uses an older or embedded fallback schema.
+	// Frontend MUST display a warning banner per ADR-0023 UI Degradation States.
+	Degraded bool `json:"degraded,omitempty,omitzero"`
+
+	// FetchedAt ISO 8601 timestamp when the schema was fetched or last cached.
+	FetchedAt time.Time  `json:"fetched_at,omitempty,omitzero"`
+	Mask      SchemaMask `json:"mask"`
+
+	// Schema Full structure representing the requested JSON Schema payload.
+	Schema map[string]interface{} `json:"schema"`
+
+	// SchemaVersion Semantic version of the schema (e.g. "1.2.0").
+	// Frontend uses this for cache drift detection and audit (ADR-0023).
+	SchemaVersion string `json:"schema_version,omitempty,omitzero"`
+
+	// Source Data source of the schema response (ADR-0023 degradation strategy):
+	// - cache:    Served from server-side schema cache (nominal path).
+	// - embedded: Backend fell back to a bundled embedded schema (warn user).
+	// - remote:   Fetched live from KubeVirt API (slow path, no cache).
+	Source DynamicSchemaResponseSource `json:"source,omitempty,omitzero"`
+}
+
+// DynamicSchemaResponseSource Data source of the schema response (ADR-0023 degradation strategy):
+// - cache:    Served from server-side schema cache (nominal path).
+// - embedded: Backend fell back to a bundled embedded schema (warn user).
+// - remote:   Fetched live from KubeVirt API (slow path, no cache).
+type DynamicSchemaResponseSource string
+
 // Error defines model for Error.
 type Error struct {
 	// Code Machine-readable error code (frontend handles i18n)
@@ -774,6 +816,15 @@ type LoginResponse struct {
 	Token               string    `json:"token"`
 }
 
+// MaskField defines model for MaskField.
+type MaskField struct {
+	// DisplayName Desired localized or standardized label for the UI form projection.
+	DisplayName string `json:"display_name"`
+
+	// Path Dot-notation JSON path resolving within the provided unified schema.
+	Path string `json:"path"`
+}
+
 // NamespaceCreateRequest defines model for NamespaceCreateRequest.
 type NamespaceCreateRequest struct {
 	Description string                            `json:"description,omitempty,omitzero"`
@@ -960,6 +1011,12 @@ type RoleUpdateRequest struct {
 	Permissions []string `json:"permissions,omitempty,omitzero"`
 }
 
+// SchemaMask defines model for SchemaMask.
+type SchemaMask struct {
+	AdvancedFields []MaskField `json:"advanced_fields,omitempty,omitzero"`
+	QuickFields    []MaskField `json:"quick_fields"`
+}
+
 // Service defines model for Service.
 type Service struct {
 	CreatedAt         time.Time `json:"created_at"`
@@ -1076,6 +1133,9 @@ type Template struct {
 	// PvcName PVC/DataVolume name for PVC mode
 	PvcName string `json:"pvc_name,omitempty,omitzero"`
 
+	// PvcNamespace Kubernetes namespace where the PVC/DataVolume is located (required when source_type is 'pvc')
+	PvcNamespace string `json:"pvc_namespace,omitempty,omitzero"`
+
 	// SourceType Boot source type. 'image' = ContainerDisk, 'pvc' = DataVolume/PVC
 	SourceType TemplateSourceType `json:"source_type,omitempty,omitzero"`
 }
@@ -1100,6 +1160,9 @@ type TemplateCreateRequest struct {
 	// PvcName Required when source_type is 'pvc'
 	PvcName string `json:"pvc_name,omitempty,omitzero"`
 
+	// PvcNamespace Kubernetes namespace where the PVC/DataVolume is located. Required when source_type is 'pvc'.
+	PvcNamespace string `json:"pvc_namespace,omitempty,omitzero"`
+
 	// SourceType Boot source type. 'image' = ContainerDisk, 'pvc' = DataVolume/PVC
 	SourceType TemplateCreateRequestSourceType `json:"source_type,omitempty,omitzero"`
 }
@@ -1115,15 +1178,18 @@ type TemplateList struct {
 
 // TemplateUpdateRequest defines model for TemplateUpdateRequest.
 type TemplateUpdateRequest struct {
-	CloudInit   string                          `json:"cloud_init,omitempty,omitzero"`
-	Description string                          `json:"description,omitempty,omitzero"`
-	DisplayName string                          `json:"display_name,omitempty,omitzero"`
-	Enabled     bool                            `json:"enabled,omitempty,omitzero"`
-	ImageUrl    string                          `json:"image_url,omitempty,omitzero"`
-	OsFamily    string                          `json:"os_family,omitempty,omitzero"`
-	OsVersion   string                          `json:"os_version,omitempty,omitzero"`
-	PvcName     string                          `json:"pvc_name,omitempty,omitzero"`
-	SourceType  TemplateUpdateRequestSourceType `json:"source_type,omitempty,omitzero"`
+	CloudInit   string `json:"cloud_init,omitempty,omitzero"`
+	Description string `json:"description,omitempty,omitzero"`
+	DisplayName string `json:"display_name,omitempty,omitzero"`
+	Enabled     bool   `json:"enabled,omitempty,omitzero"`
+	ImageUrl    string `json:"image_url,omitempty,omitzero"`
+	OsFamily    string `json:"os_family,omitempty,omitzero"`
+	OsVersion   string `json:"os_version,omitempty,omitzero"`
+	PvcName     string `json:"pvc_name,omitempty,omitzero"`
+
+	// PvcNamespace Kubernetes namespace where the PVC/DataVolume is located
+	PvcNamespace string                          `json:"pvc_namespace,omitempty,omitzero"`
+	SourceType   TemplateUpdateRequestSourceType `json:"source_type,omitempty,omitzero"`
 }
 
 // TemplateUpdateRequestSourceType defines model for TemplateUpdateRequest.SourceType.
@@ -1463,6 +1529,9 @@ type Conflict = Error
 // Forbidden defines model for Forbidden.
 type Forbidden = Error
 
+// InternalServerError defines model for InternalServerError.
+type InternalServerError = Error
+
 // NotFound defines model for NotFound.
 type NotFound = Error
 
@@ -1564,6 +1633,9 @@ type ListNotificationsParams struct {
 	// UnreadOnly Filter to unread notifications only
 	UnreadOnly bool `form:"unread_only,omitempty" json:"unread_only,omitempty,omitzero"`
 }
+
+// GetDynamicSchemaParamsEntityType defines parameters for GetDynamicSchema.
+type GetDynamicSchemaParamsEntityType string
 
 // ListSystemsParams defines parameters for ListSystems.
 type ListSystemsParams struct {
@@ -1952,6 +2024,9 @@ type ServerInterface interface {
 	// Mark notification as read
 	// (PATCH /notifications/{notification_id}/read)
 	MarkNotificationRead(c *gin.Context, notificationId NotificationID)
+	// Retrieve dynamic schema and UI mask for an entity
+	// (GET /schemas/{entity_type})
+	GetDynamicSchema(c *gin.Context, entityType GetDynamicSchemaParamsEntityType)
 	// List systems
 	// (GET /systems)
 	ListSystems(c *gin.Context, params ListSystemsParams)
@@ -3570,6 +3645,30 @@ func (siw *ServerInterfaceWrapper) MarkNotificationRead(c *gin.Context) {
 	siw.Handler.MarkNotificationRead(c, notificationId)
 }
 
+// GetDynamicSchema operation middleware
+func (siw *ServerInterfaceWrapper) GetDynamicSchema(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "entity_type" -------------
+	var entityType GetDynamicSchemaParamsEntityType
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entity_type", c.Param("entity_type"), &entityType, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter entity_type: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetDynamicSchema(c, entityType)
+}
+
 // ListSystems operation middleware
 func (siw *ServerInterfaceWrapper) ListSystems(c *gin.Context) {
 
@@ -4677,6 +4776,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/notifications/mark-all-read", wrapper.MarkAllNotificationsRead)
 	router.GET(options.BaseURL+"/notifications/unread-count", wrapper.GetUnreadCount)
 	router.PATCH(options.BaseURL+"/notifications/:notification_id/read", wrapper.MarkNotificationRead)
+	router.GET(options.BaseURL+"/schemas/:entity_type", wrapper.GetDynamicSchema)
 	router.GET(options.BaseURL+"/systems", wrapper.ListSystems)
 	router.POST(options.BaseURL+"/systems", wrapper.CreateSystem)
 	router.DELETE(options.BaseURL+"/systems/:system_id", wrapper.DeleteSystem)
@@ -4715,175 +4815,188 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9a3PbOLbgX0Fxb9UkW7KVpLvnzvjWrS1FcdKesR2vX7NTnawuREIS2iTABkE56lR+",
-	"z/6P/WW38CAFkgAfEmk5U/2l2xHxPG8cHJzz1fNpFFOCCE+8k69eDBmMEEdM/ust5P7q7J34ExPvxIsh",
-	"X3kjj8AIeSfeXHyd4cAbeQz9lmKGAu+EsxSNvMRfoQiKfnwTi7YJZ5gsvW/fRt6UkgVmkfgYoMRnOOaY",
-	"itFvcBSHCAQoROIX4KuGUP5jEcIleDF5d3306tXrn8D//3+vf3jpjdSyfksR22zXpft5lmXMKQ0RJOY6",
-	"LmWn8lpuNzECDCU0ZT4CYmDAabai7RKLCwIwCBAJ0ujl8SdykSYcRAJEgK/KY6Ev0Ofh5vgTqd/DTP6z",
-	"Hp5nJOGQ+OgG/46cuMK60SzBv6PuOLuAcYzJ0jl8pL53H1hAP4mh7145yVrsMDjleIF9SUDu8Y1G3ae4",
-	"gksL9YhfAUmjOWLgxesjTAL0BQUueo3FGOY0AVrANOTeyeuRF2GCozSSf+vpMeFoiZiaHzH7Es44ihIQ",
-	"Iwb08NaZEZu5Z3/zauRF8Iue/tWr5sUwusYBYk5Yx7pBdzhf0xC9xSSoI8K5+r7b4M5RGQ13IL0bxNa4",
-	"hqoT9X2HgSnjbzdVfL/HKAyEjEoo42C+cWBcfJ3Jr02TfGQBYhYhLYYPMEO+/KFmFioHsFKWBxPfG3mI",
-	"CFr6Rf9LzON9HtmWs0k4itywlJ+7g/IWRXEIuRtJXDfYYWjsPyDuHlh+7j7sXVLDXGmyC2PdXzgHXHeG",
-	"6TfROIkpSZC2H4Jr9FuKEi7+5VPCEZF/wjgOtcwd/5oIwvpqDPtvDC28E+9/jLe2yVh9TcanjFGmpioS",
-	"5lsYAKYn09o9xP4TTHydaXY/m/LbyHtP2RwLa2D4+bdTKZX3nqYkeMJtE8rBQs4pKJTAlK8ow7+jJ1hD",
-	"YTbxWfcQA05ioW1g+A75OMGUGIQYMxojxrEiUp9GkV5iiZ5Hnh+nsxBHmFcF4fTqDshPAAtTlaEEvLjh",
-	"QvH/dPxWqPo6ZalGZtslVcfWH43R6RoxsVjMQeIjAhmmI9BhygAnD7PlvDrdO5w8AGEYisk+vB0BGERi",
-	"WkgADH4VdmyXnSEC5yGaidUyHFhMk3+sEAFSlOiJsqYJ0Bpiay1rKCRjCeoELBiNgGnxghcRTDhiR4uQ",
-	"PhrQUKZ12ewfeRGKKNsopM4iCzAuZIMtai/edtq9Hl+vu24GA8Ed50hQiHyOgpkfpmLvQkxXZplI0Kqm",
-	"CeCQLREHukN+bvn3l96oSvX5+AmnDC7RzA9hktj1h/6Fzn9FSvJlfKdUYJXdoPyuTIsqvzEExcRQdlxQ",
-	"cfrzTrwAcnTEsTwKVfqgNSJcg6Dy0fGzWJCy+NUn6/GPLkDeDvAVToDS24ChmKFEiKjtAfClYc9Mr08n",
-	"t6feyHt3en4q/7i/nM4m0+npzY3FwhFKE2qBaPkkADurbSHpyAHRhEOeSsBnq7s6vXx3dvnBG3mTq6vr",
-	"j/en77yRd336t9PprfxzOrmcnp6fy79P/8/p9O5Wtb65UxsYee8nZ+KzbSeKzmbKdKgaqZQBBRMNymQk",
-	"D8f3F2COMFmqgzUKvNqRifXEXjO2PHK/WFAGApzEIdxYqV4bZTHchBTKxcMgwGJ0GF4ZJKyMoJLAFmru",
-	"C09hCHR/QT1iesrwEhMY5uweoBjJcwqgBJTocOSRNAyF+MymKbHXN9Ma+8WT5llO/zmyTZr43Mii59im",
-	"FbE4Pxb+qNPQJabfygXIGNyIf8dQgEGBq36sq23LFgLmWtub1R08Mx53M+JnNzFaxVeJCMzDhJ7EivQ0",
-	"wPycLi0S2c/QUlkG9DntT1IHiEMcJk2sVVm6Q4hnRsKs6XuG/3o4SgDC7Fhb7FycLINLAQp1MO+FxTL8",
-	"DctcKV9lbhwLpaR85eCma7TEQuCgAIhWIHP1gDhMl5gA0Qs8oI2NLqSzc9mZLHYhwazPfGMlGWW7BjaP",
-	"sZMMM3VU5fitF2T72TDj0jjouH4bxWoP8RY12118bkDwlBKi/Di3KBGSVDpnykiPUJJoF2N1i6nvo4Jp",
-	"aHrYzbVmLRvXJBHkPKw9LwqsJZcd6aIEtwp6mwD4gdE0vtkQ3wnDpWhRFDyVNUaYnKmPr6viRkvCBUZh",
-	"C/1UaD3KZu+wDZeC7yY/z4IrMRwK5MhVKdokDfuR4YZ0fTI5fgOjOETvM2wVN+BC4shLZLd6MilvICX4",
-	"txTNfJoWHCqG0FvDMN1q5MwU0iOO9EijbCfCII7m0o2ccZaY5IHQR2L3FZuUl5GcMWdpiZ9bgc5NgnKG",
-	"3fBvYsVGCsZVSSOLFe9V9KKa9narcVDc0TzFIZ9hYpdpSk7Otm67TuKyIK8t1KRPZzOn5GxnyGlEF0Yb",
-	"bTfWBi59M7uEdZ8MXzAD5GqatnUnrY0aL+hz0oCVeaYrSJboCibJI2WBcxcEPc5i3ahgVOU/WpQ/DYOu",
-	"nUoYKIwwKq7ChpepcsPZnGN4liC2RmyWsrDHg5d0qzb681qwYC3CEVljRknmTi/5SLTv0WikbLJCEMVI",
-	"/Kdw0uYC01IgBtajssMsf0jnaI0Zn60RS1wSx02hldP63eXfLz/+49IbeT+fTs5vf/6nN/LuLs2/r08n",
-	"058nb89PHed/A/YK2yWHbcrpUYC4dL2CG9V8KlqDECe8AKa/yFiClmq57tRQpLdaB4LGX4OB3oKASjSS",
-	"3QlrPLdFu8DvVmiV7wIT9OcfjxDxaYACsG0KXgg0oAAg4rNNzFEwAhqsbwRIc3aab7iVkxzbshvtxhJr",
-	"AHq6BYiS0VWglmDWDkSlNZlj1KymD82XibdBLdx30lV8f+E2zmovBp7EHVd1zdogr643LRrZdnl2Af0V",
-	"JuiIIRgISQyQ6A1EY/BiweR1awBWkAQhSgB+/RdidXZLG3Em+7bHqzRW9WVsFbWGn6C45FOyDHGyAiFd",
-	"At0IvFC3xgzcndU65WU8YlePYQkjEpA2wBv7cULfDjn7mdnpKHGcS5wL+xDSOQyNmCeLpRCG9BEFM4Ot",
-	"i4hsK0fLaBzAq+byz+rIKuc3t3b2aezsqj46jgqjPEymnT/YCKrZxoHlaytM1gqRTe6tobBaB+sO0Nxq",
-	"66XcWaNlnM3bCjh96J4q6wyqhX5GMOQri/hYIf+hRm65jbbt2FUVRR9knNySwUBekkr5bcW/2+gte+fc",
-	"euksuJK+Mh38+8xlEPrCESMwnEkHo4uc1UenYHH0qnfGHEyS9XJ/UPQdVaE4quXhEo0cSrz1gvyeZGSD",
-	"Gb4fgPsQkWW+HlRAliZr8EI9d/3XIv6pdM9Q1QzPTLaFMOGzRK6405qaZGK3S6KWosjYopVZjMBAC+Tj",
-	"dCZDKe03E7s51gLsy15+nNp9Yi2c3llUpjVkcw933CpdohguUSJf/XQhCh3FGDmW5RahCqXJbOkCR94i",
-	"X1xDu4Rhura3SWLk53Gmex4STa/YllBMSDQRXIPuK1Bfp9jghqjeXkmwMYJ4WHIs0N0Ogbb1XZ4L2TbE",
-	"hfRJ1ntRdC/GhimSh7U0jJmaLrv+4MU/ePFJeLFCped0id1vUTrfXaaJsJHa3EnkLUde7d2kXqDTqf4l",
-	"ljCtsZIcMcyGC5UKyzBbxcyXd7t2/HD6gFp4MVQz23byB8ZN91ZFvozgl3NElnzlnfz0+s2o8Rqr7bnE",
-	"Hrsu34ovqDj8gOv3U/D61Q8/AQIjTLZv3v8q34Vsl/XnH0btbqGaLn5yCKkAOrbp58zS4BNukoNd7pn3",
-	"vCm240Q5EsMNUAFDIH+Hrp8TZHiyXlv0GtrZGYF96O0qVQyqvPPpGjR3dzZ1kpF1GUYygH7YAHe9K5Kv",
-	"gQKXRoPdZt83RH7kcczD+mCsjPvUa6LJ+az8wGhyPpt+vLg6P1Xvi/IfjTdH9xezm9vJ7d3NbPrz5PLD",
-	"afN1Ns7VYbbGLVA1CBvD801s98IzJvUMyi5XhZHKNkSBrgxjJk/3YP3KKYdhzadZ2dSqDdi6QizCSWJd",
-	"YZPsf0CbZpUvGn2unbgPlBrbGBSh15CjcxxhfvoFRXF/4gfJ4WoePDSbc11eK3bXex0uZLd3seauClxe",
-	"WMHnVnBusAv7sHfrANZ18+021QfpW0jyaVjgRl5J2rewRASx7kp4t43fJYipxQwcuzsq7qsWx2JRH423",
-	"9eWwFRoG9JHMEuRTokLTHfS5p+s7gl9m+iXrzF/hMGDqoNY8m9kzhiy742nu2Lfg0X0conEHuWSMuKNY",
-	"MrFbE6tdRXLubXk16ogCE3mmz2ZnRHYbxInUb01wusnjIxzgYSiCmIjVGYCyUH/KxNqtAGlubWzckgtj",
-	"sUA+x2s0s+Gsrr0LQ2371C9L60/H6TqT97M+lN8e6t1r2lwjwGox4MZlDU2M6sjLytoygUNjFpo6NigE",
-	"VKl21plo2P1Bz06Xnns+4+n1lW2cW+hJl7dqNf4Wc0Tj3VD9u1oB/G4uxp7hNjCALLBxgaEX41PQ8rDm",
-	"Jg07Opt6RtjueKnsRWcb7OfI2LTrrgxK0BfBPzr/qMyF6bhryfP4tQsXyUJwjfR/DQ4fDadufFqOv2cP",
-	"QvqDJI1jyhzJajJgGP7J1z8J6uUcMTHM//0FHv3++YX476ujvx59/p/6r88v/9e/ea0c+zX764MBM5Ia",
-	"lAf1JN3YsDs+SuAzB7BCURLUs7gFaeC1EnlVJQci0P0EptdLCmOjzWwoAfx0XFjKE5FdsAmCDTEkXN/o",
-	"OC7anoRxJUR64VtFvMOyrZzjAsmX+f3onEZNGkEcOqN2CzHyj0TmC5CpBVW4i0ogsMboEdmj5d1nlK43",
-	"7LP81YjmC7m8zw1AbGCFYbfo3EWrpfdHs5qenoxyWxiA+wPe8hymBqTPTBFmCZItPB7SNJhhYk2MKr4d",
-	"iW9A0FIAOQT/nFycgxcyAywKAOQy4x+l/GWdznz2Z1IcwSXKHupXEwJCTBADTN+fg7vrc/niMf8k065G",
-	"NEAjgI6Xx+C3FG6OMR37WYMAJw/JOJ2nhKcnb94cv/qxw5PkkUeT2QJGONy4vta9jI/XviPR4tX9dPwO",
-	"cnhPwzTS0RBiX1f3U7kba0bR4i1z6bU2pRzofK+ixTH4k4Tsn8B/FoE1An+K1774eTv/+Op+arwalx09",
-	"ufyWd8hOnZxRf1Nc7w6scAAKdpPqtYYIeFwhAgxMAZxkmHgOdFe/TkEY3w/lNRJdH2o1F9+DqtRslqaQ",
-	"2wKbHJL6h6PXJuJrTSoVIN8RhmAwzdJqle87HNm2Ku/gXSmv7pJnYMjvooGFPZV0TFHW2p4vm/LZAhvP",
-	"twKce6dJ2Q1OHUJrn0GssaxnQRb04LTneve7m4v2SenSBdc+NIiUC4NqDzFD06nnu2MV20bvL2w60Uzf",
-	"38s5qDG/bU2CrjOyQgxzFKgqC74lX1chVVenLF0rmvCuT1OzS4OO9w1ZKLFdJW8LL7VLCyQTfatw1uu7",
-	"y0udC//249WV8acMYpWZwNWPOkP+yEi2f3H24Tob6GpydyM/Z0nF9sw5ZDpit9uvTTp0fyGL+01k+l/3",
-	"cw8or89RUJfSM2+Tr9iS3Wy6wmGQJVc/e5cAvoIcPCKGAPR5KiPts4HAfAMY4mwz9gX6Q6Cych93yHk2",
-	"2lYnrEdznfDSMLqSUQFZIFgJ9EYRxDz7fgloNeCXUDmz3jZUKva5D0TSqyDz0W+T2ZvJzNIUO/3jOad0",
-	"G7tLjGOR5Xreg1mjq//RHXUsCuPqohM10PnWQACuQCbIxe74lvfMIC9LVE9dvjP5zB9lua52fyjQIWPi",
-	"sIVGhszIppHzNzq/SaMIWp9ECcTVScVdtPcC4rBe1jbVs7HlQuT+yixyIVNuSoej4ogRuPr4j9PrkSZk",
-	"exq2LAzKvTIn/mfZgw9v5J1dzq6uP364Vug1X4VcTa5vzybnswryTTqx5tVUieVnbU/BEvcms+Zi20Rp",
-	"edwSbsoQaTwSaorqwyivEuegFrqe7qNJYe4iKJKUrHiyKdMnJ5ZsEfQRsYlf3s7N7eT6Vpt0UlSpH5oG",
-	"suvvGoW4bhfkoprVUJOc3Xlu2omqthtS8b1ZEQBd/dVdE6AggdpOpFHQVAFLvSq3KeJpiMWxBAcoiilH",
-	"xN/YKzyU8zUb7O/Onq1XqmjVbSLXGprNasKI7e2CKNNweJosjs3KqSsNbGVKVxXT2WpvoSd6CIgxDgMD",
-	"aBgjBNkRbNP4ziAj6XQeYd6v5NgeZQaWHAWqec5yQwN5J7khj78zuOCI1b8Y2I8n5F+Oi5EWB12jv33J",
-	"dvBMKUlomHn83BBqu7fieIZQNM8IjQ8V1sTPINHQtn0KTcfa6u0e22nJboPowaujXn68nV2f/u+705tb",
-	"0w3Vwyy9YeuZoan+usbmjNnHvXKryrH+/S+JkVfiBY6ilMuk3pKLQCIkiLx+yLPU2wu2tna+dHWnNLQv",
-	"Q9gsal8snl4BYNFRWfOq5f6in0PT0KekemN8W2OxFEwjemn/JuAUoC/ITzkCsholAvcXhos94ZBJu4HT",
-	"WFUklD80Bhvoue3A1SvWBUwbKL+/tF858jvekmVU1UcURNlNlA89Ku+6sF47HO8vpzcoSWqd6VUXyc3p",
-	"zc3Zx8vZ9enk3T/tiZwjl4nwiOYJ1SVrVQrqspMyhByvEcgbjmNGv2yAaC49l4TeX05lHF7CGYyPvZYi",
-	"dOQ8mkqB46cM882NgL/a91sEGWKTVK1yLv/1PpMsf/vHracLt8tbN/l1u5IV57Eq/Y71RbEMj1OF/ZUz",
-	"0vt7Okf3mHFws0LxCrEA3CIYCWtY6Ak5RHIyHi8xX6XzY59G44f1UaLbjrM/KmEo3uTqTMIpgkSw/xLk",
-	"E60xk8V+I1WNIQGQBECGuBwRBfQlXSNGBA0dfyKTYIUYSgSDKzn+5vUJEKMLtmPQ50fvMUs4eIfWKKRx",
-	"hAhX9ctD7CNNSnqvkxj6KwTeHL+q7O/x8fEYys/HlC3Hum8yPj+bnl7enB69OX51vOJRaKR1sYBucnXm",
-	"GfnDvdfHr45faTudwBh7J94Px6/l9IKQJILHMiB2DFO+OsqSuB4JBOo3+7xQj/cs8E48IdTLFbJU5WLF",
-	"PbLnm1evMozrG0sZQqoyrIx/1TpvW42sSzkuqVUkYdWWkUSE6/msBSXVhVCSeYnltnTIZ/shRh6Hy0SK",
-	"ahOCSR5p/FlMYgNye/g+GWxdcJ04IBGq9hUgOiDXClojL6aJBSjKyitUYczPiW9psBkEIEXT8ltRpgrD",
-	"9VsFM68HWUgXrGinguD7HxWh2GbJlz1+C/OibLLLX5u7TClZhNgvI1+By8k4MjTBYDCDkfbho/FXI/n0",
-	"N6VMQ6RC34s0pOoOlWhIlqlBXDLkL/aNb5uMs45n77xvnyvI/9FaGswKjKxcvgT5j80gv6T8PU1JUAK5",
-	"2pIL5C0ZDnJ/VYWWiu3pF1rDsmsxGqkVu746OLtqt9/O7Lo77Shw7UM77VhyLFO/H0WqjEB7vWcWH0h6",
-	"5tT+8G6r8mBBv2wDNAy05twPfVLVngVXYGkOnUizF5JiIe1+NW+hBMUzlAm1lU2eWItXKnY0kca+6rsT",
-	"QfWi7ys0OJjoGH/Vf3XX9L3R7KixtZ6ltYlQxH+/hsFOuOlgEhwQrIPLjYOaE53lxpPaEfvJDW14DCk3",
-	"thXwrabGB8SrBd2frYlRU9beQhaqBZDVe0CyjTPaR5q8R9xfAQVUgANhLvINkI8iVcl67WzrHY0b4ktn",
-	"rNUyudkQvyKMkud+SpGrFEt/BgcVYy01BCUrTGlW3VquT3pWEWsAWVkptZTdLd2WxMdRwo98SgjKb4Ds",
-	"dHiLigeX6bbP9yBStsu9VXf6aWg9wmTt1oL3BXAA0233w62Y1ek08o1Ju+FWP4KpP29Os0adEQWXqI3V",
-	"coWYajokNs0C4DbE6edALn+tvwVCBl/jp3bnw6xw+DDy01rA/olPcnlpdDeAt87NEpizmwkAM2DXw7pK",
-	"xeOv2ydn38alx2Bxyl3GerVSfZXUMZFv4vgqe4p0Yr5vK8N4ZMCrfOf4eVD0V8vtP7HqbEEC5pO7gkm+",
-	"t5/O8qivLRFld+JHeSSA2wEnOpghAIPePlVKllkgm7UBYvFOGYbNVto0EFtRN8CoBK0SQFo7wcrAGUjc",
-	"uWsTPrX3qhAL0oSbg988FYigDbpdLDL+Wo56auNuslBHN6PC7NzafVTEQb/uo84AbXIdDQOiYTnwsH6g",
-	"Thx48MukPTiwGFfmVFCX22aD2+yjMq+9x6FQwfNNQc/rG2xpRv2WIrbZ2lFFZb1Febu394MeGuy1xywk",
-	"ljc0Dv+vmwnljohDGmX4dxQ0hNoQE6cZyRR+bKefLwtxqf1LBUdFwidWypb6bnVIMw8lT66YjYOPGTRc",
-	"i2ObSBh/zf+uKuPizj+ScAN0NXqAF4BQcH+RAMiEcoxDuhE/E8BX2IjgPv5E9MvwBPiULDCLZnl6vAQu",
-	"EN+osD6b4jfJrptEynvqK5BSqPkmrhQv5DRbn1L1mJJiao8fAAwCRII0enn8icjylJF8R8xXlcHQF+jz",
-	"UO/MJr5MUHQ/CDZZLlsa3d1q2Y88tZnTmjRHzuuEnmjgSQV+vdwIEIc4TPY1DD4gbpDdfAPO3rUQ8m6H",
-	"Rp+AHlBDHNRo7Ijpfv0UO8j5UrIup+13VSjvMRj4SnUILbDbtnA6JPJcvmC7O/CANqaJw+bQtwKEQY6O",
-	"Qhxhnozzmj71sKnWfPvOndqO0ngWbOQNDAP1h2Yyfk/ZHAtdabVOcwwAZAI0v4BoZZBaCvENI3eaiiM+",
-	"sQCyFSCsw1sC13uYp91wvZ+Q054mmgVuAijzA1vpxUIuTSw+/qqTuLfwN1mJqxvDyyyObR1NW3QxFNEc",
-	"YU8J/Ws5cS8w377oahapN9njqeEZxqigaXvhst2xWn+PEk/XTauAVk2EktaQFQOUCLnGnrPWT0z2o+QB",
-	"5autyuOhhGuhnqiFWrJv35F4vYsTxLgwmY7KdEgN2qghxCx9q5urZYsh8ZMVUrMxMA3dd1jXbydTwPTy",
-	"HDZig71Bw6F8X9UqeU/s9lJ15RwgPfjVk58mnEZbFLay8gWqx1/F/1pqfLpDlKLo1FrHS2Ae2BvTAoYN",
-	"10z7w2kY/jmoU6CWfw5+cdSJcQqpBOpDGW6N1ADf8WG4UFzCgsTsu1O35CBrCo0wcyl0iIrIczUMwz32",
-	"ii5PrIG2+ShqEHBwTcS3mKjDqYWbxl+NzC9tAx4MxHfjr6xja92Ug7jfGIeW8GoT2dAfLIbjoIPqoFYc",
-	"dHBd1JmD5Im3VhfdJd99kHFemcKCO/HNqXrSpJT7oZVWkQUshmGFapGXJ1YkqjiHA4yHz98AQurDEPzt",
-	"H7cSd7XnbYuzp15paLwO6KeUUCzoiKf0YGQZGZqB2KBR9gfUMJxzUAVSyzmHT6WwB+dIb8DRHMvMsc3K",
-	"RJza3maN+2On/jD1IaRzGBrLrHWJ6X33lxhhKaeXJ8pscH30KWOmk4OtBPrnxp8VoB9UzVVW04j+7y/5",
-	"gYXOWpFZSzkw/qr/aq9c+yDPUStvmZ6lm3MxA1LPCZAkuP+U2PDRgIQ4ZnQNwwZfUt7qKYKObaF428zN",
-	"lSDiAau1DPsIVQP1VmYRdmaf062yClTOrHPFdoUTh/5URvl4nhlgmcwvv3iNYsjxHIeYbwAiQUwx4YBQ",
-	"FsEQ/y4DSTkFNxwuEfjp+FTWxpbBljGOUYgJsgWNquzi2bZkdu+BDjrWnPGtlMCbodbgfmauqt1oMADo",
-	"+yjeQxW8+WtvOziVpZcct/Egiz/wEQoqge5q15omcgLN9vjCt9LXyzaU+zVPvf1N/4rcD9QVrSHFZ92d",
-	"U7LbkNkR9K7eIR+rNLwdKPVHe40vlEuE/XWMBh+AGea6IkjVwnPjZyq/94OetsBRawqf6Ii8p62lagnS",
-	"RwJ0aY1dMcGQzHbsxMS1/P5cGUWtrm82UTDZn03U6lpxSRpgfhTSxmSAAebndHk4owtmWTzcLx3cPSnb",
-	"pWNerk+/Ktt9AFXwo8MTjT7TiyjMuTMKB5iDkC73fVKmM5ZLmjBzlf/yWeyvkpdYz1rMRBxgXj4TpHw1",
-	"VlWFj8wCwg7pLRtebWsKD5ICoTDJvqyfjQPUJgOgCxot0jDc7Hz6HhSDCgDFKEWzjrORGMbEYkiXuCZ1",
-	"z7n8PAzK5NgH8pPqud3WtmxgoL0XDBZZTs7wiPkK+AzJnGHq/OxCVVSbr22qEJ9fCw3oYJZ17W05Pgza",
-	"ewKK/4BKQbmyjIIVfisEQ0HseF0Lw3O8RgQlg0Y//iyXYn00w6ggNoATAOVKa6lHLxXEjM7Nm1i11eK+",
-	"GYKKb10bv0YwwIfb+Y2qriN2rpb6beT9pEzuYU+oxsSE8mzyGrDngKqHe4eEMt99Lhl3FgMFC0I5Xugl",
-	"N6QuKLQ8WPYCTkFKBCmAwtIBJeHG8Q5YtZ/pFlt8BGgB05B7JwsYJtsyXnNKQwTJ0AkMjNU7cxcYbfpN",
-	"X1CE3YKygqw23z4WsG6hmXEE2cMRDMMjAWS3rXIB2cMkDAtUJPjVa1WHIAxLSxazogBAJZNKWxRzAVjp",
-	"kzXusjtFO0d58U6XjL6T7aa6ZOZwCt6YxnaRrDhDrbYHWhFK3MJtICsN2h6OX81/ameGJhd7GIHAoUks",
-	"mlY6Ppo2BmjtYypwXZnO9nMySMIsQLIdTSabJCs55pTPN7rNU0jmhqY3lPG3m7YtPzJZdGJIYatg4xKz",
-	"6mu/AjbJsZHhNful6ZJerWagU50a/KD36np/bjwcPIRMYQq8SFC4ONK1JUeA0PwO5KUVrQajjr+qP5qy",
-	"veRZW/hGpkHXM5dzpRRTpLw8/kSmMPFhgESLhDOICT8BUZpwsIJrBH5HjAJZthno5Sfu/C85vXUTG6qb",
-	"O/OLYys7pH0xRzpwzhdNoQd+YpRkGLOJFpeBsjeah5fPNTKhx3QumpzKuVwK4jkzSUprkTflPx5PT+Rp",
-	"A/yX8fm/xClVV9E9/kRuDJrFCSgX2JUiDlNi40oVjdcPuoZSIAeNomwkln0jKZ/2yXBgqBxzOx1UzDhC",
-	"0bwpiF8B50K3fM5yQK2xwVpTW945g0APQZqJuZBult4kCMytPlc2V6t7BtaiBlMjNexrOj7rOIJJEBRp",
-	"bhcR0eWxQ08kOur3gUQR44dO5tKMkIaHEiaQd3r5vTOgh5UaB38x3k1yfL82Q8YIxdfnzQIhOxnWGw1Z",
-	"oyGp8lk9FNQ7dlof+k7KmThPAwxgAqDlpJbBs9ELpBo+Q8tALeywRoEGTg1+Du9E0gtp6UXa0kUTv46/",
-	"6r+anEutfUT3F4klg/B/CiwC6V4BOYFZXFEut9LeBNzCe6zmaNd4qrbV1srQ6Du0qyeHolWCOJ09Twv8",
-	"J5DHdbzep3OoNKRLcu/vINIT7eEhOgCOB1Mnh7UUm0nsezQPc1K2+pSKCqddTqI/0hGV0hFZc2woiK4b",
-	"rmvvL77fq1pH7LaZO7tz4LflheBTxnzfX7io4f7CSQcKhxkFrCMD99vHeZoCyhd/PGUkARDEcImJkC1y",
-	"FkAX+r3Vr3Su699infaKr4oBxMefiMzbk4AEIRnuInui5D8AQ8s0hEwlL5GfpT7iK4QZoI9WraKI8q0a",
-	"4o8oAvdjQBehvM3x1mskQf4q81c6r5LbyPH4c/uqU3VO1Fs+RDjbqHegBUv+r8KSv0tQIkx9RPiROhno",
-	"R6sRDVCogqFxgKKYckT8DXhAmyxRvPulqAbaH29E/6XfiOZEWn09ZRGL45g+Itbjy+UC0Rqvl0+/ID/l",
-	"4kyrvohpQU6lCcAkQDEiASI83CgCn6OEH6HFgjJxGogg4dhPGsn7Sm5oUBqXU3wfJK7g/K9N6MU9tngM",
-	"beODr/J/mSPHdZrfitBuOln2Gvp8npGGNN+aSUObeT0c1XNM5JZjO0i3fM/8PQB94qvIWDfQ9dtj9RK0",
-	"xIl7lJFQo2avmaVwZYgon3eGl/YIYYizTd2rZs42/xrokFvpGxtq0AXEIQq64iJT125mkN7s+4vrXK8P",
-	"o+J2uE94M1Aql3oEFnXaKGeC/JH4LlrOoWkyJ+BWzbDMSW+7RLCi9khC6AtvPIqKs+LRGid4Hso7A9EJ",
-	"ZDgA841YULaOR/w7ZMHxJzLV7XACxCZTcY5NEykU9En1+u1kalZ8B3IKpSZZGtojU6XS09DRU3iD8m9p",
-	"LrsbINu9n7ey6KRSo7q3NUV8fV03hgtPkg3xwRpDcI3X28uYV39+eQwyNL559QZMNHUqixatEeEzLNDF",
-	"xcoQWZ8A1ua25/gTiRkN7D1UhUkZpivwfX9RjtC9xbI8qm6uCDlGDBRukNwXSPcXnYX9/UXHq6DWTS9h",
-	"ZHVK9ieDsk3XSZ93WfB0Jn7Ai1LeqOze8+WhLqwk1souCrdhuyOKh1XmDvbv8ZpJ6OVS/LFVGIx9ShIa",
-	"Ipuetvl7/gzuL6eSOpLE8PUUOD/ADPkccPogrIQkSYUxV+B0X2fSLZEWJAFgUsrkSk+Z3jYe1gL1/mKq",
-	"djCRa3qW6NYr1CuutaZVywzAWYYmgKMIBRhyFG7AiwzSkgX7PYTvvNLyUVzismy5gBcZCbz8DqIhM0tM",
-	"mEmFzbbmqUoNtdKDfxqGAjy5+0lo8ozNMpiNNYA1I9gNGY2MvA7bs2WB5kN8ia7M0/yzphYtdH3r8psI",
-	"ptFbSdaIYER8tCUWvoJcT4cDWbkk4ZDxEUg4jUdalsqflC+TEvSJ+DAMjwEQqnQp+2DCESMwDDeAU/UY",
-	"SthYK0iCEDH5oln8iEmA1zhIYfiJjPU8YzXROJslW5mQ1rl9OJd3QmDBJBkF4P7iSGk5EAs6FxQvN38k",
-	"IIWMkis2kS8dlPup9CFOlof1m1pTiUjXodUL8LyzBt8RvMBIkIl2f+o9vFAkNpbEDcYZZb9s5CzdsM73",
-	"Ixv0aCi+sZ2A1fr7c8io8Sy2cBkADdu/GX7zN71u/ab9xmlct28aD71tGve4axq32fSa+E5z4x5mioIS",
-	"dMRxhKQtP6eUJ5zB2EhDJeR1BGQSHAR8Sh8wkgpFkN08xMkKJQCSXMkhWb37+BOZhljsB1zc3dyCy4+3",
-	"MgMZmMskTmaWK+lhuLs+U+6A40/k/rU2/PPRjHVFiMMAcvgfIGb0yybXWQmADAEcxaHUGBK5RwFaYIIC",
-	"m/r4GCNyf3F/OX2WFtL95fRGbb3OPBIYyyCU50raIQrgieW6AL0Q6sbyq7TcIvkXYusMZZXkWUGqdMXk",
-	"6swbeSkLvRNvDGM8Xr+WuNOzlXuqtFTAXyH/YWvDbMOGdGKn6iP07HlHbrJsAx5eGlFH+pmEpb8OnyuU",
-	"mct6ZcFz1W73mPEUhiCC/goTe/e1dcI8U/gjZQ+LkD7m7j1zwYabuWKHhmnCEbNO6atvtnnzaDdbv21U",
-	"W7VjMR2VBdB/MdZdSj5l2X7KV0L+KP40Npxa0Ssjn4yrfKODTIVpmyDL2mntJRNpVntdZjFtgKElTjjb",
-	"2Hb67y8tUXC2XV6FkC8oiwAmc/qllJ/IjMh588ocspASpjpqXn5SqgFdRCArVWBDq6wkYFtdulyqIOQC",
-	"NoRkX+PAQVui7VHWIvG+ff723wEAAP//aomUMN05AQA=",
+	"H4sIAAAAAAAC/+y9+3LbONYg/ioo/b6qSX4lWUm6e76ZfDW15ShO2jOx47Vsz051svogEpLQJgE2CMpR",
+	"p/I8+x77ZFu4USAF8CKRljPV/3Q7Iq7njoODc74OAhonlCDC08Hrr4MEMhgjjpj81xvIg9X5W/EnJoPX",
+	"gwTy1WA4IDBGg9eDufg6w+FgOGDotwwzFA5ec5ah4SANViiGoh/fJKJtyhkmy8G3b8PBhJIFZrH4GKI0",
+	"YDjhmIrRpzhOIgRCFCHxCwhUQyj/sYjgEjw7fXs9evHi5U/g//6flz88HwzVsn7LENts16X7DRzLmFMa",
+	"IUjsdVzKTuW13GwSBBhKacYCBMTAgFOzou0SiwsCMAwRCbP4+ckncpGlHMQCRICvymOhLzDg0ebkE6ne",
+	"w0z+sxqe5yTlkARoin9HXlxh3WiW4t9Re5xdwCTBZOkdPlbf2w8soJ8mMPCvnJgWewxOOV7gQBKQf3yr",
+	"UfspruDSQT3iV0CyeI4YePZyhEmIvqDQR6+JGMOeJkQLmEV88PrlcBBjguMsln/r6THhaImYmh8x9xLO",
+	"OYpTkCAG9PDOmRGb+Wd/9WI4iOEXPf2LF/WLYXSNQ8S8sE50g/ZwvqYReoNJWEWEc/V9v8G9ozIa7UF6",
+	"U8TWuIKqU/V9j4Ep4282u/h+h1EUChmVUsbBfOPBuPg6k1/rJvnIQsQcQloMH2KGAvlDxSxUDuCkrAFM",
+	"g8FwgIigpV/0v8Q8g89D13I2KUexH5byc3tQ3qA4iSD3I4nrBnsMjYN7xP0Dy8/th71NK5grS/dhrLsL",
+	"74Dr1jD9JhqnCSUp0vZDeI1+y1DKxb8CSjgi8k+YJJGWueNfU0FYX61h/4OhxeD14P8bb22Tsfqajs8Y",
+	"o0xNVSTMNzAETE+mtXuEg0eY+Npo9sBM+W04eEfZHAtroP/5t1NJY4AjRmAk5A9iqk/vKzCTglTOCpBq",
+	"KBXwO5qR8BGRQCgHCzmn4BcCM76iDP+OHmENhdnEZ91DDHiaCN0Ho7cowCmmxGKLhNEEMY4VywQ0jvUS",
+	"S9w1HARJNotwjPmuWJ5c3QL5CWBhODOUgmdTLsyQn07eCMOjSnWrkdl2Sbtj64/W6HSNmFgs5iANEIEM",
+	"0yFoMWWI0/vZcr473Vuc3gNhporJ3r8ZAhjGYlpIAAx/FVZ1m50hAucRmonVMhw6DKV/rhABUrDpiUzT",
+	"FGh9tbXdNRTSsQR1ChaMxsC2v8GzGKYcsdEiog8WNJShXz6EDAcxiinbKKTOYgcwLmSDLWov3rTavR5f",
+	"r7tqBgvBLedIUYQCjsJZEGVi70Jp7MxyKkGrmqaAQ7ZEHOgO+SnqP58PhrtUn4+fcsrgEs2CCKapW5vp",
+	"X+j8V6TksOE7pZB32Q3K78rQ2eU3hqCYGMqOCyrOooPXgxByNOJYHsx2+qA1IlyDYOej52exIHX+UJ+c",
+	"h1G6AHk7wFc4BcqKAAwlDKVCRG2Po88t62pyfXZ6czYYDt6efTiTf9xdTmank8nZdOqwt4QKh1ogOj4J",
+	"wM4qW0g68kA05ZBnEvBmdVdnl2/PL98PhoPTq6vrj3dnbwfDwfXZ388mN/LPyenl5OzDB/n32f86m9ze",
+	"qNbTW7WB4eDd6bn47NqJorOZMmR2TWbKgIKJBmU6lEf1uwswR5gs1TEfhYPKkYnTf1AxtnQAPFtQBkKc",
+	"JhHcOKlem4gJ3EQUysXDMMRidBhdWSSsTLKSwBZq7gvPYAR0f0E9YnrK8BILTW3YPUQJkqcmQAko0eFw",
+	"QLIoEuLTTFNir2+2bfjLQBqLOf3nyLZp4nMti37ALq2IxWm28EeVhi4x/VYuQMbgRvw7gQIMClzVY11t",
+	"WzYQMNfa+t3dwRPjcT8jfvYTo1N8lYjAPtroSZxIz0LMP9ClQyIHBi07y4ABp91J6hBxiKO0jrV2lu4R",
+	"4sZImNV9N/ivhqMEIDSH7GLn4mQGLgUoVMG8ExYz+OuXuTK+Mk4lB6VkfOXhpmu0xELgoBCIVsA4nkAS",
+	"ZUtMgOgF7tHGRRfS9bpsTRb7kKDpM984SUbZrqHLf+0lQ6OOdjl+65PZfrbMuCwJW67fRbHaX71FzXYX",
+	"n2sQPKGEKK/SDUqFJJWuojLSY5Sm2uG5u8UsCFDBNLT9/fZaTcvaNUkEeQ9rT4sCK8llT7oowW0HvXUA",
+	"fM9olkw3JPDCcClaFAXPzhpjTM7Vx5e74kZLwgVGUQP9VGg9NLO32IZPwbeTn+fhlRgOhXLkXSlaJw27",
+	"keGWdH00OT6FcRKhdwZbxQ34kDgcpLJbNZmUN5AR/FuGZgHNCg4VS+itYZRtNbIxhfSIQz3S0OxEGMTx",
+	"XDq1DWeJSe4JfSBuz7VNeYbkrDlLS/zcCHR+EpQz7Id/GysuUrAubmpZrHjLoxdVt7cbjYPijuYZjvgM",
+	"E7dMU3JytnXbtRKXBXntoCZ9Opt5JWczQ04jujDacLuxJnDpmtklrLtk+IIZIFdTt61baW1UeEGfkgbc",
+	"mWeygmSJrmCaPlAWendB0MMs0Y0KRlX+o0P50yhs26mEgcIIw+IqXHiZKDecyzmGZ8qlP8tY1OHBS7pV",
+	"a/15DViwEuGIrDGjxLjTSz4S7Xu0GimbrBDSMRT/KZy0ucC0FIih86jsMcvvszlaY8Zna8RSn8TxU+jO",
+	"af328h+XH/95ORgOfj47/XDz878Gw8Htpf339dnp5OfTNx/OPOd/C/YK2yWHbcbpKERcul7BVDWfiNYg",
+	"wikvgOkvMrKhoVquOjUU6a3SgaDxV2OgNyCgEo2YG2qN56ZoF/jdCq3yzWSK/vzjCJGAhigE26bgmUAD",
+	"CgEiAdskHIVDoMH6SoA0Z6f5hjs5ybMtt9FuLbECoGdbgCgZvQvUEsyagai0JnuMitV0ofmMeOvVwn0r",
+	"XcV3F37jrPJi4FHccbuuWRfk324IjHEwlRv3bydESwZDFBa4ZgGjdMcbbV2w6UA4OSTIUpQCSACNxLGY",
+	"MoDiOQoFhyxgFM1hcA8U9E8+kXdM3tyG4OJ2emP85gCCB8gIJkswh4SIszVimoFe/QBuz8FbuUjlTp1y",
+	"yFHqu4hbIB6scj1Wut6efgR/+fOLl0AotJTDOAEPck8rpFcIHmAK9BBiJxFMOQig+OeJzceVajGG6X0d",
+	"GSqsXIiW3+xADLeV9HU3ViCLIpBylgU8Y2jrVhYwVMhRnvoQ/H368RKo6cwlwsnAQS5qDbZaK8ULoRgS",
+	"jgOgW5ibCA24Z+hkeQI+DV6evDp58Wnw3Ma1JBDpBV9QpsAJQoYXHCi9JEaDJAQwC3GukF79oC9b0Rd9",
+	"YlRjO28WpS/AcQMNOQT6yre43Jx489lAaNFYyhnkaLl5/voTGakVvwYAABmNEarrYqXgRikO81HV1p4R",
+	"Gsu7mQTyldjEKOeI1+ANDO4FTBYoioDkDU4BBPOMhJFQIIZ1DFgFYwgAMjUQQzHlci3vNJVGeI3Ugv6R",
+	"zdEdZhycXp2DZ2lEH+QKhoBQtTIDUC2Z5G/i33pO6Y4Ww9dLfU2wmtZd0iePWCmfB1xX9xcwWGGCRgzB",
+	"UNiBKvAEiMbg2cKQ0QoKGKUAv/wLcV61yRPqTPZtrlXkUfnMBLqUFYvlpSwu+YwsI5yuQESXQDcSiOeS",
+	"xG/PK68EZWx22/uKEgYkIF2At/bjhb4bcm6PnddN6/GKeBf2PqJzGFnxn45zShTRBxTOLKOiiMimVlwZ",
+	"jT349H23QzrK1PvNfzYIaOLtqj56HBXDPGSw2W2UFWC4jYnN11aYrBEi65zrfWG1CtYtoLk9KyzlzmrP",
+	"5WbeRsDpwvLdZZ1ebeCfEYz4yiE+Vii4r5Bb/iOjZWbsGMj0XsYMayt0OFBBhy78+4/cZfXkt4rPwyvp",
+	"qdcPIZ64DEJfVEDmTF5v+MhZffQKFk+valfw0SRZJ7eXRc/1LhSHlTxcopFjibdOkN+RjKxxAhwG4C5E",
+	"ZJmvexWQpclqfOBPXf81iL4s3XLuaoYnJtvEuX2WyhW3WlOdTGx3Rd1QFFlbdDKLFZbsgHySzWQgt/te",
+	"dD+3fogD2StIMrdHvsGVm4kJdwaMH3AZsMqWKIFLlMoXkG2IQsdQx55l+UWoQmk6W/rAkbfIF1fTLmWY",
+	"rt1t0gQFeZT7gYdE2ye/JRQbEnUEV6P7CtTX6mVCzZuCTkmw9v1Cv+RYoLs9wvyruzwVsq2JSuuSrA+i",
+	"6E6MDVsk92tpWDPVXbX/wYt/8OKj8OIOlX6gS+x/Cdc6ciJLhY3U5EY0bzkcVEZG6AV6r/S+JBKmFVaS",
+	"5wWF5UKlwjI0q5gFMrLEjR9O71EDL4Zq5trOBUzvPYF3ZQ4qXYigVIwOIhrACP+uLrmEhAkhC+W/IzhH",
+	"kXRi8xUCt+fizxgkjP6qLmpO3A5t5S4qTUb5iFCublTkNZRoJx/hRWtMluAB8xVW12/aSg5BRvAC5/cf",
+	"J7XHff3SubBtF8jy/BR1gQZFURbDLx8QWYrt/fTy1bA27qDpUc6NHplqZEHFeRFcv5uAly9++AkQGAtg",
+	"mTiNv8qHfNtl/fmHYbOwgbqb+hxCKuKZbbo55tW40etUR5vAoANDe9w4Ub7XaANUhCfI05jo918GT86b",
+	"nk5j8VsjsAtTZ5cqerV38ulqjJ32bOolI+cyrFwy3bABbnu9Jp9vhj4jALab/dA3TcMBxzyqjp413Kee",
+	"f55+mJVfhJ5+mE0+Xlx9OFMPQvMfrUeidxez6c3pze10Nvn59PL9Wf1NNM4tCLPGLVA1CGvfU9nY7oRn",
+	"bOrplV2uCiOVza4CXVn2X54tyPmVUw6jik+zsnVaGWF7hViM09S5wjrZf4829VaSaPS5cuIuUGpto1eE",
+	"XkOOPuAY87MvKE66Ez9IDlfxQq3eAm7zvLy93mtxh729vrZ3VeDywgo+N4JzjV3YxRGhCmBtN99sU12Q",
+	"voMkH4cFpvIW172FJSKItVfC+238NkVMLabnxxbD4r4qcSwW9dFKhlKO9KFRSB/ILEUBJeotkYc+D7wt",
+	"iOGXmU49MAtWOAqZOtvWz2b3TCAz12L1HbsWPLqPRzTuIZesEfcUSzZ2Kx7X7CI5d1C9GLZEgY082821",
+	"NyLbDeJF6rc6OE3zkBIPeBiKISZidRagHNSfMbF2J0DqW1sbdyQvWixQwPEazVw4q2rvw1DTPtXL0vrT",
+	"c7o28n7WhfI7QL0P6jZXC7BKDPhxWUETwyrycrK2zLhTmzasig0KMWiqnXMmGrV/gbnXPfGB7y47TYuQ",
+	"5BZ62uZxcYW/xR7ReuhZnQhBAL+di7FjuPUMIAdsfGDoxPgUtNyvuUmjls6mjhG2P1529mK9KtmNQgrX",
+	"UMbDtHxcvr1rcKDhtwwH9x2OWCK2wvAuMtPZebs5I9ehua1EIuiLEBg6X7fMHe25j8vz3jYLKTJh2la6",
+	"3BoPl4ZTO8FUfqPB7oW6A2mWJJR50qkZYFgO2Zc/yQsijpgY5n//Ake/f34m/vti9NfR5/9f//X5+f/4",
+	"j0Gjm4yK/XUhcQxJ9Sp09CTt5E57fJTAZw/ghKIkqCdx7VPDayXy2hWViED/I81Ob2WsjdazoQTw43Fh",
+	"KZORuVEUBBthSLi+wvLcLD4K40qIdMK3inj7ZVs5xwWSuWO60Tm1pkMMceSN7C68o3ggMqONTH6rQqJU",
+	"ips1Rg/I/aLCfyhrG4Uxy18Wab6Qy/tcA8QaVuh3i95dNFp6dzSr6enRKLeBxXs44B1PpipA+sQUoSko",
+	"4ODxiGbhDBNn6m7xbSS+yQe7IeQQ/Ov04gN4JnOUoxBALnPSUsqfV+nMJ38IxzFcIpNKZjdlLcQEMcB0",
+	"wAC4vf4gA4ryTzIxeExDNATy1fhvGdycYDoOTIMQp/fpOJtnhGevX706efFji6QZwwFNZwsY42jj+1qV",
+	"uyVZB57gqau7yfgt5PCORlmswz/Evq7uJnI3zsgoPZqMadgd8h/ZHDGCOEqtuJKHFWJIRkWVZsSpDNzi",
+	"KATPDDmrDAbW7b1o9adkHfzpuf+lvCfV4RtKuXkuL1qcgD9JTP8J/K2IvKGaAfwNbFc3vrqbWI/LZceB",
+	"BEDDS3yvjWC4sS4WfQ/WPAJH+VnnuhKlChNPgQ+ua0nvETnhBNQv5+T74YRaJujC7MjVW68mh5mlLmy9",
+	"wLbH5Mb++OexmKEBnTemyh183hKGYDgxOTjLd22e1Jw7aSt8+TFv0ydwptrHGBKmbdoyn2njo1X5VGUW",
+	"WOtqEOA8OKfafnBqEQn/BJ4GyFJcZEGPTnu+Z/r7XQ88Kl364NqFspJyoVdFJWaoO4B+d6zi2ujdhUv9",
+	"2rV+OjmS1ibDr8jmeU5WiGFucmwFjuSehbyerVJ6rmjK274kN/c3La9+bN3uKISU14xslkNQVgVRodTX",
+	"t5eXunDOzcerK+tPGUAty4aoH3U5naFVmefi/P21Gejq9HYqP5sMpAcmKLR94tvtV2YovLuQdYlP5cMi",
+	"/+ssKEM3UFiV/ztvk6/YkQp1ssJRaCqxnL9NAV9BDh6EWQUDnslXHmYgMN8AhjjbjAOB/gjA/PlTc3ma",
+	"F1auRnOV8NIwupIRKSYIsQR6q35zXqqnBLQK8EuonDsvfnaKDfvPgtLBI4vXbCvf2BkTswx7ryo8VnDd",
+	"2G3ia4ss1/Ee7PKi3Y/uKXpVGFdXqKqAzrcaAvAF0UEudse3vGcHGDoiyqqSo8qsHMikptv/kUqL9Mr9",
+	"ViXrM32rRs7f6XyaxTF0PscTiKuSivto7wXEUbWsrSt+50qczIOVXRFL5ueWvl/FEUNw9fGfZ9dDTcju",
+	"rIkmBM+/Mi/+Z+ax0WA4OL+cXV1/fH+t0Gu/SLo6vb45P/0w20G+TSfOJNyqCs2s6SlY4t5m1lxs2ygt",
+	"j1vCTRkitUdCTVFdGOW7xNmrha6n+2hTmL9imiQlJ55cyvTRicUsgj4gdhqUtzO9Ob2+0SadFFXqh7qB",
+	"3Pq7QiGum8UbqWYV1CRn956b9qKq7YZUbLmpGKQL1/sLCBUkUNOJNArqymWqJBAuRTyJsDiW4BDFCeWI",
+	"BBt3OahycQeL/f2lNvRKFa36TeRKQ7NeTVhx5W0QZRsOj5N0tV45taWBrUxpq2JaW+0N9EQHsUnWYaAH",
+	"DWOFv3vinmrfuBiSzuYx5t1Kju1RpmfJUaCapyw3NJD3khvy+DuDC45Y9WuVw3hC/uW5g2lw0LX6u5fs",
+	"Bs+EkpRGxuPnh1DTvRXHs4SifUaofSSzJoGBRE3b5hlvPWurtntcpyW3DaIH3x318uPN7Prsf96eTW9s",
+	"N1QHs3SGrSeGpurrGpcz5hD3yo2q3f6Pv9iXjM9wHGdc5uCXXARSIUHk9UNe0sZd3b2x86WtO6WmfRnC",
+	"27mKIw13AVh0VFa8qLq76ObQ1PcpqdoY3xZkLsU1iV7avwk4BegLCjKOACW60rnlYk85ZNJu4DRR5Yvl",
+	"D7VxDXpuN3D1inW18xrK7y5LX478lrdkhqq6CLgou4nyoYflXRfW64bj3eVkitK00pm+6yKZnk2n5x8v",
+	"Z9dnp2//5c67HvtMhAc0T6mub+9KAXaNIsjxGoG84Thh9MtGZQJbUAYIvbucyJDIlDOY1Cf8yhW/72gq",
+	"BU6QMcw38j2U2vcbBBlip5la5Vz+652RLH//581AV8CRt27y63YlK86Twbdv8jZIXRTLSMVAkqpyRg7y",
+	"4ivTFUpWiIXgBsFYWMNCT8gh0tfj8RLzVTY/CWg8vl+PUt12bP7YiXgZnF7JFGwghkSw/3Jb5WWNGc9g",
+	"BGJVPCWVJXRkNM2IKKAv6RoxImjo5BM5DVeIoVQwuC558/K1rBQj2I7BgI/eYZZy8BatUUSTGBGuysVE",
+	"OECalPReTxNZ50YV4ynu7+Hh4QTKzyeULce6bzr+cD45u5yejV6dvDhZ8TiyUgo5QHd6dT6w0v0PXp68",
+	"OHmh7XQCEzx4Pfjh5KWcXhCSRPBYxiaPYcZXI5NzeSQQqPNF8ELx/vNw8HoghHq5nGaqpJrkHtnz1YsX",
+	"BuP6xlJG86rsPuNftc7bVnBqU7tTahVJWJU1pxHhej5n9Wl1IZQaL7Hclo6+bT7EcMDhMpWi2oZgmgd9",
+	"fxaTuIDcHL6PBlsfXE89kIhU+x0geiDXCFrDQUJTB1CUlVco2ZyfE9/QcNMLQIqm5beiTBWG67cdzLzs",
+	"ZSFtsKKdCoLvf1SE4polX/b4DcwruMouf63vMqFkEeGgjHwFLi/jyNAEi8EsRjqEj8ZfrVzx35QyjZB6",
+	"hVCkIVWksERDsqoU4pIhf3FvfNtkbDqevx18+7yD/B+ddUSdwFBr1Fj6sR7kl5S/oxkJSyBXW/KBvCHD",
+	"QR6sdqGlYnu6hVa/7FqMRmrEri+Ozq7a7bc3u+5POwpch9BOM5Ycy0oNo1hV/Wiu9+xaIWnHnNod3l1F",
+	"WRzol22AhoHWnIehT6ra8/AKLO2hVbFISCRa2wqChpq3UDHmCcqEykJEj6zFdwrs1JHGoeq7FUF1ou93",
+	"aLA30TH+qv9qr+k7o9lhbWs9S2MToYj/bg2DvXDTwiQ4Ilh7lxtHNSday41HtSMOkxva8OhTbqS6+LHH",
+	"1HiPCpbGVLV+qibG7lJzR6WDLFQLINP/gHQbZ3SINJFVk4ECKsChMBf5Bsj3oCrNkHa2dY7GDQmkM9Zp",
+	"mUw3JNgRRulTP6XIVYqlP4GDirWWCoKSBeE0q24t10c9q4g1AFMFTi1lf0u3IfFxlPJRQAlB+Q2Qmw5v",
+	"UPHgMtn2+R5Eyna5N+pOP4ucRxjTbi14XwAHMN32MNyKWb1Oo8CatB1u9SOY6vPmxDRqjSi4RE2slivE",
+	"VNM+sal34Tt76s9ef22wBYKBr/VTs/OhnqMnp6we/agnObPDCgBvnZslMJubCQANsKthvUvF46/bJ2ff",
+	"xqXHYEnGfca6XtqZ1WGH1DGRb+JkRSB9V2W9byvDeGjBq3zn+LlX9FubUJt7bNXZgATsJ3cFk/xgP53j",
+	"UV9TIjJ34qM8EsDvgBMd7BCAXm+fdioMOiBr2gCxeK8Mw3YrbRqIragbYFSCVgkgjZ1gZeD0JO78pUQf",
+	"23tViAWpw83Rb54KRNAE3T4WGX8tRz01cTc5qKOdUWF3buw+KuKgW/dRa4DWuY76AVG/HHhcP1ArDjz6",
+	"ZdIBHFiMK/MqqMtts95t9mGZ197hSKjg+aag5/UNtjSjfssQ22ztqKKy3qK82dv7Xg8N7rp3DhLLG1qH",
+	"/5f1hHJLxCGNMvw7CmtCbYiNU0MyhR+b6efLQlxq91LBUw3zkZWyo7ZgFdLsQ8mjK2br4GMHDVfi2CUS",
+	"xl/zv3eVcXHnH0m0ATCK6AMKAV4AQsHdRQogE8oxiehG/EwAX2ErgvvkE9Evw1MQULLALJ7lmQpTuEB8",
+	"o8L6XIrfJrt2Einvqa9ASqHmm2SncCanZn1K1WNKiqk9fgAwDBEJs/j5ySciS6PG8h0xX+0Mhr7AgEd6",
+	"Zy7xZYOi/UGwznLZ0uj+Vsth5KnNnMakOfReJ3REA48q8KvlRog4xFF6qGHwHnGL7OYbcP62gZD3OzS6",
+	"BHSPGuKoRmNLTHfrp9hDzpeSdXltv6tCaZnewFeqgemA3baF1yGRp1UG292Be7SxTRw2h4ETIAxyNIpw",
+	"jHk6zutJVcNmt97gd+7U9pRldGAjb2AZqD/Uk/E7yuZY6EqndZpjACAboPkFRCOD1FEEsh+5U1eY85EF",
+	"kKv4ZRXeUrg+wDxth+vDhJz2NFETuAmgTI3spBcHudSx+PirzqffwN/kJK52DC+zODZ1NG3RxVBMc4Q9",
+	"JvSv5cSdwHz7oqtepE7N46n+Gcaq3up64bLdsVp/hxJP1+zbAa2aCKWNISsGKBFyhT3nrN2ZHkbJPcpX",
+	"V4XRYwnXQi1bB7WYb9+ReL1NUsS4MJlGZTqkFm1UEKJJ3+rnatmiT/yYIn4uBqaR/w7r+s3pBDC9PI+N",
+	"WGNv0Kgv39duhcZHdnupmoYekB796inIUk7jLQobWfkC1eOv4n8NNT7dI0pRdGqs4yUwj+yNaQDDmmum",
+	"w+HUD/8c1SlQyT9HvzhqxTiFVALVoQw3VmqA7/gwXKhj4UCi+e7VLTnI6kIj7FwKLaIi8lwN/XCPu5jN",
+	"I2ugbT6KCgQcXRPxLSaqcOrgpvFXK/NL04AHC/Ht+Mt0bKybchB3G+PQEF5NIhu6g0V/HHRUHdSIg46u",
+	"i1pzkDzxVuqi2/S7DzLOK1M4cCe+eVVPlpZyPzTSKrKART+ssFvk5ZEViSrO4QHj8fM3yLpIEfj7P28k",
+	"7irP2w5nT7XS0Hjt0U8poVjQEY/pwTAZGeqBWKNRDgdUP5xzVAVSyTnHT6VwAOdIb8BojmXm2HplIk5t",
+	"b0zj7tipO0y9j+gcRtYyK11iet/dJUZYyunlidIMro8+Zcy0crCVQP/U+HMH6EdVczurqUX/95f8wEFn",
+	"jcisoRwYf9V/NVeuXZDnsJG3TM/SzrlogNRxAiQJ7j+lLnzUICFJGF3DqMaXlLd6jKBjVyjeNnPzThBx",
+	"j9Va+n2EqoF6I7MIe7PP6VamApU361yxXeHEoT+VUT6eGwPMyPzyi9c4gRzPcYT5BiASJhQTDghlMYzw",
+	"7zKQlFMw5XCJwE8nZ7JMuQy2THCCIkyQK2hUZRc325LZvXs66DhzxjdSAq/6WoP/mbmqdqPBAGAQoOQA",
+	"VfDqr53t4EyWXvLcxgMTfxAgFO4Euqtda5rICdTs8VngpK/nTSj3a556+5v+FfkfqCtaQ4rP2junZLc+",
+	"syPoXb1FAVZpeFtQ6o/uGl8olwiH6xgNPgAN5toiSNXC8+NnIr93g56mwFFrih7piHygraVqCdIHAnRp",
+	"jX0xwZDMduzFxLX8/lQZRa2uazZRMDmcTdTqGnFJFmI+imhtMsAQ8w90eTyjC5osHv6XDv6elO3TMS/X",
+	"p1+V7T+AKvjR4olGl+lFFOb8GYVDzEFEl4c+KdMZyyVN2LnKf/ks9reTl1jPWsxEHGJePhNkfDVWVYVH",
+	"dgFhj/SWDa+2NYV7SYFQmORQ1jfjALXJEOiCRossijZ7n757xaACQDFK0a7jbCWGsbEY0SWuSN3zQX7u",
+	"B2Vy7CP5SfXcfmtbNrDQ3gkGiywnZ3jAfAUChmTOMHV+9qEqrszXNlGIz6+FenQwy7r2rhwfFu09AsW/",
+	"R6WgXFlGwQm/FYKRIHa8roThB7xGBKW9Rj/+LJfifDTDqCA2gFMA5UorqUcvFSSMzu2bWLXV4r4Zgopv",
+	"fRu/RjDEx9v5VFXXETtXS/02HPykTO5+T6jWxIRyM3kF2HNAVcO9RUKZ7z6XjD+LgYIFoRwv9JJrUhcU",
+	"Wh4tewGnICOCFEBh6YCSaON5B6zaz3SLLT5CtIBZxAevFzBKt2W85pRGCJK+ExhYq/fmLrDadJu+oAi7",
+	"BWUFWW2/fSxg3UEz4xiy+xGMopEAst9WuYDs/jSKClQk+HXQqA5BFJWWLGZFIYBKJpW2KOYCcKePadxm",
+	"d4p2RnnxTp+MvpXtJrpkZn8K3prGdZGsOEOttgNaEUrcwW3AlAZtDsev9j+1M0OTizuMQODQJhZNKy0f",
+	"TVsDNPYxFbiuTGeHORkkYRYg2YwmDfq/qty18nT9rYoc324IjHEwVUTVJGeeNXJlrgRzbWO0iUyV88hX",
+	"L4XdVZ0TdEOgOgKGOMNo3c2J8acmXc6JSvoqTBnEjKVTZcGoFYKwuHJIQnB7DmKY3pvEsQphFuFo6BiS",
+	"2aSmSp1XpU91m8dQ5jVNp5TxN5umLT8yWaekTxpTsPFpZvW1W52c5tjIMap/qYvrUKvpyRGgBj9qKIbe",
+	"nx8PR486VJgCz1IULUa6HOkQEJpfmz13otVi1PFX9UddgqA80Q/fyMz5euZyep1iVp3nJ5/IBKYBDJFo",
+	"kXIGMeGvQZylHKzgGoHfEaNAVvoGevmpP2VQTm/txIbq5k8W5NnKHpmC7JGOnCZIU+iRX6WlBmMu0eIz",
+	"Ig5Gc//yuUImdJgBSJNTOf1PQTwbK7a0Fhlc8ePJ5LU8oIL/tj7/N8Ap0IWXTz6RqUWzOAXlmsxSxGFK",
+	"XFypAji7QVdfCuSogbe1xHJo8O3jvjIPLZVjb6eFihnHKJ7XvftQwLnQLZ+yHFBrrLHW1Jb3TjrRQVxv",
+	"ai+knaV3Gob2Vp8qm6vVPQFrUYOplhoONR2fdOjJaRgWaW4fEdHmfUxHJDrs9k1NEePHzv9Tj5CatzU2",
+	"kPdKFrA3oPuVGkdPMtBOcny/NoNhhGLCgnqBYE6G1UaDadQnVT6pt6V6x17rQ19jenMtaoABTAB0nNQM",
+	"PGu9QKrhE7QM1MKOaxRo4FTg5/hOJL2Qhl6kLV3U8ev4q/6rzrnU2Ed0d5E6kk7/TWARSPcKyAnM4Yry",
+	"uZUOJuAG3mM1R7PGE7WtplaGRt+xXT05FJ0SxOvseVzgP4I8ruL1Lp1DpSF9kvtwB5Ge6AAP0RFw3Js6",
+	"Oa6lWE9i36N5mJOy06dUVDjN0lj9kcGqlMHKmZZFQXRdc117d/H9XtV6wv3tdOut3wo4HpU+ZhTC3YWP",
+	"Gu4uvHSgcGgoYB1buN++59QUUL744xkjKYAggUtMhGyRswC60E/0fqVzXTIZ60xpfFWMOT/5RGSqpxSk",
+	"CMkIKdkTpf8FGFpmEWQq3438LPURXyHMAH1wahVFlG/UEH9EEfjfj/oI5U2Ot04jCfKHvL/S+S65DT3v",
+	"hbcPgVXnVD3/RISzjXo6XLDk/yos+dsUpcLUR4SP1MlAv3OOaYgiFT+PQxQnlCMSbMA92pjaAv7HxRpo",
+	"fzwr/rd+VpwT6e6DO4dYHCf0AbEOH7sXiNZ68H72BQUZF2da9UVMC3IqTQEmIUoQCRHh0UYR+BylfIQW",
+	"C8rEaSCGhOMgrSXvK7mhXmlcTvF9kLiC8783oRf32OD9vIsPvsr/GUeO7zS/FaHtdLLs1ff53JCGNN/q",
+	"SUObeR0c1XNM5JZjM0g3fAL/PQD9NFDB1H6g6+fq6vFwiRMPqDyiRjUP4KVwZYgon7fBS3OEMMTZpuoh",
+	"PGebfw90yK10jQ016ALiCIVtcWHUtZ8ZpDf77uI61+v9qLg97hNe9ZT9pxqBRZ02zJkgzyuwj5bzaBrj",
+	"BNyqGWac9K5LBCdqRxJCX3jtUVScFUdrnOJ5JO8MRCdgcADmG7Egs44H/Dtk4cknMtHtcArEJjNxjs1S",
+	"KRT0SfX6zelkbJeolVMoNcmyyB2ZKpWeho6eYtAr/5bmcrsBzO6DvJVDJ5UaVT3HKuLr67o2XPg03ZAA",
+	"rDEE13i9vYx58efnJ8Cg8dWLV+BUU6eyaNEaET7DAl1crAyR9WvAmtz2nHwiCaOhu4cqSirDdAW+7y7K",
+	"Ebo3WFbU1c0VISeIgcINkv8C6e6itbC/u2h5FdS46SWMnU7J7mSQ2XTlCxgTPG3ED3hWSjVm7j2fH+vC",
+	"SmKt7KLwG7Z7orhfZe5h/w6vmYReLsUfO4XBOKAkpRFy6WmXv+fP4O5yIqkjTS1fT4HzQ8xQwAGn98JK",
+	"SNNMGHMFTg908uUSaUESAialTK70lOnt4mEtUO8uJmoHp3JNTxLdeoV6xZXWtGppAGySegEcxyjEkKNo",
+	"A54ZSEsW7PYQvvdKy0dxicuy5QKeGRJ4/h1EQxpLTJhJhc025qmdsnulHBE0igR4cveT0OSGzQzMxhrA",
+	"mhHchoxGRl6678myQP0hvkRX9mn+SVOLFrqBc/l1BFPrrSRrRDAiAdoSC19BrqfDoSx2k3LI+BCknCZD",
+	"LUvlT8qXSQn6RAIYRScACFW6lH2wfnEabQCn6jGUsLFWkIQRYvIRvPgRkxCvcZjB6BMZ63nGaqKxmcWs",
+	"TEjr3D6cyzshsGCSjEJwdzFSWg4kgs4FxcvNjwSkkFWlxyXypYPyMJXex8nyuH5TZ/YZ6Tp0egGedqLp",
+	"W4IXGAky0e5PvYdnisTGkrjB2FD281rO0g2rfD+yQYeG4ivXCVitvzuHjBrPYQuXAVCz/Wn/m592uvVp",
+	"843TpGrfNOl72zTpcNc0abLpNQm85sYdNIqCEjTiOEbSlp9TylPOYGJlLhPyOgYy6wACAaX3GEmFIshu",
+	"HuF0hVIASa7kkCz4fvKJTCIs9gMubqc34PLjjUxaB+Yy75edGE16GG6vz5U74OQTuXupDf98NGtdMeIw",
+	"hBz+F0gY/bLJdVYKIEMAx0kkNYZE7ihEC0xQ6FIfHxNE7i7uLidP0kK6u5xM1darzCOBMQOhPL3WHlEA",
+	"jyzXBeiFULeWv0vLDfLFybwYCmU7+dbCTOmK06vzwXCQsWjwejCGCR6vX0rc6dnKPVUmMxCsUHC/tWG2",
+	"YUM6F9juI3TzvCM3WbYBD8+tqCP9TMLRX4fPFSoTml4meG632x1mPIMRiGGwwsTdfe2cME8u/0DZ/SKi",
+	"D7l7z16w5WbesUOjLOWIOacM1DfXvHm0m6vfNqptt2Mxg5kD0H+x1l3KV+bYfsZXQv4o/rQ2nDnRKyOf",
+	"rKt8q4PMnuqawCR6dfaSuVd3e12amDbA0BKnnG1cO/3P544oONcuryLIF5TFAJM5/VJKaWVH5Lx6YQ9Z",
+	"yCK0O2pesVSqAV13wlS3cKFVFp9wrS5bLlUQcgEbQrKvceihLdF2ZFq4lmcS90hP8DJTsNfJcFRom0x/",
+	"g5GFD5P/5tvnb/8vAAD//3ft+g8ZRQEA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/handlers/json_helpers.go
+++ b/internal/api/handlers/json_helpers.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"encoding/json"
+
+	"kv-shepherd.io/shepherd/internal/api/generated"
+)
+
+// jsonParseSchema parses raw JSON bytes into a map[string]interface{}.
+// Intended for parsing large embedded schema files once at startup.
+func jsonParseSchema(data []byte, out *map[string]interface{}) error {
+	return json.Unmarshal(data, out)
+}
+
+// jsonParseMask parses raw JSON bytes into a generated.SchemaMask struct.
+func jsonParseMask(data []byte, out *generated.SchemaMask) error {
+	return json.Unmarshal(data, out)
+}

--- a/internal/api/handlers/server_admin.go
+++ b/internal/api/handlers/server_admin.go
@@ -346,17 +346,18 @@ func clusterToAPI(cl *ent.Cluster) generated.Cluster {
 
 func templateToAPI(t *ent.Template) generated.Template {
 	return generated.Template{
-		Id:          t.ID,
-		Name:        t.Name,
-		DisplayName: t.DisplayName,
-		Description: t.Description,
-		SourceType:  generated.TemplateSourceType(t.SourceType),
-		ImageUrl:    t.ImageURL,
-		PvcName:     t.PvcName,
-		CloudInit:   t.CloudInit,
-		OsFamily:    t.OsFamily,
-		OsVersion:   t.OsVersion,
-		Enabled:     t.Enabled,
+		Id:           t.ID,
+		Name:         t.Name,
+		DisplayName:  t.DisplayName,
+		Description:  t.Description,
+		SourceType:   generated.TemplateSourceType(t.SourceType),
+		ImageUrl:     t.ImageURL,
+		PvcName:      t.PvcName,
+		PvcNamespace: t.PvcNamespace,
+		CloudInit:    t.CloudInit,
+		OsFamily:     t.OsFamily,
+		OsVersion:    t.OsVersion,
+		Enabled:      t.Enabled,
 	}
 }
 

--- a/internal/api/handlers/server_admin_catalog.go
+++ b/internal/api/handlers/server_admin_catalog.go
@@ -38,6 +38,8 @@ type templateCreateRequest struct {
 	ImageURL *string `json:"image_url"`
 	// PVCName is the PersistentVolumeClaim name, required when source_type == "pvc".
 	PVCName *string `json:"pvc_name"`
+	// PVCNamespace is the Kubernetes namespace where the PVC lives, required when source_type == "pvc".
+	PVCNamespace *string `json:"pvc_namespace"`
 	// CloudInit is optional cloud-init userdata YAML.
 	CloudInit *string `json:"cloud_init"`
 	OsFamily  *string `json:"os_family"`
@@ -51,10 +53,12 @@ type templateUpdateRequest struct {
 	SourceType  *string `json:"source_type"`
 	ImageURL    *string `json:"image_url"`
 	PVCName     *string `json:"pvc_name"`
-	CloudInit   *string `json:"cloud_init"`
-	OsFamily    *string `json:"os_family"`
-	OsVersion   *string `json:"os_version"`
-	Enabled     *bool   `json:"enabled"`
+	// PVCNamespace is the Kubernetes namespace where the PVC lives.
+	PVCNamespace *string `json:"pvc_namespace"`
+	CloudInit    *string `json:"cloud_init"`
+	OsFamily     *string `json:"os_family"`
+	OsVersion    *string `json:"os_version"`
+	Enabled      *bool   `json:"enabled"`
 }
 
 type instanceSizeCreateRequest struct {
@@ -229,8 +233,8 @@ func (s *Server) CreateAdminTemplate(c *gin.Context) {
 		return
 	}
 
-	// ADR-0036: Validate source_type and its dependent fields.
-	if err := validateTemplateSource(req.SourceType, req.ImageURL, req.PVCName); err != nil {
+	// ADR-0036: Validate source_type and its dependent fields (including pvc_namespace).
+	if err := validateTemplateSource(req.SourceType, req.ImageURL, req.PVCName, req.PVCNamespace); err != nil {
 		c.JSON(http.StatusBadRequest, generated.Error{Code: "INVALID_TEMPLATE_SOURCE", Message: err.Error()})
 		return
 	}
@@ -261,6 +265,11 @@ func (s *Server) CreateAdminTemplate(c *gin.Context) {
 	if req.PVCName != nil {
 		if v := strings.TrimSpace(*req.PVCName); v != "" {
 			create = create.SetPvcName(v)
+		}
+	}
+	if req.PVCNamespace != nil {
+		if v := strings.TrimSpace(*req.PVCNamespace); v != "" {
+			create = create.SetPvcNamespace(v)
 		}
 	}
 	if req.CloudInit != nil {
@@ -315,8 +324,35 @@ func (s *Server) UpdateAdminTemplate(c *gin.Context, templateId generated.Templa
 		return
 	}
 
-	// ADR-0036: Validate source_type consistency if any source field is being updated.
-	if err := validateTemplateSource(req.SourceType, req.ImageURL, req.PVCName); err != nil {
+	// Finding 3 fix: resolve the effective source configuration by merging the
+	// existing DB record with the incoming request fields.
+	//
+	// Problem: validateTemplateSource(req.SourceType, ...) short-circuits when
+	// source_type is nil ("draft template" path), allowing a PATCH that sets
+	// pvc_namespace="" without source_type to clear pvc_namespace on a record
+	// that already has source_type="pvc", leaving the row in an inconsistent state.
+	//
+	// Fix: always validate against the effective (merged) state. If the request
+	// does not include a field, fall back to the stored value.
+	existingTpl, err := s.client.Template.Get(ctx, templateId)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, generated.Error{Code: "TEMPLATE_NOT_FOUND"})
+			return
+		}
+		logger.Error("failed to get admin template for update validation", zap.Error(err), zap.String("template_id", templateId))
+		c.JSON(http.StatusInternalServerError, generated.Error{Code: "INTERNAL_ERROR"})
+		return
+	}
+
+	// Build resolved (merged) source fields for validation.
+	resolvedSourceType := resolveStringPtr(req.SourceType, existingTpl.SourceType)
+	resolvedImageURL := resolveStringPtr(req.ImageURL, existingTpl.ImageURL)
+	resolvedPVCName := resolveStringPtr(req.PVCName, existingTpl.PvcName)
+	resolvedPVCNamespace := resolveStringPtr(req.PVCNamespace, existingTpl.PvcNamespace)
+
+	// ADR-0036: Validate source_type consistency against the effective state.
+	if err := validateTemplateSource(resolvedSourceType, resolvedImageURL, resolvedPVCName, resolvedPVCNamespace); err != nil {
 		c.JSON(http.StatusBadRequest, generated.Error{Code: "INVALID_TEMPLATE_SOURCE", Message: err.Error()})
 		return
 	}
@@ -351,6 +387,13 @@ func (s *Server) UpdateAdminTemplate(c *gin.Context, templateId generated.Templa
 			update = update.ClearPvcName()
 		} else {
 			update = update.SetPvcName(v)
+		}
+	}
+	if req.PVCNamespace != nil {
+		if v := strings.TrimSpace(*req.PVCNamespace); v == "" {
+			update = update.ClearPvcNamespace()
+		} else {
+			update = update.SetPvcNamespace(v)
 		}
 	}
 	if req.CloudInit != nil {
@@ -567,7 +610,23 @@ func (s *Server) UpdateAdminInstanceSize(c *gin.Context, instanceSizeId generate
 		return
 	}
 
-	if err := validateInstanceSizeUpdate(req); err != nil {
+	// Finding 2 fix: read the existing record BEFORE validation so that the effective
+	// dedicated_cpu value is the merge of (existing DB value) + (request value).
+	// Without this, a PATCH that changes only spec_overrides (not dedicated_cpu) would
+	// use dedicatedFlag=false even when the stored record has dedicated_cpu=true,
+	// causing false-positive rejection of a valid partial update.
+	existingSize, err := s.client.InstanceSize.Get(ctx, instanceSizeId)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, generated.Error{Code: "INSTANCE_SIZE_NOT_FOUND"})
+			return
+		}
+		logger.Error("failed to get admin instance size for update validation", zap.Error(err), zap.String("instance_size_id", instanceSizeId))
+		c.JSON(http.StatusInternalServerError, generated.Error{Code: "INTERNAL_ERROR"})
+		return
+	}
+
+	if err := validateInstanceSizeUpdate(req, existingSize.DedicatedCPU); err != nil {
 		c.JSON(http.StatusBadRequest, generated.Error{Code: "INVALID_REQUEST", Message: err.Error()})
 		return
 	}
@@ -1930,10 +1989,42 @@ func validateInstanceSizeCreate(req instanceSizeCreateRequest) error {
 	if requiresHugepages && !hasHugepagesSize {
 		return fmt.Errorf("hugepages_size is required when requires_hugepages is true")
 	}
+
+	// ADR-0036 constraint: dedicated_cpu indexed field must agree with spec_overrides.
+	// Reject mismatches at write time to prevent data inconsistency that would be
+	// caught (confusingly) only at approval time.
+	if req.SpecOverrides != nil {
+		specHasDedicated := service.HasDedicatedCPUInSpecOverrides(req.SpecOverrides)
+		if specHasDedicated && !dedicated {
+			return fmt.Errorf(
+				"spec_overrides sets dedicatedCpuPlacement=true but dedicated_cpu is false; " +
+					"set dedicated_cpu=true to keep indexed field consistent with the spec override")
+		}
+		if dedicated && !specHasDedicated {
+			// spec_overrides explicitly sets dedicatedCpuPlacement to false — also an inconsistency.
+			// Use the canonical service function that checks BOTH flat dot-notation key AND nested
+			// map format (DynamicSchemaForm / Ant Design output).
+			if conflictPath, hasConflict := service.SpecOverrideSetsExplicitFalseForDedicatedCPU(req.SpecOverrides); hasConflict {
+				return fmt.Errorf(
+					"spec_overrides path %q is false but dedicated_cpu is true; "+
+						"remove the override or set dedicated_cpu=false", conflictPath)
+			}
+		}
+	}
+
 	return nil
 }
 
-func validateInstanceSizeUpdate(req instanceSizeUpdateRequest) error {
+// validateInstanceSizeUpdate validates a PATCH request for an InstanceSize.
+//
+// existingDedicatedCPU is the current value stored in the database. The effective
+// dedicated_cpu for validation is determined by merging:
+//   - If req.DedicatedCpu is set: use the request value (user is explicitly changing it).
+//   - If req.DedicatedCpu is nil: use the existing DB value (partial update, field unchanged).
+//
+// This prevents false-positive errors where a PATCH only updates spec_overrides
+// while leaving dedicated_cpu unchanged, but the validator would default to false.
+func validateInstanceSizeUpdate(req instanceSizeUpdateRequest, existingDedicatedCPU bool) error {
 	if req.CpuCores != nil && *req.CpuCores < 1 {
 		return fmt.Errorf("cpu_cores must be >= 1")
 	}
@@ -1952,7 +2043,54 @@ func validateInstanceSizeUpdate(req instanceSizeUpdateRequest) error {
 	if req.CpuCores != nil && req.DedicatedCpu != nil && *req.DedicatedCpu && req.CpuRequest != nil && *req.CpuRequest > 0 && *req.CpuRequest != *req.CpuCores {
 		return fmt.Errorf("cpu_request must equal cpu_cores when dedicated_cpu is true")
 	}
+
+	// ADR-0036 constraint: dedicated_cpu indexed field must agree with spec_overrides.
+	// Use the effective dedicated_cpu: request value if provided, else the existing DB value.
+	effectiveDedicated := existingDedicatedCPU
+	if req.DedicatedCpu != nil {
+		effectiveDedicated = *req.DedicatedCpu
+	}
+
+	if req.SpecOverrides != nil {
+		specHasDedicated := service.HasDedicatedCPUInSpecOverrides(*req.SpecOverrides)
+		if specHasDedicated && !effectiveDedicated {
+			return fmt.Errorf(
+				"spec_overrides sets dedicatedCpuPlacement=true but dedicated_cpu is false; " +
+					"set dedicated_cpu=true to keep indexed field consistent with the spec override")
+		}
+		if effectiveDedicated && !specHasDedicated {
+			// spec_overrides explicitly sets dedicatedCpuPlacement to false — also an inconsistency.
+			// Use the canonical service function that checks BOTH flat dot-notation key AND nested
+			// map format (DynamicSchemaForm / Ant Design output).
+			if conflictPath, hasConflict := service.SpecOverrideSetsExplicitFalseForDedicatedCPU(*req.SpecOverrides); hasConflict {
+				return fmt.Errorf(
+					"spec_overrides path %q is false but dedicated_cpu is true; "+
+						"remove the override or set dedicated_cpu=false", conflictPath)
+			}
+		}
+	}
+
 	return nil
+}
+
+// resolveStringPtr merges a PATCH request field with an existing database value for
+// template source validation.
+//
+//   - If reqField is non-nil, the request is explicitly providing a value (possibly empty
+//     to clear), so we use it unchanged.
+//   - If reqField is nil, the field is absent from the PATCH request (no change intended),
+//     so we fall back to the current stored value wrapped as *string.
+//
+// This lets validateTemplateSource see the effective (post-merge) state rather than
+// the partial view from the request alone.
+func resolveStringPtr(reqField *string, existingValue string) *string {
+	if reqField != nil {
+		return reqField
+	}
+	if existingValue == "" {
+		return nil
+	}
+	return &existingValue
 }
 
 func normalizePermissionKeys(raw []string) ([]string, error) {
@@ -2030,8 +2168,9 @@ func authProviderToAPI(p *ent.AuthProvider) generated.AuthProvider {
 
 // validateTemplateSource enforces the ADR-0036 rule that source_type must be
 // either "image" or "pvc" (when provided), and that the corresponding required
-// field (image_url or pvc_name) is present. The two modes are mutually exclusive.
-func validateTemplateSource(sourceType, imageURL, pvcName *string) error {
+// fields (image_url, or pvc_name + pvc_namespace) are present.
+// The two modes are mutually exclusive.
+func validateTemplateSource(sourceType, imageURL, pvcName, pvcNamespace *string) error {
 	if sourceType == nil {
 		// No source configured yet — allowed (draft template).
 		return nil
@@ -2044,6 +2183,9 @@ func validateTemplateSource(sourceType, imageURL, pvcName *string) error {
 	case "pvc":
 		if pvcName == nil || strings.TrimSpace(*pvcName) == "" {
 			return fmt.Errorf("pvc_name is required when source_type is 'pvc'")
+		}
+		if pvcNamespace == nil || strings.TrimSpace(*pvcNamespace) == "" {
+			return fmt.Errorf("pvc_namespace is required when source_type is 'pvc'")
 		}
 	default:
 		return fmt.Errorf("source_type must be 'image' or 'pvc', got %q", *sourceType)

--- a/internal/api/handlers/server_schema.go
+++ b/internal/api/handlers/server_schema.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"kv-shepherd.io/shepherd/internal/api/generated"
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+	"kv-shepherd.io/shepherd/internal/pkg/schema"
+)
+
+// schemaVersion is the embedded schema baseline version.
+// Reflects the KubeVirt source release this schema was extracted from.
+// Format: semantic version aligned with KubeVirt release tag.
+// Increment the patch when the extraction/pruning logic changes without
+// a KubeVirt upgrade; bump minor/major when KubeVirt version changes.
+const schemaVersion = "1.7.0"
+
+// ── Parse-once cache ──────────────────────────────────────────────────────────
+//
+// The embedded instancesize.schema.json is 229 KB. Parsing it on every request
+// wastes CPU. We parse once on first request per entity type using sync.Once,
+// and serve the pre-parsed result directly.
+//
+// Thread-safety: sync.Once guarantees that only one goroutine runs the
+// initialiser; subsequent callers block until it completes and then read
+// the cached value. The cached values are never mutated after init.
+
+type schemaCache struct {
+	once     sync.Once
+	schema   map[string]interface{}
+	mask     generated.SchemaMask
+	err      error
+	cachedAt time.Time // set once during sync.Once initialisation — "schema was cached at"
+}
+
+// schemaCaches maps entity_type → lazy-initialised parse cache.
+// Add a new entry here when a new entity type is supported.
+var schemaCaches = map[string]*schemaCache{
+	"instancesize": {},
+}
+
+// loadSchemaCache initialises the cache for entityType on first call.
+// Must be called with a valid entityType (one that exists in schemaCaches).
+func loadSchemaCache(c *schemaCache, entityType string) {
+	c.once.Do(func() {
+		schemaBytes, _ := schema.SchemaFor(entityType)
+		if err := jsonParseSchema(schemaBytes, &c.schema); err != nil {
+			c.err = err
+			return
+		}
+
+		maskBytes, _ := schema.MaskFor(entityType)
+		if err := jsonParseMask(maskBytes, &c.mask); err != nil {
+			c.err = err
+			return
+		}
+
+		// Ensure quick_fields is never nil in the response (OpenAPI requires array).
+		if c.mask.QuickFields == nil {
+			c.mask.QuickFields = []generated.MaskField{}
+		}
+
+		// Record when this schema was first parsed and cached.
+		// ADR-0023: fetched_at represents cache initialisation time, not request time.
+		// Frontend uses this to detect schema drift (cache age > threshold).
+		c.cachedAt = time.Now().UTC()
+	})
+}
+
+// GetDynamicSchema handles GET /schemas/{entity_type}.
+//
+// Returns the embedded JSON Schema and UI mask for the requested entity type.
+// Per ADR-0023, the current implementation serves from the embedded baseline
+// (source: "embedded"). When a remote schema cache is available, handlers
+// will prefer the cached version and degrade to embedded on fetch errors.
+//
+// entity_type must be one of: instancesize.
+//   - template: excluded — cloud_init is a static YAML textarea (master-flow Step 3).
+//   - cluster:  excluded — schema not yet designed (ADR-0023 phase 2).
+//
+// Returns 400 UNSUPPORTED_ENTITY_TYPE if entity_type is not in the supported set.
+//
+// ADR-0023: embedded schema is the authoritative baseline; degraded=false
+// because the embedded schema IS the current source of truth (no remote
+// schema has been configured yet).
+func (s *Server) GetDynamicSchema(c *gin.Context, entityType generated.GetDynamicSchemaParamsEntityType) {
+	entityTypeStr := string(entityType)
+
+	cache, known := schemaCaches[entityTypeStr]
+	if !known {
+		c.JSON(http.StatusBadRequest, generated.Error{
+			Code:    "UNSUPPORTED_ENTITY_TYPE",
+			Message: "unsupported entity_type: " + entityTypeStr,
+		})
+		return
+	}
+
+	// Parse-once: initialises on first request, returns cached result thereafter.
+	loadSchemaCache(cache, entityTypeStr)
+	if cache.err != nil {
+		logger.Error("failed to parse embedded schema/mask",
+			zap.String("entity_type", entityTypeStr),
+			zap.Error(cache.err))
+		c.JSON(http.StatusInternalServerError, generated.Error{Code: "INTERNAL_ERROR"})
+		return
+	}
+
+	c.JSON(http.StatusOK, generated.DynamicSchemaResponse{
+		Schema:        cache.schema,
+		Mask:          cache.mask,
+		SchemaVersion: schemaVersion,
+		Source:        generated.Embedded,
+		// degraded=false: embedded schema IS the current source of truth.
+		// Set to true only when falling back from a more-recent remote schema.
+		Degraded: false,
+		// FetchedAt records when the schema was first parsed into the in-process cache,
+		// NOT the current request time. ADR-0023: frontend uses this for drift detection.
+		FetchedAt: cache.cachedAt,
+	})
+}

--- a/internal/api/handlers/server_schema_test.go
+++ b/internal/api/handlers/server_schema_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"kv-shepherd.io/shepherd/internal/api/generated"
+)
+
+// TestGetDynamicSchema does not require a database — the handler reads only
+// from in-process embedded schema files. We construct a *Server{} with zero
+// values deliberately; the handler does not access any Server fields.
+func TestGetDynamicSchema_Instancesize_Returns200(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	srv := &Server{} // no DB needed for this handler
+	c, w := newSchemaGinContext(t, "instancesize")
+
+	srv.GetDynamicSchema(c, generated.Instancesize)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp generated.DynamicSchemaResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
+	}
+
+	// schema must be a non-empty map.
+	if len(resp.Schema) == 0 {
+		t.Error("response schema is empty, want non-empty map")
+	}
+
+	// quick_fields must be present (may be empty list but not nil).
+	if resp.Mask.QuickFields == nil {
+		t.Error("mask.quick_fields is nil, want array")
+	}
+	if len(resp.Mask.QuickFields) == 0 {
+		t.Error("expected at least one quick_field for instancesize")
+	}
+
+	// schema_version must be set.
+	if resp.SchemaVersion == "" {
+		t.Error("schema_version is empty, want semver string")
+	}
+
+	// source must be "embedded" (current implementation serves from embedded baseline).
+	if resp.Source != generated.Embedded {
+		t.Errorf("source = %q, want %q", resp.Source, generated.Embedded)
+	}
+
+	// degraded must be false (embedded IS the source of truth now, not a fallback).
+	if resp.Degraded {
+		t.Error("degraded = true, want false for embedded schema")
+	}
+}
+
+func TestGetDynamicSchema_Template_Returns400(t *testing.T) {
+	// template is excluded from the dynamic schema endpoint.
+	// Templates use static fields only (cloud_init YAML textarea, master-flow Step 3).
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	srv := &Server{}
+	c, w := newSchemaGinContext(t, "template")
+
+	srv.GetDynamicSchema(c, generated.GetDynamicSchemaParamsEntityType("template"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (template has no dynamic schema), body=%s",
+			w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var errResp generated.Error
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != "UNSUPPORTED_ENTITY_TYPE" {
+		t.Errorf("error code = %q, want %q", errResp.Code, "UNSUPPORTED_ENTITY_TYPE")
+	}
+}
+
+func TestGetDynamicSchema_Cluster_Returns400(t *testing.T) {
+	// cluster is not a supported entity_type (no schema defined, ADR-0023 phase 2).
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	srv := &Server{}
+	c, w := newSchemaGinContext(t, "cluster")
+
+	// Cast string directly to GetDynamicSchemaParamsEntityType to simulate
+	// a raw request; oapi-codegen enum will not include cluster.
+	srv.GetDynamicSchema(c, generated.GetDynamicSchemaParamsEntityType("cluster"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (cluster has no real schema), body=%s",
+			w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var errResp generated.Error
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != "UNSUPPORTED_ENTITY_TYPE" {
+		t.Errorf("error code = %q, want %q", errResp.Code, "UNSUPPORTED_ENTITY_TYPE")
+	}
+}
+
+// TestGetDynamicSchema_InstancesizeMask_ContainsCpuCores verifies that the
+// instancesize mask quick_fields contain the CPU cores path (integration check).
+func TestGetDynamicSchema_InstancesizeMask_ContainsCpuCores(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	srv := &Server{}
+	c, w := newSchemaGinContext(t, "instancesize")
+	srv.GetDynamicSchema(c, generated.Instancesize)
+
+	var resp generated.DynamicSchemaResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	cpuCoresPath := "spec.template.spec.domain.cpu.cores"
+	found := false
+	for _, f := range resp.Mask.QuickFields {
+		if f.Path == cpuCoresPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("quick_fields does not contain path %q; got %+v", cpuCoresPath, resp.Mask.QuickFields)
+	}
+}
+
+// newSchemaGinContext builds a minimal gin.Context for GET /schemas/{entityType}.
+// /schemas/ is a public endpoint (OpenAPI security:[], router.go publicPrefixes).
+// No authentication headers are required.
+func newSchemaGinContext(t *testing.T, entityType string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/schemas/"+entityType, nil)
+	c.Request = req
+	return c, w
+}

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -17,6 +17,9 @@ import (
 var publicPrefixes = []string{
 	"/api/v1/auth/login",
 	"/api/v1/health/",
+	// Schema metadata: does not contain sensitive data; must be accessible
+	// before login for bootstrap tooling (ADR-0023). Matches OpenAPI security:[].
+	"/api/v1/schemas/",
 }
 
 func newRouter(cfg *config.Config, server generated.ServerInterface, jwtCfg middleware.JWTConfig) *gin.Engine {

--- a/internal/jobs/vm_create.go
+++ b/internal/jobs/vm_create.go
@@ -590,11 +590,15 @@ func extractTemplateImage(templateSpec map[string]interface{}) (string, error) {
 
 // extractTemplateImageFromEnt resolves the boot image from an Ent Template object.
 // ADR-0036: Template no longer stores spec JSONB; image_url and pvc_name are explicit fields.
+// PVC image format: "pvc:namespace/name" when pvc_namespace is set, "pvc:name" otherwise (legacy).
 func extractTemplateImageFromEnt(tpl *ent.Template) (string, error) {
 	if tpl.ImageURL != "" {
 		return tpl.ImageURL, nil
 	}
 	if tpl.PvcName != "" {
+		if tpl.PvcNamespace != "" {
+			return "pvc:" + tpl.PvcNamespace + "/" + tpl.PvcName, nil
+		}
 		return "pvc:" + tpl.PvcName, nil
 	}
 	return "", fmt.Errorf("template %s has no image_url or pvc_name configured", tpl.ID)
@@ -602,7 +606,7 @@ func extractTemplateImageFromEnt(tpl *ent.Template) (string, error) {
 
 // extractTemplateImageFromSnapshot resolves the boot image from a template snapshot map
 // stored at approval time. Snapshot keys use the ADR-0036 semantic format:
-// source_type, image_url, pvc_name. Falls back to legacy spec-map lookup.
+// source_type, image_url, pvc_name, pvc_namespace. Falls back to legacy spec-map lookup.
 func extractTemplateImageFromSnapshot(snapshot map[string]interface{}) (string, error) {
 	// ADR-0036 format (new snapshots)
 	sourceType := lookupStringValue(snapshot, "source_type")
@@ -613,6 +617,9 @@ func extractTemplateImageFromSnapshot(snapshot map[string]interface{}) (string, 
 		}
 	case "pvc":
 		if pvc := lookupStringValue(snapshot, "pvc_name"); pvc != "" {
+			if ns := lookupStringValue(snapshot, "pvc_namespace"); ns != "" {
+				return "pvc:" + ns + "/" + pvc, nil
+			}
 			return "pvc:" + pvc, nil
 		}
 	}

--- a/internal/pkg/schema/embed.go
+++ b/internal/pkg/schema/embed.go
@@ -1,0 +1,86 @@
+// Package schema provides embedded KubeVirt-subset schemas and mask
+// configurations for the dynamic schema API endpoint (ADR-0023).
+//
+// # Architecture
+//
+// The schema pipeline is:
+//
+//	KubeVirt CRD JSON Schema → (pruned subset) → embedded JSON file
+//	                                         ↓
+//	                       GET /schemas/{entity_type}
+//	                                         ↓
+//	               DynamicSchemaResponse { schema, mask, source: "embedded" }
+//
+// Currently all entity types are served from embedded baseline files.
+// When a remote schema cache is implemented (ADR-0023 Phase 2), the handler
+// SHOULD prefer the cached remote version and fall back to embedded on error.
+//
+// # Supported entity types
+//
+// - instancesize: KubeVirt v1.7.0 VirtualMachineSpec sub-schema (cpu, memory, gpu, hugepages).
+//
+// template and cluster are intentionally excluded:
+//   - template: cloud_init is a static YAML textarea; no dynamic schema needed (master-flow Step 3).
+//   - cluster:  schema not yet designed (ADR-0023 phase 2).
+//
+// # Adding a new entity type
+//  1. Add a JSON schema file to this package directory (e.g., cluster.schema.json).
+//  2. Add a JSON mask file (e.g., cluster.mask.json).
+//  3. Register the entity type in SchemaFor / MaskFor switch statements.
+package schema
+
+import _ "embed"
+
+// ─── Embedded schema files ────────────────────────────────────────────────────
+
+// instancesize.schema.json: KubeVirt v1.7.0 VirtualMachineSpec schema, pruned
+// to the spec.template subtree relevant for spec_overrides.
+//
+// Source: kubevirt/api v1.7.0, api/openapi-spec/swagger.json
+//
+//	→ definitions.v1.VirtualMachineSpec → resolved $refs inline
+//	→ wrapped under root "properties.spec" to match spec_overrides path prefix.
+//
+// Schema version: kv-shepherd:instancesize:kubevirt-v1.7.0
+// All mask paths in instancesize.mask.json must be validated against this file.
+//
+//go:embed instancesize.schema.json
+var instancesizeSchema []byte
+
+// instancesize.mask.json: UI projection mask for instancesize entity.
+// Defines quick_fields (always visible) and advanced_fields (collapsible).
+//
+//go:embed instancesize.mask.json
+var instancesizeMask []byte
+
+// ─── Lookup ───────────────────────────────────────────────────────────────────
+
+// SchemaFor returns the embedded JSON schema bytes for the given entity type.
+// Returns nil and false if the entity type is unknown or not yet implemented.
+//
+// Supported: "instancesize".
+// Unknown types (including "template" and "cluster") should be rejected
+// by the caller with HTTP 400.
+func SchemaFor(entityType string) ([]byte, bool) {
+	switch entityType {
+	case "instancesize":
+		return instancesizeSchema, true
+	default:
+		return nil, false
+	}
+}
+
+// MaskFor returns the embedded JSON mask bytes for the given entity type.
+// Returns nil and false if the entity type is unknown or not yet implemented.
+//
+// Supported: "instancesize".
+// Unknown types (including "template" and "cluster") should be rejected
+// by the caller with HTTP 400.
+func MaskFor(entityType string) ([]byte, bool) {
+	switch entityType {
+	case "instancesize":
+		return instancesizeMask, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/pkg/schema/embed_test.go
+++ b/internal/pkg/schema/embed_test.go
@@ -1,0 +1,208 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"kv-shepherd.io/shepherd/internal/pkg/schema"
+)
+
+// TestMain runs mask-path pre-deployment validation before any test executes.
+//
+// Stage 1 requirement (master-flow.md:186):
+//
+//	"Invalid mask paths must fail validation before deployment."
+//
+// If any mask path cannot be resolved within its corresponding schema, the
+// entire test binary exits non-zero here — preventing deployment of a broken
+// schema/mask pair. This mirrors a CI gate: schema_test is run on every build.
+func TestMain(m *testing.M) {
+	if err := validateAllMasks(); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: mask path pre-deployment validation failed:\n%v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+// validateAllMasks checks every registered entity type's mask against its schema.
+// All errors are collected and reported together.
+func validateAllMasks() error {
+	// Only entity types with real embedded schemas are validated.
+	// template and cluster are intentionally excluded from the dynamic schema endpoint.
+	entityTypes := []string{"instancesize"}
+
+	var allErrors []string
+	for _, et := range entityTypes {
+		sBytes, ok := schema.SchemaFor(et)
+		if !ok {
+			allErrors = append(allErrors, fmt.Sprintf("[%s] SchemaFor returned false", et))
+			continue
+		}
+		mBytes, ok := schema.MaskFor(et)
+		if !ok {
+			allErrors = append(allErrors, fmt.Sprintf("[%s] MaskFor returned false", et))
+			continue
+		}
+		if err := schema.ValidateMaskPaths(sBytes, mBytes); err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("[%s] %v", et, err))
+		}
+	}
+
+	if len(allErrors) > 0 {
+		combined := ""
+		for _, e := range allErrors {
+			combined += "\n" + e
+		}
+		return errors.New(combined)
+	}
+	return nil
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+func TestSchemaFor_KnownEntityTypes(t *testing.T) {
+	// Only instancesize has a real embedded schema.
+	knownTypes := []string{"instancesize"}
+
+	for _, entityType := range knownTypes {
+		t.Run(entityType, func(t *testing.T) {
+			data, ok := schema.SchemaFor(entityType)
+			if !ok {
+				t.Fatalf("SchemaFor(%q) returned ok=false, want true", entityType)
+			}
+			if len(data) == 0 {
+				t.Fatalf("SchemaFor(%q) returned empty bytes", entityType)
+			}
+			// Verify it parses as valid JSON object.
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				t.Fatalf("SchemaFor(%q): invalid JSON: %v", entityType, err)
+			}
+		})
+	}
+}
+
+func TestSchemaFor_UnknownEntityType(t *testing.T) {
+	// template and cluster are intentionally excluded from the schema endpoint.
+	for _, unknown := range []string{"template", "cluster", "nonexistent", ""} {
+		t.Run(unknown, func(t *testing.T) {
+			_, ok := schema.SchemaFor(unknown)
+			if ok {
+				t.Errorf("SchemaFor(%q) returned ok=true, want false", unknown)
+			}
+		})
+	}
+}
+
+func TestMaskFor_KnownEntityTypes(t *testing.T) {
+	// Only instancesize has a real embedded mask.
+	knownTypes := []string{"instancesize"}
+
+	for _, entityType := range knownTypes {
+		t.Run(entityType, func(t *testing.T) {
+			data, ok := schema.MaskFor(entityType)
+			if !ok {
+				t.Fatalf("MaskFor(%q) returned ok=false, want true", entityType)
+			}
+			if len(data) == 0 {
+				t.Fatalf("MaskFor(%q) returned empty bytes", entityType)
+			}
+			// Verify it parses as valid JSON with a quick_fields array.
+			var mask struct {
+				QuickFields    []interface{} `json:"quick_fields"`
+				AdvancedFields []interface{} `json:"advanced_fields"`
+			}
+			if err := json.Unmarshal(data, &mask); err != nil {
+				t.Fatalf("MaskFor(%q): invalid JSON: %v", entityType, err)
+			}
+			// quick_fields may be empty but must be present (not nil after unmarshal).
+			if mask.QuickFields == nil {
+				t.Fatalf("MaskFor(%q): quick_fields is nil, want array (may be empty)", entityType)
+			}
+		})
+	}
+}
+
+func TestMaskFor_UnknownEntityType(t *testing.T) {
+	// template and cluster are intentionally excluded from the schema endpoint.
+	for _, unknown := range []string{"template", "cluster", "nonexistent", ""} {
+		t.Run(unknown, func(t *testing.T) {
+			_, ok := schema.MaskFor(unknown)
+			if ok {
+				t.Errorf("MaskFor(%q) returned ok=true, want false", unknown)
+			}
+		})
+	}
+}
+
+// TestInstancesizeSchema_RequiredPaths verifies that the embedded instancesize
+// schema contains the paths referenced by ALL mask fields (not just spot-check).
+// This is insurance in addition to TestMain's full validation.
+func TestInstancesizeSchema_RequiredPaths(t *testing.T) {
+	schemaBytes, _ := schema.SchemaFor("instancesize")
+	maskBytes, _ := schema.MaskFor("instancesize")
+
+	if err := schema.ValidateMaskPaths(schemaBytes, maskBytes); err != nil {
+		t.Errorf("mask path validation failed:\n%v", err)
+	}
+}
+
+// TestValidateMaskPaths_InvalidPath verifies that ValidateMaskPaths correctly
+// rejects a mask pointing to a non-existent schema path.
+func TestValidateMaskPaths_InvalidPath(t *testing.T) {
+	schemaJSON := []byte(`{
+		"properties": {
+			"spec": {
+				"properties": {
+					"cores": {"type": "integer"}
+				}
+			}
+		}
+	}`)
+	maskJSON := []byte(`{
+		"quick_fields": [{"path": "spec.cores"}],
+		"advanced_fields": [{"path": "spec.nonexistent.deep.path"}]
+	}`)
+
+	err := schema.ValidateMaskPaths(schemaJSON, maskJSON)
+	if err == nil {
+		t.Fatal("expected error for invalid mask path, got nil")
+	}
+	// Should report the invalid path specifically.
+	if got := err.Error(); len(got) == 0 {
+		t.Error("expected non-empty error message")
+	}
+	t.Logf("correctly rejected invalid path with error: %v", err)
+}
+
+// TestValidateMaskPaths_ArrayTraversal verifies that paths through array-typed
+// nodes (e.g., gpus[]) are correctly resolved via items.properties.
+func TestValidateMaskPaths_ArrayTraversal(t *testing.T) {
+	schemaJSON := []byte(`{
+		"properties": {
+			"devices": {
+				"properties": {
+					"gpus": {
+						"type": "array",
+						"items": {
+							"properties": {
+								"deviceName": {"type": "string"}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`)
+	maskJSON := []byte(`{
+		"quick_fields": [{"path": "devices.gpus"}],
+		"advanced_fields": []
+	}`)
+
+	if err := schema.ValidateMaskPaths(schemaJSON, maskJSON); err != nil {
+		t.Errorf("array traversal path rejected unexpectedly: %v", err)
+	}
+}

--- a/internal/pkg/schema/instancesize.mask.json
+++ b/internal/pkg/schema/instancesize.mask.json
@@ -1,0 +1,54 @@
+{
+    "quick_fields": [
+        {
+            "path": "spec.template.spec.domain.cpu.cores",
+            "display_name": "CPU Cores"
+        },
+        {
+            "path": "spec.template.spec.domain.cpu.threads",
+            "display_name": "CPU Threads"
+        },
+        {
+            "path": "spec.template.spec.domain.memory.guest",
+            "display_name": "Guest Memory"
+        },
+        {
+            "path": "spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+            "display_name": "Dedicated CPU"
+        }
+    ],
+    "advanced_fields": [
+        {
+            "path": "spec.template.spec.domain.devices.gpus",
+            "display_name": "GPU Devices"
+        },
+        {
+            "path": "spec.template.spec.domain.memory.hugepages.pageSize",
+            "display_name": "Hugepages Size"
+        },
+        {
+            "path": "spec.template.spec.domain.cpu.model",
+            "display_name": "CPU Model"
+        },
+        {
+            "path": "spec.template.spec.domain.cpu.sockets",
+            "display_name": "CPU Sockets"
+        },
+        {
+            "path": "spec.template.spec.domain.features.hyperv.relaxed.enabled",
+            "display_name": "Hyper-V Relaxed"
+        },
+        {
+            "path": "spec.template.spec.domain.features.hyperv.vapic.enabled",
+            "display_name": "Hyper-V vAPIC"
+        },
+        {
+            "path": "spec.template.spec.domain.devices.autoattachGraphicsDevice",
+            "display_name": "Auto-attach Graphics"
+        },
+        {
+            "path": "spec.template.spec.domain.devices.autoattachSerialConsole",
+            "display_name": "Auto-attach Serial Console"
+        }
+    ]
+}

--- a/internal/pkg/schema/instancesize.schema.json
+++ b/internal/pkg/schema/instancesize.schema.json
@@ -1,0 +1,3184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "kv-shepherd:instancesize:kubevirt-v1.7.0",
+  "type": "object",
+  "title": "KubeVirt VirtualMachine Spec Overrides",
+  "description": "Official KubeVirt v1.7.0 VirtualMachineSpec schema (source: kubevirt/api, v1.7.0). Generated from CRD OpenAPI swagger.json for use with spec_overrides (ADR-0023).",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "description": "KubeVirt VirtualMachineSpec (spec_overrides target root).",
+      "properties": {
+        "template": {
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+              "type": "object",
+              "properties": {
+                "annotations": {
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "creationTimestamp": {
+                  "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "deletionGracePeriodSeconds": {
+                  "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "deletionTimestamp": {
+                  "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "finalizers": {
+                  "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                  "type": "string"
+                },
+                "generation": {
+                  "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "labels": {
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "managedFields": {
+                  "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                  "type": "array",
+                  "items": {
+                    "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+                    "type": "object",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                        "type": "object"
+                      },
+                      "manager": {
+                        "description": "Manager is an identifier of the workflow managing these fields.",
+                        "type": "string"
+                      },
+                      "operation": {
+                        "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                        "type": "string"
+                      },
+                      "time": {
+                        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                  "type": "array",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "type": "object",
+                    "required": [
+                      "apiVersion",
+                      "kind",
+                      "name",
+                      "uid"
+                    ],
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "resourceVersion": {
+                  "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "selfLink": {
+                  "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                  "type": "string"
+                }
+              }
+            },
+            "spec": {
+              "description": "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
+              "type": "object",
+              "required": [
+                "domain"
+              ],
+              "properties": {
+                "accessCredentials": {
+                  "description": "Specifies a set of public keys to inject into the vm guest",
+                  "type": "array",
+                  "items": {
+                    "description": "AccessCredential represents a credential source that can be used to authorize remote access to the vm guest Only one of its members may be specified.",
+                    "type": "object",
+                    "properties": {
+                      "sshPublicKey": {
+                        "description": "SSHPublicKeyAccessCredential represents a source and propagation method for injecting ssh public keys into a vm guest",
+                        "type": "object",
+                        "required": [
+                          "source",
+                          "propagationMethod"
+                        ],
+                        "properties": {
+                          "propagationMethod": {
+                            "description": "SSHPublicKeyAccessCredentialPropagationMethod represents the method used to inject a ssh public key into the vm guest. Only one of its members may be specified.",
+                            "type": "object",
+                            "properties": {
+                              "configDrive": {
+                                "type": "object"
+                              },
+                              "noCloud": {
+                                "type": "object"
+                              },
+                              "qemuGuestAgent": {
+                                "type": "object",
+                                "required": [
+                                  "users"
+                                ],
+                                "properties": {
+                                  "users": {
+                                    "description": "Users represents a list of guest users that should have the ssh public keys added to their authorized_keys file.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "source": {
+                            "description": "SSHPublicKeyAccessCredentialSource represents where to retrieve the ssh key credentials Only one of its members may be specified.",
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "object",
+                                "required": [
+                                  "secretName"
+                                ],
+                                "properties": {
+                                  "secretName": {
+                                    "description": "SecretName represents the name of the secret in the VMI's namespace",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "userPassword": {
+                        "description": "UserPasswordAccessCredential represents a source and propagation method for injecting user passwords into a vm guest Only one of its members may be specified.",
+                        "type": "object",
+                        "required": [
+                          "source",
+                          "propagationMethod"
+                        ],
+                        "properties": {
+                          "propagationMethod": {
+                            "description": "UserPasswordAccessCredentialPropagationMethod represents the method used to inject a user passwords into the vm guest. Only one of its members may be specified.",
+                            "type": "object",
+                            "properties": {
+                              "qemuGuestAgent": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "source": {
+                            "description": "UserPasswordAccessCredentialSource represents where to retrieve the user password credentials Only one of its members may be specified.",
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "object",
+                                "required": [
+                                  "secretName"
+                                ],
+                                "properties": {
+                                  "secretName": {
+                                    "description": "SecretName represents the name of the secret in the VMI's namespace",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "affinity": {
+                  "description": "Affinity is a group of affinity scheduling rules.",
+                  "type": "object",
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Node affinity is a group of node affinity scheduling rules.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": "object",
+                            "required": [
+                              "weight",
+                              "preference"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "podAffinity": {
+                      "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "weight",
+                              "podAffinityTerm"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "namespaceSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "podAntiAffinity": {
+                      "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "weight",
+                              "podAffinityTerm"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "namespaceSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "architecture": {
+                  "description": "Specifies the architecture of the vm guest you are attempting to run. Defaults to the compiled architecture of the KubeVirt components",
+                  "type": "string"
+                },
+                "dnsConfig": {
+                  "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+                  "type": "object",
+                  "properties": {
+                    "nameservers": {
+                      "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "options": {
+                      "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                      "type": "array",
+                      "items": {
+                        "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name is this DNS resolver option's name. Required.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is this DNS resolver option's value.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "searches": {
+                      "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "dnsPolicy": {
+                  "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.\n\nPossible enum values:\n - `\"ClusterFirst\"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.\n - `\"ClusterFirstWithHostNet\"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.\n - `\"Default\"` indicates that the pod should use the default (as determined by kubelet) DNS settings.\n - `\"None\"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.",
+                  "type": "string",
+                  "enum": [
+                    "ClusterFirst",
+                    "ClusterFirstWithHostNet",
+                    "Default",
+                    "None"
+                  ]
+                },
+                "domain": {
+                  "type": "object",
+                  "required": [
+                    "devices"
+                  ],
+                  "properties": {
+                    "chassis": {
+                      "description": "Chassis specifies the chassis info passed to the domain.",
+                      "type": "object",
+                      "properties": {
+                        "asset": {
+                          "type": "string"
+                        },
+                        "manufacturer": {
+                          "type": "string"
+                        },
+                        "serial": {
+                          "type": "string"
+                        },
+                        "sku": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "clock": {
+                      "description": "Represents the clock and timers of a vmi.",
+                      "type": "object",
+                      "properties": {
+                        "timer": {
+                          "description": "Represents all available timers in a vmi.",
+                          "type": "object",
+                          "properties": {
+                            "hpet": {
+                              "type": "object",
+                              "properties": {
+                                "present": {
+                                  "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+                                  "type": "boolean"
+                                },
+                                "tickPolicy": {
+                                  "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"merge\", \"discard\".",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "hyperv": {
+                              "type": "object",
+                              "properties": {
+                                "present": {
+                                  "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "kvm": {
+                              "type": "object",
+                              "properties": {
+                                "present": {
+                                  "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "pit": {
+                              "type": "object",
+                              "properties": {
+                                "present": {
+                                  "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+                                  "type": "boolean"
+                                },
+                                "tickPolicy": {
+                                  "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"discard\".",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "rtc": {
+                              "type": "object",
+                              "properties": {
+                                "present": {
+                                  "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+                                  "type": "boolean"
+                                },
+                                "tickPolicy": {
+                                  "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\".",
+                                  "type": "string"
+                                },
+                                "track": {
+                                  "description": "Track the guest or the wall clock.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "timezone": {
+                          "description": "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
+                          "type": "string"
+                        },
+                        "utc": {
+                          "description": "UTC sets the guest clock to UTC on each boot.",
+                          "type": "object",
+                          "properties": {
+                            "offsetSeconds": {
+                              "description": "OffsetSeconds specifies an offset in seconds, relative to UTC. If set, guest changes to the clock will be kept during reboots and not reset.",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "cpu": {
+                      "description": "CPU allows specifying the CPU topology.",
+                      "type": "object",
+                      "properties": {
+                        "cores": {
+                          "description": "Cores specifies the number of cores inside the vmi. Must be a value greater or equal 1.",
+                          "type": "integer",
+                          "format": "int64"
+                        },
+                        "dedicatedCpuPlacement": {
+                          "description": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node with enough dedicated pCPUs and pin the vCPUs to it.",
+                          "type": "boolean"
+                        },
+                        "features": {
+                          "description": "Features specifies the CPU features list inside the VMI.",
+                          "type": "array",
+                          "items": {
+                            "description": "CPUFeature allows specifying a CPU feature.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the CPU feature",
+                                "type": "string"
+                              },
+                              "policy": {
+                                "description": "Policy is the CPU feature attribute which can have the following attributes: force    - The virtual CPU will claim the feature is supported regardless of it being supported by host CPU. require  - Guest creation will fail unless the feature is supported by the host CPU or the hypervisor is able to emulate it. optional - The feature will be supported by virtual CPU if and only if it is supported by host CPU. disable  - The feature will not be supported by virtual CPU. forbid   - Guest creation will fail if the feature is supported by host CPU. Defaults to require",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "isolateEmulatorThread": {
+                          "description": "IsolateEmulatorThread requests one more dedicated pCPU to be allocated for the VMI to place the emulator thread on it.",
+                          "type": "boolean"
+                        },
+                        "maxSockets": {
+                          "description": "MaxSockets specifies the maximum amount of sockets that can be hotplugged",
+                          "type": "integer",
+                          "format": "int64"
+                        },
+                        "model": {
+                          "description": "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map. It is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node and \"host-model\" to get CPU closest to the node one. Defaults to host-model.",
+                          "type": "string"
+                        },
+                        "numa": {
+                          "type": "object",
+                          "properties": {
+                            "guestMappingPassthrough": {
+                              "description": "NUMAGuestMappingPassthrough instructs kubevirt to model numa topology which is compatible with the CPU pinning on the guest. This will result in a subset of the node numa topology being passed through, ensuring that virtual numa nodes and their memory never cross boundaries coming from the node numa mapping.",
+                              "type": "object"
+                            }
+                          }
+                        },
+                        "realtime": {
+                          "description": "Realtime holds the tuning knobs specific for realtime workloads.",
+                          "type": "object",
+                          "properties": {
+                            "mask": {
+                              "description": "Mask defines the vcpu mask expression that defines which vcpus are used for realtime. Format matches libvirt's expressions. Example: \"0-3,^1\",\"0,2,3\",\"2-3\"",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "sockets": {
+                          "description": "Sockets specifies the number of sockets inside the vmi. Must be a value greater or equal 1.",
+                          "type": "integer",
+                          "format": "int64"
+                        },
+                        "threads": {
+                          "description": "Threads specifies the number of threads inside the vmi. Must be a value greater or equal 1.",
+                          "type": "integer",
+                          "format": "int64"
+                        }
+                      }
+                    },
+                    "devices": {
+                      "type": "object",
+                      "properties": {
+                        "autoattachGraphicsDevice": {
+                          "description": "Whether to attach the default graphics device or not. VNC will not be available if set to false. Defaults to true.",
+                          "type": "boolean"
+                        },
+                        "autoattachInputDevice": {
+                          "description": "Whether to attach an Input Device. Defaults to false.",
+                          "type": "boolean"
+                        },
+                        "autoattachMemBalloon": {
+                          "description": "Whether to attach the Memory balloon device with default period. Period can be adjusted in virt-config. Defaults to true.",
+                          "type": "boolean"
+                        },
+                        "autoattachPodInterface": {
+                          "description": "Whether to attach a pod network interface. Defaults to true.",
+                          "type": "boolean"
+                        },
+                        "autoattachSerialConsole": {
+                          "description": "Whether to attach the default virtio-serial console or not. Serial console access will not be available if set to false. Defaults to true.",
+                          "type": "boolean"
+                        },
+                        "autoattachVSOCK": {
+                          "description": "Whether to attach the VSOCK CID to the VM or not. VSOCK access will be available if set to true. Defaults to false.",
+                          "type": "boolean"
+                        },
+                        "blockMultiQueue": {
+                          "description": "Whether or not to enable virtio multi-queue for block devices. Defaults to false.",
+                          "type": "boolean"
+                        },
+                        "clientPassthrough": {
+                          "description": "Represent a subset of client devices that can be accessed by VMI. At the moment only, USB devices using Usbredir's library and tooling. Another fit would be a smartcard with libcacard.\n\nThe struct is currently empty as there is no immediate request for user-facing APIs. This structure simply turns on USB redirection of UsbClientPassthroughMaxNumberOf devices.",
+                          "type": "object"
+                        },
+                        "disableHotplug": {
+                          "description": "DisableHotplug disabled the ability to hotplug disks.",
+                          "type": "boolean"
+                        },
+                        "disks": {
+                          "description": "Disks describes disks, cdroms and luns which are connected to the vmi.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "blockSize": {
+                                "description": "BlockSize provides the option to change the block size presented to the VM for a disk. Only one of its members may be specified.",
+                                "type": "object",
+                                "properties": {
+                                  "custom": {
+                                    "description": "CustomBlockSize represents the desired logical and physical block size for a VM disk.",
+                                    "type": "object",
+                                    "properties": {
+                                      "discardGranularity": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "logical": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "physical": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      }
+                                    }
+                                  },
+                                  "matchVolume": {
+                                    "description": "Represents if a feature is enabled or disabled.",
+                                    "type": "object",
+                                    "properties": {
+                                      "enabled": {
+                                        "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "bootOrder": {
+                                "description": "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "cache": {
+                                "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none: Guest I/O not cached on the host, but may be kept in a disk cache. writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees. writeback: Guest I/O cached on the host. Defaults to none if the storage supports O_DIRECT, otherwise writethrough.",
+                                "type": "string"
+                              },
+                              "cdrom": {
+                                "type": "object",
+                                "properties": {
+                                  "bus": {
+                                    "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
+                                    "type": "string"
+                                  },
+                                  "readonly": {
+                                    "description": "ReadOnly. Defaults to true.",
+                                    "type": "boolean"
+                                  },
+                                  "tray": {
+                                    "description": "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "changedBlockTracking": {
+                                "description": "ChangedBlockTracking indicates this disk should have CBT option Defaults to false.",
+                                "type": "boolean"
+                              },
+                              "dedicatedIOThread": {
+                                "description": "dedicatedIOThread indicates this disk should have an exclusive IO Thread. Enabling this implies useIOThreads = true. Defaults to false.",
+                                "type": "boolean"
+                              },
+                              "disk": {
+                                "type": "object",
+                                "properties": {
+                                  "bus": {
+                                    "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, usb.",
+                                    "type": "string"
+                                  },
+                                  "pciAddress": {
+                                    "description": "If specified, the virtual disk will be placed on the guests pci address with the specified PCI address. For example: 0000:81:01.10",
+                                    "type": "string"
+                                  },
+                                  "readonly": {
+                                    "description": "ReadOnly. Defaults to false.",
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "errorPolicy": {
+                                "description": "If specified, it can change the default error policy (stop) for the disk",
+                                "type": "string"
+                              },
+                              "io": {
+                                "description": "IO specifies which QEMU disk IO mode should be used. Supported values are: native, default, threads.",
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "object",
+                                "properties": {
+                                  "bus": {
+                                    "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
+                                    "type": "string"
+                                  },
+                                  "readonly": {
+                                    "description": "ReadOnly. Defaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "reservation": {
+                                    "description": "Reservation indicates if the disk needs to support the persistent reservation for the SCSI disk",
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "name": {
+                                "description": "Name is the device name",
+                                "type": "string"
+                              },
+                              "serial": {
+                                "description": "Serial provides the ability to specify a serial number for the disk device.",
+                                "type": "string"
+                              },
+                              "shareable": {
+                                "description": "If specified the disk is made sharable and multiple write from different VMs are permitted",
+                                "type": "boolean"
+                              },
+                              "tag": {
+                                "description": "If specified, disk address and its tag will be provided to the guest via config drive metadata",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "downwardMetrics": {
+                          "type": "object"
+                        },
+                        "filesystems": {
+                          "description": "Filesystems describes filesystem which is connected to the vmi.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "virtiofs"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name is the device name",
+                                "type": "string"
+                              },
+                              "virtiofs": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        },
+                        "gpus": {
+                          "description": "Whether to attach a GPU device to the vmi.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "claimName": {
+                                "description": "ClaimName needs to be provided from the list vmi.spec.resourceClaims[].name where this device is allocated",
+                                "type": "string"
+                              },
+                              "deviceName": {
+                                "description": "DeviceName is the name of the device provisioned by device-plugins",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the GPU device as exposed by a device plugin",
+                                "type": "string"
+                              },
+                              "requestName": {
+                                "description": "RequestName needs to be provided from resourceClaim.spec.devices.requests[].name where this device is requested",
+                                "type": "string"
+                              },
+                              "tag": {
+                                "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
+                                "type": "string"
+                              },
+                              "virtualGPUOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "display": {
+                                    "type": "object",
+                                    "properties": {
+                                      "enabled": {
+                                        "description": "Enabled determines if a display addapter backed by a vGPU should be enabled or disabled on the guest. Defaults to true.",
+                                        "type": "boolean"
+                                      },
+                                      "ramFB": {
+                                        "description": "Represents if a feature is enabled or disabled.",
+                                        "type": "object",
+                                        "properties": {
+                                          "enabled": {
+                                            "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hostDevices": {
+                          "description": "Whether to attach a host device to the vmi.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "claimName": {
+                                "description": "ClaimName needs to be provided from the list vmi.spec.resourceClaims[].name where this device is allocated",
+                                "type": "string"
+                              },
+                              "deviceName": {
+                                "description": "DeviceName is the name of the device provisioned by device-plugins",
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "requestName": {
+                                "description": "RequestName needs to be provided from resourceClaim.spec.devices.requests[].name where this device is requested",
+                                "type": "string"
+                              },
+                              "tag": {
+                                "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "inputs": {
+                          "description": "Inputs describe input devices",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "name"
+                            ],
+                            "properties": {
+                              "bus": {
+                                "description": "Bus indicates the bus of input device to emulate. Supported values: virtio, usb.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the device name",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type indicated the type of input device. Supported values: tablet.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "interfaces": {
+                          "description": "Interfaces describe network interfaces which are added to the vmi.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "acpiIndex": {
+                                "description": "If specified, the ACPI index is used to provide network interface device naming, that is stable across changes in PCI addresses assigned to the device. This value is required to be unique across all devices and be between 1 and (16*1024-1).",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "binding": {
+                                "description": "PluginBinding represents a binding implemented in a plugin.",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name references to the binding name as denined in the kubevirt CR. version: 1alphav1",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "bootOrder": {
+                                "description": "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each interface or disk that has a boot order must have a unique value. Interfaces without a boot order are not tried.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "bridge": {
+                                "description": "InterfaceBridge connects to a given network via a linux bridge.",
+                                "type": "object"
+                              },
+                              "dhcpOptions": {
+                                "description": "Extra DHCP options to use in the interface.",
+                                "type": "object",
+                                "properties": {
+                                  "bootFileName": {
+                                    "description": "If specified will pass option 67 to interface's DHCP server",
+                                    "type": "string"
+                                  },
+                                  "ntpServers": {
+                                    "description": "If specified will pass the configured NTP server to the VM via DHCP option 042.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "privateOptions": {
+                                    "description": "If specified will pass extra DHCP options for private use, range: 224-254",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "DHCPExtraOptions defines Extra DHCP options for a VM.",
+                                      "type": "object",
+                                      "required": [
+                                        "option",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "option": {
+                                          "description": "Option is an Integer value from 224-254 Required.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "value": {
+                                          "description": "Value is a String value for the Option provided Required.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "tftpServerName": {
+                                    "description": "If specified will pass option 66 to interface's DHCP server",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "macAddress": {
+                                "description": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
+                                "type": "string"
+                              },
+                              "macvtap": {
+                                "description": "DeprecatedInterfaceMacvtap is an alias to the deprecated InterfaceMacvtap that connects to a given network by extending the Kubernetes node's L2 networks via a macvtap interface. Deprecated: Removed in v1.3",
+                                "type": "object"
+                              },
+                              "masquerade": {
+                                "description": "InterfaceMasquerade connects to a given network using netfilter rules to nat the traffic.",
+                                "type": "object"
+                              },
+                              "model": {
+                                "description": "Interface model. One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Logical name of the interface as well as a reference to the associated networks. Must match the Name of a Network.",
+                                "type": "string"
+                              },
+                              "passt": {
+                                "description": "DeprecatedInterfacePasst is an alias to the deprecated InterfacePasst Deprecated: Removed in v1.3",
+                                "type": "object"
+                              },
+                              "pciAddress": {
+                                "description": "If specified, the virtual network interface will be placed on the guests pci address with the specified PCI address. For example: 0000:81:01.10",
+                                "type": "string"
+                              },
+                              "ports": {
+                                "description": "List of ports to be forwarded to the virtual machine.",
+                                "type": "array",
+                                "items": {
+                                  "description": "Port represents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
+                                  "type": "object",
+                                  "required": [
+                                    "port"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number of port to expose for the virtual machine. This must be a valid port number, 0 < x < 65536.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "protocol": {
+                                      "description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\".",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "slirp": {
+                                "description": "DeprecatedInterfaceSlirp is an alias to the deprecated InterfaceSlirp that connects to a given network using QEMU user networking mode. Deprecated: Removed in v1.3",
+                                "type": "object"
+                              },
+                              "sriov": {
+                                "description": "InterfaceSRIOV connects to a given network by passing-through an SR-IOV PCI device via vfio.",
+                                "type": "object"
+                              },
+                              "state": {
+                                "description": "State represents the requested operational state of the interface. The supported values are: `absent`, expressing a request to remove the interface. `down`, expressing a request to set the link down. `up`, expressing a request to set the link up. Empty value functions as `up`.",
+                                "type": "string"
+                              },
+                              "tag": {
+                                "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "logSerialConsole": {
+                          "description": "Whether to log the auto-attached default serial console or not. Serial console logs will be collect to a file and then streamed from a named `guest-console-log`. Not relevant if autoattachSerialConsole is disabled. Defaults to cluster wide setting on VirtualMachineOptions.",
+                          "type": "boolean"
+                        },
+                        "networkInterfaceMultiqueue": {
+                          "description": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.",
+                          "type": "boolean"
+                        },
+                        "panicDevices": {
+                          "description": "PanicDevices provides additional crash information when a guest crashes.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "model": {
+                                "description": "Model specifies what type of panic device is provided. The panic model used when this attribute is missing depends on the hypervisor and guest arch. One of: isa, hyperv, pvpanic.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "rng": {
+                          "description": "Rng represents the random device passed from host",
+                          "type": "object"
+                        },
+                        "sound": {
+                          "description": "Represents the user's configuration to emulate sound cards in the VMI.",
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "model": {
+                              "description": "We only support ich9 or ac97. If SoundDevice is not set: No sound card is emulated. If SoundDevice is set but Model is not: ich9",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "User's defined name for this sound device",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "tpm": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "description": "Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine Defaults to True",
+                              "type": "boolean"
+                            },
+                            "persistent": {
+                              "description": "Persistent indicates the state of the TPM device should be kept accross reboots Defaults to false",
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "useVirtioTransitional": {
+                          "description": "Fall back to legacy virtio 0.9 support if virtio bus is selected on devices. This is helpful for old machines like CentOS6 or RHEL6 which do not understand virtio_non_transitional (virtio 1.0).",
+                          "type": "boolean"
+                        },
+                        "video": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "description": "Type specifies the video device type (e.g., virtio, vga, bochs, ramfb). If not specified, the default is architecture-dependent (VGA for BIOS-based VMs, Bochs for EFI-based VMs on AMD64; virtio for Arm and s390x).",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "watchdog": {
+                          "description": "Named watchdog device.",
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "diag288": {
+                              "description": "diag288 watchdog device.",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "description": "The action to take. Valid values are poweroff, reset, shutdown. Defaults to reset.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "i6300esb": {
+                              "description": "i6300esb watchdog device.",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "description": "The action to take. Valid values are poweroff, reset, shutdown. Defaults to reset.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "name": {
+                              "description": "Name of the watchdog.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "features": {
+                      "type": "object",
+                      "properties": {
+                        "acpi": {
+                          "description": "Represents if a feature is enabled or disabled.",
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "apic": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                              "type": "boolean"
+                            },
+                            "endOfInterrupt": {
+                              "description": "EndOfInterrupt enables the end of interrupt notification in the guest. Defaults to false.",
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "hyperv": {
+                          "description": "Hyperv specific features.",
+                          "type": "object",
+                          "properties": {
+                            "evmcs": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "frequencies": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "ipi": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "reenlightenment": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "relaxed": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "reset": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "runtime": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "spinlocks": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                },
+                                "spinlocks": {
+                                  "description": "Retries indicates the number of retries. Must be a value greater or equal 4096. Defaults to 4096.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            },
+                            "synic": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "synictimer": {
+                              "type": "object",
+                              "properties": {
+                                "direct": {
+                                  "description": "Represents if a feature is enabled or disabled.",
+                                  "type": "object",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                      "type": "boolean"
+                                    }
+                                  }
+                                },
+                                "enabled": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "tlbflush": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "vapic": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "vendorid": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                },
+                                "vendorid": {
+                                  "description": "VendorID sets the hypervisor vendor id, visible to the vmi. String up to twelve characters.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "vpindex": {
+                              "description": "Represents if a feature is enabled or disabled.",
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hypervPassthrough": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "kvm": {
+                          "type": "object",
+                          "properties": {
+                            "hidden": {
+                              "description": "Hide the KVM hypervisor from standard MSR based discovery. Defaults to false",
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "pvspinlock": {
+                          "description": "Represents if a feature is enabled or disabled.",
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "smm": {
+                          "description": "Represents if a feature is enabled or disabled.",
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "firmware": {
+                      "type": "object",
+                      "properties": {
+                        "acpi": {
+                          "type": "object",
+                          "properties": {
+                            "msdmNameRef": {
+                              "description": "Similar to SlicNameRef, another ACPI entry that is used in more recent Windows versions. The above points to the spec of MSDM too.",
+                              "type": "string"
+                            },
+                            "slicNameRef": {
+                              "description": "SlicNameRef should match the volume name of a secret object. The data in the secret should be a binary blob that follows the ACPI SLIC standard, see: https://learn.microsoft.com/en-us/previous-versions/windows/hardware/design/dn653305(v=vs.85)",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "bootloader": {
+                          "description": "Represents the firmware blob used to assist in the domain creation process. Used for setting the QEMU BIOS file path for the libvirt domain.",
+                          "type": "object",
+                          "properties": {
+                            "bios": {
+                              "description": "If set (default), BIOS will be used.",
+                              "type": "object",
+                              "properties": {
+                                "useSerial": {
+                                  "description": "If set, the BIOS output will be transmitted over serial",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "efi": {
+                              "description": "If set, EFI will be used instead of BIOS.",
+                              "type": "object",
+                              "properties": {
+                                "persistent": {
+                                  "description": "If set to true, Persistent will persist the EFI NVRAM across reboots. Defaults to false",
+                                  "type": "boolean"
+                                },
+                                "secureBoot": {
+                                  "description": "If set, SecureBoot will be enabled and the OVMF roms will be swapped for SecureBoot-enabled ones. Requires SMM to be enabled. Defaults to true",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "kernelBoot": {
+                          "description": "Represents the firmware blob used to assist in the kernel boot process. Used for setting the kernel, initrd and command line arguments",
+                          "type": "object",
+                          "properties": {
+                            "container": {
+                              "description": "If set, the VM will be booted from the defined kernel / initrd.",
+                              "type": "object",
+                              "required": [
+                                "image"
+                              ],
+                              "properties": {
+                                "image": {
+                                  "description": "Image that contains initrd / kernel files.",
+                                  "type": "string"
+                                },
+                                "imagePullPolicy": {
+                                  "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+                                  "type": "string",
+                                  "enum": [
+                                    "Always",
+                                    "IfNotPresent",
+                                    "Never"
+                                  ]
+                                },
+                                "imagePullSecret": {
+                                  "description": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
+                                  "type": "string"
+                                },
+                                "initrdPath": {
+                                  "description": "the fully-qualified path to the ramdisk image in the host OS",
+                                  "type": "string"
+                                },
+                                "kernelPath": {
+                                  "description": "The fully-qualified path to the kernel image in the host OS",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "kernelArgs": {
+                              "description": "Arguments to be passed to the kernel at boot time",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "serial": {
+                          "description": "The system-serial-number in SMBIOS",
+                          "type": "string"
+                        },
+                        "uuid": {
+                          "description": "UUID reported by the vmi bios. Defaults to a random generated uid.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "ioThreads": {
+                      "type": "object",
+                      "properties": {
+                        "supplementalPoolThreadCount": {
+                          "description": "SupplementalPoolThreadCount specifies how many iothreads are allocated for the supplementalPool policy.",
+                          "type": "integer",
+                          "format": "int64"
+                        }
+                      }
+                    },
+                    "ioThreadsPolicy": {
+                      "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto, supplementalPool",
+                      "type": "string"
+                    },
+                    "launchSecurity": {
+                      "type": "object",
+                      "properties": {
+                        "sev": {
+                          "type": "object",
+                          "properties": {
+                            "attestation": {
+                              "type": "object"
+                            },
+                            "dhCert": {
+                              "description": "Base64 encoded guest owner's Diffie-Hellman key.",
+                              "type": "string"
+                            },
+                            "policy": {
+                              "type": "object",
+                              "properties": {
+                                "encryptedState": {
+                                  "description": "SEV-ES is required. Defaults to false.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "session": {
+                              "description": "Base64 encoded session blob.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "snp": {
+                          "type": "object"
+                        },
+                        "tdx": {
+                          "type": "object"
+                        }
+                      }
+                    },
+                    "machine": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "QEMU machine type is the actual chipset of the VirtualMachineInstance.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "memory": {
+                      "description": "Memory allows specifying the VirtualMachineInstance memory features.",
+                      "type": "object",
+                      "properties": {
+                        "guest": {
+                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                          "type": [
+                            "string",
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "hugepages": {
+                          "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
+                          "type": "object",
+                          "properties": {
+                            "pageSize": {
+                              "description": "PageSize specifies the hugepage size, for x86_64 architecture valid values are 1Gi and 2Mi.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "maxGuest": {
+                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                          "type": [
+                            "string",
+                            "integer",
+                            "number"
+                          ]
+                        }
+                      }
+                    },
+                    "resources": {
+                      "type": "object",
+                      "properties": {
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
+                          "type": "object",
+                          "additionalProperties": {
+                            "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                            "type": [
+                              "string",
+                              "integer",
+                              "number"
+                            ]
+                          }
+                        },
+                        "overcommitGuestOverhead": {
+                          "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
+                          "type": "boolean"
+                        },
+                        "requests": {
+                          "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
+                          "type": "object",
+                          "additionalProperties": {
+                            "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                            "type": [
+                              "string",
+                              "integer",
+                              "number"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "evictionStrategy": {
+                  "description": "EvictionStrategy describes the strategy to follow when a node drain occurs. The possible options are: - \"None\": No action will be taken, according to the specified 'RunStrategy' the VirtualMachine will be restarted or shutdown. - \"LiveMigrate\": the VirtualMachineInstance will be migrated instead of being shutdown. - \"LiveMigrateIfPossible\": the same as \"LiveMigrate\" but only if the VirtualMachine is Live-Migratable, otherwise it will behave as \"None\". - \"External\": the VirtualMachineInstance will be protected and `vmi.Status.EvacuationNodeName` will be set on eviction. This is mainly useful for cluster-api-provider-kubevirt (capk) which needs a way for VMI's to be blocked from eviction, yet signal capk that eviction has been called on the VMI so the capk controller can handle tearing the VMI down. Details can be found in the commit description https://github.com/kubevirt/kubevirt/commit/c1d77face705c8b126696bac9a3ee3825f27f1fa.",
+                  "type": "string"
+                },
+                "hostname": {
+                  "description": "Specifies the hostname of the vmi If not specified, the hostname will be set to the name of the vmi, if dhcp or cloud-init is configured properly.",
+                  "type": "string"
+                },
+                "livenessProbe": {
+                  "description": "Probe describes a health check to be performed against a VirtualMachineInstance to determine whether it is alive or ready to receive traffic.",
+                  "type": "object",
+                  "properties": {
+                    "exec": {
+                      "description": "ExecAction describes a \"run in container\" action.",
+                      "type": "object",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "guestAgentPing": {
+                      "description": "GuestAgentPing configures the guest-agent based ping probe",
+                      "type": "object"
+                    },
+                    "httpGet": {
+                      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "type": "array",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                          "type": [
+                            "string",
+                            "number"
+                          ]
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                          "type": "string",
+                          "enum": [
+                            "HTTP",
+                            "HTTPS"
+                          ]
+                        }
+                      }
+                    },
+                    "initialDelaySeconds": {
+                      "description": "Number of seconds after the VirtualMachineInstance has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "tcpSocket": {
+                      "description": "TCPSocketAction describes an action based on opening a socket",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                          "type": [
+                            "string",
+                            "number"
+                          ]
+                        }
+                      }
+                    },
+                    "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. For exec probes the timeout fails the probe but does not terminate the command running on the guest. This means a blocking command can result in an increasing load on the guest. A small buffer will be added to the resulting workload exec probe to compensate for delays caused by the qemu guest exec mechanism. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "networks": {
+                  "description": "List of networks that can be attached to a vm's virtual interface.",
+                  "type": "array",
+                  "items": {
+                    "description": "Network represents a network type and a resource that should be connected to the vm.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "multus": {
+                        "description": "Represents the multus cni network.",
+                        "type": "object",
+                        "required": [
+                          "networkName"
+                        ],
+                        "properties": {
+                          "default": {
+                            "description": "Select the default network and add it to the multus-cni.io/default-network annotation.",
+                            "type": "boolean"
+                          },
+                          "networkName": {
+                            "description": "References to a NetworkAttachmentDefinition CRD object. Format: <networkName>, <namespace>/<networkName>. If namespace is not specified, VMI namespace is assumed.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Network name. Must be a DNS_LABEL and unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "pod": {
+                        "description": "Represents the stock pod network interface.",
+                        "type": "object",
+                        "properties": {
+                          "vmIPv6NetworkCIDR": {
+                            "description": "IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.",
+                            "type": "string"
+                          },
+                          "vmNetworkCIDR": {
+                            "description": "CIDR for vm network. Default 10.0.2.0/24 if not specified.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "nodeSelector": {
+                  "description": "NodeSelector is a selector which must be true for the vmi to fit on a node. Selector which must match a node's labels for the vmi to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "priorityClassName": {
+                  "description": "If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default.",
+                  "type": "string"
+                },
+                "readinessProbe": {
+                  "description": "Probe describes a health check to be performed against a VirtualMachineInstance to determine whether it is alive or ready to receive traffic.",
+                  "type": "object",
+                  "properties": {
+                    "exec": {
+                      "description": "ExecAction describes a \"run in container\" action.",
+                      "type": "object",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "guestAgentPing": {
+                      "description": "GuestAgentPing configures the guest-agent based ping probe",
+                      "type": "object"
+                    },
+                    "httpGet": {
+                      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "type": "array",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "type": "object",
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                          "type": [
+                            "string",
+                            "number"
+                          ]
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                          "type": "string",
+                          "enum": [
+                            "HTTP",
+                            "HTTPS"
+                          ]
+                        }
+                      }
+                    },
+                    "initialDelaySeconds": {
+                      "description": "Number of seconds after the VirtualMachineInstance has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "tcpSocket": {
+                      "description": "TCPSocketAction describes an action based on opening a socket",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                          "type": [
+                            "string",
+                            "number"
+                          ]
+                        }
+                      }
+                    },
+                    "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. For exec probes the timeout fails the probe but does not terminate the command running on the guest. This means a blocking command can result in an increasing load on the guest. A small buffer will be added to the resulting workload exec probe to compensate for delays caused by the qemu guest exec mechanism. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "resourceClaims": {
+                  "description": "ResourceClaims define which ResourceClaims must be allocated and reserved before the VMI, hence virt-launcher pod is allowed to start. The resources will be made available to the domain which consumes them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate in kubernetes\n https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/\nThis field should only be configured if one of the feature-gates GPUsWithDRA or HostDevicesWithDRA is enabled. This feature is in alpha.",
+                  "type": "array",
+                  "items": {
+                    "description": "PodResourceClaim references exactly one ResourceClaim, either directly or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim for the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "schedulerName": {
+                  "description": "If specified, the VMI will be dispatched by specified scheduler. If not specified, the VMI will be dispatched by default scheduler.",
+                  "type": "string"
+                },
+                "startStrategy": {
+                  "description": "StartStrategy can be set to \"Paused\" if Virtual Machine should be started in paused state.",
+                  "type": "string"
+                },
+                "subdomain": {
+                  "description": "If specified, the fully qualified vmi hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi, no matter if the vmi itself can pick up a hostname.",
+                  "type": "string"
+                },
+                "terminationGracePeriodSeconds": {
+                  "description": "Grace period observed after signalling a VirtualMachineInstance to stop after which the VirtualMachineInstance is force terminated.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "tolerations": {
+                  "description": "If toleration is specified, obey all the toleration rules.",
+                  "type": "array",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                    "type": "object",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\n\nPossible enum values:\n - `\"NoExecute\"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.\n - `\"NoSchedule\"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.\n - `\"PreferNoSchedule\"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.",
+                        "type": "string",
+                        "enum": [
+                          "NoExecute",
+                          "NoSchedule",
+                          "PreferNoSchedule"
+                        ]
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.\n\nPossible enum values:\n - `\"Equal\"`\n - `\"Exists\"`",
+                        "type": "string",
+                        "enum": [
+                          "Equal",
+                          "Exists"
+                        ]
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "topologySpreadConstraints": {
+                  "description": "TopologySpreadConstraints describes how a group of VMIs will be spread across a given topology domains. K8s scheduler will schedule VMI pods in a way which abides by the constraints.",
+                  "type": "array",
+                  "items": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "type": "object",
+                    "required": [
+                      "maxSkew",
+                      "topologyKey",
+                      "whenUnsatisfiable"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "minDomains": {
+                        "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "nodeAffinityPolicy": {
+                        "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\n\nPossible enum values:\n - `\"Honor\"` means use this scheduling directive when calculating pod topology spread skew.\n - `\"Ignore\"` means ignore this scheduling directive when calculating pod topology spread skew.",
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\n\nPossible enum values:\n - `\"Honor\"` means use this scheduling directive when calculating pod topology spread skew.\n - `\"Ignore\"` means ignore this scheduling directive when calculating pod topology spread skew.",
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.\n\nPossible enum values:\n - `\"DoNotSchedule\"` instructs the scheduler not to schedule the pod when constraints are not satisfied.\n - `\"ScheduleAnyway\"` instructs the scheduler to schedule the pod even if constraints are not satisfied.",
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "volumes": {
+                  "description": "List of volumes that can be mounted by disks belonging to the vmi.",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a vmi.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "cloudInitConfigDrive": {
+                        "description": "Represents a cloud-init config drive user data source. More info: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html",
+                        "type": "object",
+                        "properties": {
+                          "networkData": {
+                            "description": "NetworkData contains config drive inline cloud-init networkdata.",
+                            "type": "string"
+                          },
+                          "networkDataBase64": {
+                            "description": "NetworkDataBase64 contains config drive cloud-init networkdata as a base64 encoded string.",
+                            "type": "string"
+                          },
+                          "networkDataSecretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "userData": {
+                            "description": "UserData contains config drive inline cloud-init userdata.",
+                            "type": "string"
+                          },
+                          "userDataBase64": {
+                            "description": "UserDataBase64 contains config drive cloud-init userdata as a base64 encoded string.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cloudInitNoCloud": {
+                        "description": "Represents a cloud-init nocloud user data source. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+                        "type": "object",
+                        "properties": {
+                          "networkData": {
+                            "description": "NetworkData contains NoCloud inline cloud-init networkdata.",
+                            "type": "string"
+                          },
+                          "networkDataBase64": {
+                            "description": "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.",
+                            "type": "string"
+                          },
+                          "networkDataSecretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "userData": {
+                            "description": "UserData contains NoCloud inline cloud-init userdata.",
+                            "type": "string"
+                          },
+                          "userDataBase64": {
+                            "description": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "ConfigMapVolumeSource adapts a ConfigMap into a volume. More info: https://kubernetes.io/docs/concepts/storage/volumes/#configmap",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or it's keys must be defined",
+                            "type": "boolean"
+                          },
+                          "volumeLabel": {
+                            "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "containerDisk": {
+                        "description": "Represents a docker image with an embedded disk.",
+                        "type": "object",
+                        "required": [
+                          "image"
+                        ],
+                        "properties": {
+                          "image": {
+                            "description": "Image is the name of the image with the embedded disk.",
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+                            "type": "string",
+                            "enum": [
+                              "Always",
+                              "IfNotPresent",
+                              "Never"
+                            ]
+                          },
+                          "imagePullSecret": {
+                            "description": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path defines the path to disk file in the container",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "dataVolume": {
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "hotpluggable": {
+                            "description": "Hotpluggable indicates whether the volume can be hotplugged and hotunplugged.",
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "description": "Name of both the DataVolume and the PVC in the same namespace.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "DownwardAPIVolumeSource represents a volume containing downward API info.",
+                        "type": "object",
+                        "properties": {
+                          "fields": {
+                            "description": "Fields is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                  "type": "object",
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                  "type": "object",
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                      "type": [
+                                        "string",
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "volumeLabel": {
+                            "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "downwardMetrics": {
+                        "description": "DownwardMetricsVolumeSource adds a very small disk to VMIs which contains a limited view of host and guest metrics. The disk content is compatible with vhostmd (https://github.com/vhostmd/vhostmd) and vm-dump-metrics.",
+                        "type": "object"
+                      },
+                      "emptyDisk": {
+                        "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle.",
+                        "type": "object",
+                        "required": [
+                          "capacity"
+                        ],
+                        "properties": {
+                          "capacity": {
+                            "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                            "type": [
+                              "string",
+                              "integer",
+                              "number"
+                            ]
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "type": "object",
+                        "properties": {
+                          "persistentVolumeClaim": {
+                            "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+                            "type": "object",
+                            "required": [
+                              "claimName"
+                            ],
+                            "properties": {
+                              "claimName": {
+                                "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "hostDisk": {
+                        "description": "Represents a disk created on the cluster level",
+                        "type": "object",
+                        "required": [
+                          "path",
+                          "type"
+                        ],
+                        "properties": {
+                          "capacity": {
+                            "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                            "type": [
+                              "string",
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "path": {
+                            "description": "The path to HostDisk image located on the cluster",
+                            "type": "string"
+                          },
+                          "shared": {
+                            "description": "Shared indicate whether the path is shared between nodes",
+                            "type": "boolean"
+                          },
+                          "type": {
+                            "description": "Contains information if disk.img exists or should be created allowed options are 'Disk' and 'DiskOrCreate'",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "memoryDump": {
+                        "type": "object",
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "hotpluggable": {
+                            "description": "Hotpluggable indicates whether the volume can be hotplugged and hotunplugged.",
+                            "type": "boolean"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Volume's name. Must be a DNS_LABEL and unique within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "object",
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "hotpluggable": {
+                            "description": "Hotpluggable indicates whether the volume can be hotplugged and hotunplugged.",
+                            "type": "boolean"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "SecretVolumeSource adapts a Secret into a volume.",
+                        "type": "object",
+                        "properties": {
+                          "optional": {
+                            "description": "Specify whether the Secret or it's keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          },
+                          "volumeLabel": {
+                            "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "serviceAccount": {
+                        "description": "ServiceAccountVolumeSource adapts a ServiceAccount into a volume.",
+                        "type": "object",
+                        "properties": {
+                          "serviceAccountName": {
+                            "description": "Name of the service account in the pod's namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "sysprep": {
+                        "description": "Represents a Sysprep volume source.",
+                        "type": "object",
+                        "properties": {
+                          "configMap": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "secret": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/pkg/schema/validate.go
+++ b/internal/pkg/schema/validate.go
@@ -1,0 +1,119 @@
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ValidateMaskPaths verifies that every path in mask.quick_fields and
+// mask.advanced_fields resolves within the provided JSON Schema.
+//
+// This implements Stage 1 requirement: "Invalid mask paths must fail
+// validation before deployment." (master-flow.md:186)
+//
+// The check is path-navigation based: for a path like
+// "spec.template.spec.domain.cpu.cores", this function walks the nested
+// "properties" / "items.properties" hierarchy of the JSON Schema and
+// confirms the final key exists. Array-typed nodes (type: "array") may be
+// traversed through their "items" sub-schema.
+//
+// Returns a non-nil error listing ALL invalid paths, not just the first,
+// so that operator can fix all issues in one deployment cycle.
+func ValidateMaskPaths(schemaJSON, maskJSON []byte) error {
+	var rawSchema map[string]interface{}
+	if err := json.Unmarshal(schemaJSON, &rawSchema); err != nil {
+		return fmt.Errorf("parse schema: %w", err)
+	}
+
+	var mask struct {
+		QuickFields []struct {
+			Path string `json:"path"`
+		} `json:"quick_fields"`
+		AdvancedFields []struct {
+			Path string `json:"path"`
+		} `json:"advanced_fields"`
+	}
+	if err := json.Unmarshal(maskJSON, &mask); err != nil {
+		return fmt.Errorf("parse mask: %w", err)
+	}
+
+	var invalid []string
+	check := func(section, path string) {
+		if path == "" {
+			invalid = append(invalid, fmt.Sprintf("%s[empty path]", section))
+			return
+		}
+		if err := resolveSchemaPath(rawSchema, path); err != nil {
+			invalid = append(invalid, fmt.Sprintf("%s path %q: %v", section, path, err))
+		}
+	}
+
+	for _, f := range mask.QuickFields {
+		check("quick_fields", f.Path)
+	}
+	for _, f := range mask.AdvancedFields {
+		check("advanced_fields", f.Path)
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("mask has %d invalid path(s):\n  - %s",
+			len(invalid), strings.Join(invalid, "\n  - "))
+	}
+	return nil
+}
+
+// resolveSchemaPath navigates a JSON Schema object following dot-notation path.
+// Traversal rules (JSON Schema Draft-07):
+//   - At each segment, look for the key in current node's "properties" map.
+//   - If the current node has type "array", descend into "items" before
+//     trying "properties" again (covers array-of-objects paths).
+//   - Leaf segments just need to exist; their type is validated by the
+//     schema itself (not this validator).
+func resolveSchemaPath(schema map[string]interface{}, path string) error {
+	segments := strings.Split(path, ".")
+	cur := schema
+
+	for i, seg := range segments {
+		// If current node is array-typed, descend into items before trying properties.
+		if t, ok := cur["type"]; ok && t == "array" {
+			items, hasItems := cur["items"]
+			if !hasItems {
+				return fmt.Errorf("segment[%d] %q: array node has no 'items'", i, seg)
+			}
+			itemsMap, ok := items.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("segment[%d] %q: 'items' is not an object", i, seg)
+			}
+			cur = itemsMap
+		}
+
+		props, ok := cur["properties"]
+		if !ok {
+			return fmt.Errorf("segment[%d] %q: node has no 'properties'", i, seg)
+		}
+		propsMap, ok := props.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("segment[%d] %q: 'properties' is not an object", i, seg)
+		}
+		next, ok := propsMap[seg]
+		if !ok {
+			available := make([]string, 0, len(propsMap))
+			for k := range propsMap {
+				available = append(available, k)
+			}
+			return fmt.Errorf("segment[%d] %q: not found in properties (available: %v)",
+				i, seg, available)
+		}
+		nextMap, ok := next.(map[string]interface{})
+		if !ok {
+			// Leaf node with non-object definition (e.g. primitive type): valid if last seg.
+			if i == len(segments)-1 {
+				return nil
+			}
+			return fmt.Errorf("segment[%d] %q: not an object, cannot traverse further", i, seg)
+		}
+		cur = nextMap
+	}
+	return nil
+}

--- a/internal/service/approval_validator.go
+++ b/internal/service/approval_validator.go
@@ -95,7 +95,12 @@ func (v *ApprovalValidator) ValidateApproval(
 			return fmt.Errorf("query instance size: %w", err)
 		}
 
-		if err := ValidateOvercommit(size.CPUCores, size.CPURequest, size.MemoryMB, size.MemoryRequestMB, size.DedicatedCPU); err != nil {
+		// Resolve effective dedicated_cpu: consider both the indexed column AND any
+		// spec_overrides path that sets dedicatedCpuPlacement (ADR-0036 constraint guard).
+		// This prevents bypassing the dedicated+overcommit conflict check by only setting
+		// the flag inside spec_overrides while leaving the top-level dedicated_cpu unset.
+		effectiveDedicatedCPU := size.DedicatedCPU || hasDedicatedCPUInSpecOverrides(size.SpecOverrides)
+		if err := ValidateOvercommit(size.CPUCores, size.CPURequest, size.MemoryMB, size.MemoryRequestMB, effectiveDedicatedCPU); err != nil {
 			return err
 		}
 
@@ -303,6 +308,13 @@ func hasSRIOVRequirement(spec map[string]interface{}) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(fmt.Sprint(networks)), "sriov")
+}
+
+// hasDedicatedCPUInSpecOverrides is a package-internal alias for the exported
+// HasDedicatedCPUInSpecOverrides, kept for readability at the call site.
+// Single source of truth lives in instancesize_validator.go.
+func hasDedicatedCPUInSpecOverrides(spec map[string]interface{}) bool {
+	return HasDedicatedCPUInSpecOverrides(spec)
 }
 
 func extractHugepagesSize(spec map[string]interface{}) string {

--- a/internal/service/instancesize_validator.go
+++ b/internal/service/instancesize_validator.go
@@ -105,6 +105,16 @@ func DetectSpecOverridesConflicts(
 				}
 			}
 		}
+	} else {
+		// Reverse direction: spec_overrides sets dedicatedCpuPlacement=true without
+		// the indexed dedicated_cpu flag. This creates a data inconsistency where
+		// the scheduler index disagrees with the KubeVirt spec that is actually applied.
+		if HasDedicatedCPUInSpecOverrides(overrides) {
+			warnings = append(warnings,
+				"spec_overrides sets dedicatedCpuPlacement=true but indexed dedicated_cpu field is false; "+
+					"set dedicated_cpu=true so the value is indexed for scheduling and approval queries",
+			)
+		}
 	}
 
 	return warnings
@@ -123,4 +133,118 @@ func toIntSafe(raw interface{}) (int, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// HasDedicatedCPUInSpecOverrides reports whether spec_overrides explicitly sets
+// KubeVirt's dedicatedCpuPlacement to true.
+//
+// This is the single source of truth for the "spec path bypass" detection,
+// shared between the InstanceSize create/update validation (handlers) and the
+// approval validator (service). Both use different call sites but the same
+// semantic: does the effective dedicated-CPU intent in spec_overrides disagree
+// with the indexed dedicated_cpu field?
+//
+// Supported key formats — both are checked to handle all callers:
+//
+//  1. Flat dot-notation key (DB-stored / API round-trip):
+//     "spec.template.spec.domain.cpu.dedicatedCpuPlacement" = true
+//
+//  2. Nested map (produced by DynamicSchemaForm via Ant Design Form.getFieldsValue):
+//     {"spec": {"template": {"spec": {"domain": {"cpu": {"dedicatedCpuPlacement": true}}}}}}
+//
+// The DynamicSchemaForm component uses namePath = field.path.split('.') when
+// registering field names, so Ant Design stores values as a nested object tree.
+// getFieldsValue() / JSON.stringify() therefore produces the nested structure,
+// not the flat key. Both formats must be handled here to prevent constraint bypass.
+func HasDedicatedCPUInSpecOverrides(overrides map[string]interface{}) bool {
+	for _, path := range []string{
+		"spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+		"spec.domain.cpu.dedicatedCpuPlacement",
+	} {
+		// Check flat dot-notation key (database-stored format).
+		if raw, ok := overrides[path]; ok && raw != nil {
+			if boolFromRaw(raw) {
+				return true
+			}
+		}
+		// Check nested map format (DynamicSchemaForm / Ant Design output format).
+		if v := extractNestedBool(overrides, strings.Split(path, ".")); v != nil && *v {
+			return true
+		}
+	}
+	return false
+}
+
+// boolFromRaw converts an interface{} to bool, accepting both bool and string "true".
+func boolFromRaw(raw interface{}) bool {
+	switch v := raw.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true")
+	}
+	return false
+}
+
+// extractNestedBool traverses a nested map[string]interface{} along the given
+// path segments and returns a pointer to the boolean value at the leaf, or nil
+// if the path does not exist or the leaf is not a recognizable boolean.
+//
+// This handles the DynamicSchemaForm output format where Ant Design Form
+// stores field values as a nested object tree keyed by path segments.
+func extractNestedBool(m map[string]interface{}, path []string) *bool {
+	if len(path) == 0 || m == nil {
+		return nil
+	}
+	val, ok := m[path[0]]
+	if !ok || val == nil {
+		return nil
+	}
+	if len(path) == 1 {
+		b := boolFromRaw(val)
+		return &b
+	}
+	switch nested := val.(type) {
+	case map[string]interface{}:
+		return extractNestedBool(nested, path[1:])
+	}
+	return nil
+}
+
+// SpecOverrideSetsExplicitFalseForDedicatedCPU checks whether spec_overrides
+// **explicitly** sets dedicatedCpuPlacement to false.
+//
+// This is the counterpart to HasDedicatedCPUInSpecOverrides.  Both must be
+// checked in tandem:
+//
+//   - HasDedicatedCPUInSpecOverrides: spec sets it true  → inconsistent if dedicated_cpu=false
+//   - SpecOverrideSetsExplicitFalseForDedicatedCPU: spec sets it false → inconsistent if dedicated_cpu=true
+//
+// Like the sibling function, both flat dot-notation keys and nested map format
+// (produced by DynamicSchemaForm / Ant Design Form.getFieldsValue) are checked.
+//
+// Returns (conflicting path description, true) when an explicit false is found;
+// ("", false) when no explicit false is present (path absent = not a conflict).
+func SpecOverrideSetsExplicitFalseForDedicatedCPU(overrides map[string]interface{}) (string, bool) {
+	for _, path := range []string{
+		"spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+		"spec.domain.cpu.dedicatedCpuPlacement",
+	} {
+		// Check flat dot-notation key (database-stored / API round-trip format).
+		if raw, ok := overrides[path]; ok && raw != nil {
+			// Use safe type assertion (Go spec: v, ok := x.(T) never panics).
+			if b, isBool := raw.(bool); isBool && !b {
+				return path, true
+			}
+			if s, isStr := raw.(string); isStr && strings.EqualFold(strings.TrimSpace(s), "false") {
+				return path, true
+			}
+		}
+		// Check nested map format (DynamicSchemaForm / Ant Design format).
+		segments := strings.Split(path, ".")
+		if v := extractNestedBool(overrides, segments); v != nil && !*v {
+			return path + " (nested)", true
+		}
+	}
+	return "", false
 }

--- a/internal/service/instancesize_validator_test.go
+++ b/internal/service/instancesize_validator_test.go
@@ -226,3 +226,482 @@ func TestToIntSafe(t *testing.T) {
 		})
 	}
 }
+
+// TestHasDedicatedCPUInSpecOverrides covers the exported function used by both
+// the handler write-path validation and the approval-time bypass guard.
+func TestHasDedicatedCPUInSpecOverrides(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]interface{}
+		want      bool
+	}{
+		{
+			name:      "nil overrides",
+			overrides: nil,
+			want:      false,
+		},
+		{
+			name:      "empty overrides",
+			overrides: map[string]interface{}{},
+			want:      false,
+		},
+		{
+			name: "bool true — long path",
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": true,
+			},
+			want: true,
+		},
+		{
+			name: "bool true — short path",
+			overrides: map[string]interface{}{
+				"spec.domain.cpu.dedicatedCpuPlacement": true,
+			},
+			want: true,
+		},
+		{
+			name: "bool false — not dedicated",
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": false,
+			},
+			want: false,
+		},
+		{
+			name: "string \"true\" (case-insensitive)",
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": "True",
+			},
+			want: true,
+		},
+		{
+			name: "string \"false\" — not dedicated",
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": "false",
+			},
+			want: false,
+		},
+		{
+			name: "unrelated path only",
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.cores": 4,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasDedicatedCPUInSpecOverrides(tt.overrides)
+			if got != tt.want {
+				t.Errorf("HasDedicatedCPUInSpecOverrides() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDetectSpecOverridesConflicts_ReverseDedicated covers the newly added case:
+// spec_overrides sets dedicatedCpuPlacement=true but the indexed field is false.
+func TestDetectSpecOverridesConflicts_ReverseDedicated(t *testing.T) {
+	tests := []struct {
+		name          string
+		dedicatedCPU  bool
+		overrides     map[string]interface{}
+		wantWarning   bool
+		wantSubstring string
+	}{
+		{
+			name:         "spec=true, indexed=false → warning",
+			dedicatedCPU: false,
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": true,
+			},
+			wantWarning:   true,
+			wantSubstring: "dedicated_cpu field is false",
+		},
+		{
+			name:         "spec=false, indexed=true → warning",
+			dedicatedCPU: true,
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": false,
+			},
+			wantWarning:   true,
+			wantSubstring: "dedicated",
+		},
+		{
+			name:         "spec=true, indexed=true → no conflict warning",
+			dedicatedCPU: true,
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.dedicatedCpuPlacement": true,
+			},
+			wantWarning: false,
+		},
+		{
+			name:         "no dedicated key in spec, indexed=false → no warning",
+			dedicatedCPU: false,
+			overrides: map[string]interface{}{
+				"spec.template.spec.domain.cpu.cores": 4,
+			},
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := DetectSpecOverridesConflicts(4, 8192, tt.dedicatedCPU, nil, tt.overrides)
+			hasWarning := false
+			for _, w := range warnings {
+				if tt.wantSubstring != "" && strings.Contains(w, tt.wantSubstring) {
+					hasWarning = true
+					break
+				} else if tt.wantSubstring == "" {
+					hasWarning = true
+					break
+				}
+			}
+			if tt.wantWarning && !hasWarning {
+				t.Errorf("expected warning containing %q, got: %v", tt.wantSubstring, warnings)
+			}
+			if !tt.wantWarning && len(warnings) > 0 {
+				// Filter out unrelated warnings (e.g., overcommit) before asserting
+				for _, w := range warnings {
+					if strings.Contains(w, "dedicated") {
+						t.Errorf("unexpected dedicated_cpu warning: %s", w)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestHasDedicatedCPUInSpecOverrides_NestedFormat covers the DynamicSchemaForm / Ant Design
+// output format where Form.getFieldsValue() returns a nested object tree rather than
+// flat dot-notation keys.
+//
+// The DynamicSchemaForm component registers fields with namePath = path.split('.'),
+// which causes Ant Design to store values under nested keys.  JSON.stringify then
+// produces {"spec":{"template":{"spec":{"domain":{"cpu":{"dedicatedCpuPlacement":true}}}}}}
+// instead of the flat key "spec.template.spec.domain.cpu.dedicatedCpuPlacement".
+// Without this nested-format support the constraint bypass described in Finding 1 would
+// allow dedicated_cpu=false with a spec override that sets dedicatedCpuPlacement=true.
+func TestHasDedicatedCPUInSpecOverrides_NestedFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]interface{}
+		want      bool
+	}{
+		{
+			name: "nested long path — true",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{
+									"dedicatedCpuPlacement": true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nested long path — false",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{
+									"dedicatedCpuPlacement": false,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nested short path — true",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"domain": map[string]interface{}{
+						"cpu": map[string]interface{}{
+							"dedicatedCpuPlacement": true,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nested with string 'true'",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{
+									"dedicatedCpuPlacement": "True",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nested — unrelated key only",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{
+									"cores": 4,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "mix: nested true + flat key absent",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{
+									"dedicatedCpuPlacement": true,
+									"cores":                 8,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasDedicatedCPUInSpecOverrides(tt.overrides)
+			if got != tt.want {
+				t.Errorf("HasDedicatedCPUInSpecOverrides() = %v, want %v (nested format)", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractNestedBool covers the internal helper directly as a unit test.
+func TestExtractNestedBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       map[string]interface{}
+		path    []string
+		wantVal *bool
+	}{
+		{
+			name:    "nil map",
+			m:       nil,
+			path:    []string{"a"},
+			wantVal: nil,
+		},
+		{
+			name:    "empty path",
+			m:       map[string]interface{}{"a": true},
+			path:    []string{},
+			wantVal: nil,
+		},
+		{
+			name:    "single segment — bool true",
+			m:       map[string]interface{}{"x": true},
+			path:    []string{"x"},
+			wantVal: func() *bool { b := true; return &b }(),
+		},
+		{
+			name:    "single segment — bool false",
+			m:       map[string]interface{}{"x": false},
+			path:    []string{"x"},
+			wantVal: func() *bool { b := false; return &b }(),
+		},
+		{
+			name:    "single segment missing",
+			m:       map[string]interface{}{"y": true},
+			path:    []string{"x"},
+			wantVal: nil,
+		},
+		{
+			name: "two level path",
+			m: map[string]interface{}{
+				"a": map[string]interface{}{"b": true},
+			},
+			path:    []string{"a", "b"},
+			wantVal: func() *bool { b := true; return &b }(),
+		},
+		{
+			name: "intermediate not a map",
+			m: map[string]interface{}{
+				"a": "not a map",
+			},
+			path:    []string{"a", "b"},
+			wantVal: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractNestedBool(tt.m, tt.path)
+			if tt.wantVal == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("expected %v, got nil", *tt.wantVal)
+				return
+			}
+			if *got != *tt.wantVal {
+				t.Errorf("extractNestedBool() = %v, want %v", *got, *tt.wantVal)
+			}
+		})
+	}
+}
+
+// TestSpecOverrideSetsExplicitFalseForDedicatedCPU covers the counterpart to
+// HasDedicatedCPUInSpecOverrides: detecting spec_overrides that explicitly set
+// dedicatedCpuPlacement=false while dedicated_cpu=true.
+//
+// Both flat dot-notation keys (DB-stored format) and nested map format
+// (DynamicSchemaForm / Ant Design output format) must be detected.
+func TestSpecOverrideSetsExplicitFalseForDedicatedCPU(t *testing.T) {
+	tests := []struct {
+		name         string
+		overrides    map[string]interface{}
+		wantConflict bool
+		wantPathSub  string // expected substring in returned conflict path
+	}{
+		{name: "nil overrides – no conflict", overrides: nil, wantConflict: false},
+		{name: "empty overrides – no conflict", overrides: map[string]interface{}{}, wantConflict: false},
+		{
+			name:         "flat key=true – not a false conflict",
+			overrides:    map[string]interface{}{"spec.template.spec.domain.cpu.dedicatedCpuPlacement": true},
+			wantConflict: false,
+		},
+		{
+			name:         "flat long path=false – conflict",
+			overrides:    map[string]interface{}{"spec.template.spec.domain.cpu.dedicatedCpuPlacement": false},
+			wantConflict: true,
+			wantPathSub:  "spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+		},
+		{
+			name:         "flat short path=false – conflict",
+			overrides:    map[string]interface{}{"spec.domain.cpu.dedicatedCpuPlacement": false},
+			wantConflict: true,
+			wantPathSub:  "spec.domain.cpu.dedicatedCpuPlacement",
+		},
+		{
+			name:         "flat key=string \"false\" – conflict",
+			overrides:    map[string]interface{}{"spec.template.spec.domain.cpu.dedicatedCpuPlacement": "false"},
+			wantConflict: true,
+			wantPathSub:  "spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+		},
+		{
+			name:         "flat key=string \"FALSE\" case-insensitive – conflict",
+			overrides:    map[string]interface{}{"spec.template.spec.domain.cpu.dedicatedCpuPlacement": "FALSE"},
+			wantConflict: true,
+			wantPathSub:  "spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+		},
+		{
+			name:         "flat key absent – no conflict",
+			overrides:    map[string]interface{}{"spec.template.spec.domain.cpu.cores": 8},
+			wantConflict: false,
+		},
+		{
+			name: "nested long path=false – conflict (DynamicSchemaForm format)",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{"dedicatedCpuPlacement": false},
+							},
+						},
+					},
+				},
+			},
+			wantConflict: true,
+			wantPathSub:  "spec.template.spec.domain.cpu.dedicatedCpuPlacement",
+		},
+		{
+			name: "nested long path=true – no conflict",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{"dedicatedCpuPlacement": true},
+							},
+						},
+					},
+				},
+			},
+			wantConflict: false,
+		},
+		{
+			name: "nested short path=false – conflict",
+			overrides: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"domain": map[string]interface{}{
+						"cpu": map[string]interface{}{"dedicatedCpuPlacement": false},
+					},
+				},
+			},
+			wantConflict: true,
+			wantPathSub:  "spec.domain.cpu.dedicatedCpuPlacement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotConflict := SpecOverrideSetsExplicitFalseForDedicatedCPU(tt.overrides)
+			if gotConflict != tt.wantConflict {
+				t.Errorf("SpecOverrideSetsExplicitFalseForDedicatedCPU() conflict=%v, want %v (path=%q)",
+					gotConflict, tt.wantConflict, gotPath)
+				return
+			}
+			if tt.wantConflict {
+				if gotPath == "" {
+					t.Errorf("expected non-empty path when conflict=true")
+				} else if tt.wantPathSub != "" && !testStringContains(gotPath, tt.wantPathSub) {
+					t.Errorf("path %q does not contain expected substring %q", gotPath, tt.wantPathSub)
+				}
+			} else if gotPath != "" {
+				t.Errorf("expected empty path when no conflict, got %q", gotPath)
+			}
+		})
+	}
+}
+
+// testStringContains reports whether substr is a substring of s.
+func testStringContains(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	if len(s) < len(substr) {
+		return false
+	}
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/web/src/features/admin-instance-sizes/components/AdminInstanceSizesContent.tsx
+++ b/web/src/features/admin-instance-sizes/components/AdminInstanceSizesContent.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from 'react';
 import {
+    Alert,
     Button,
     Card,
     Checkbox,
@@ -11,8 +12,8 @@ import {
     Input,
     InputNumber,
     Modal,
-    Select,
     Space,
+    Spin,
     Switch,
     Table,
     Tag,
@@ -25,8 +26,6 @@ import {
     DeleteOutlined,
     EditOutlined,
     HddOutlined,
-    MinusCircleOutlined,
-    PlusOutlined,
     ReloadOutlined,
     SearchOutlined,
     ThunderboltOutlined,
@@ -35,6 +34,13 @@ import { useTranslation } from 'react-i18next';
 
 import { useAdminInstanceSizesController } from '../hooks/useAdminInstanceSizesController';
 import { formatMemory, type InstanceSize } from '../types';
+import {
+    DynamicSchemaForm,
+    type DynamicSchemaFormHandle,
+    type SchemaNode,
+    type SchemaMask,
+} from '../../admin-templates/components/DynamicSchemaForm';
+import { useDynamicSchema } from '../../admin-templates/hooks/useDynamicSchema';
 
 const { Title, Text } = Typography;
 
@@ -61,11 +67,87 @@ function highlightText(text: string, highlight: string): React.ReactNode {
 }
 
 /**
- * Shared form fields for InstanceSize create/edit modals.
- * Uses Ant Design shouldUpdate pattern for conditional overcommit sections
- * and Form.List for GPU devices (per master-flow Stage 3 Step 4 design).
+ * Schema-driven spec_overrides section for InstanceSize modals.
+ *
+ * Replaces hardcoded Hugepages Select + GPU Form.List + JSON textarea.
+ * Loads schema+mask from GET /schemas/instancesize (ADR-0023 Stage 1).
+ *
+ * Degradation chain (ADR-0023):
+ *   success → DynamicSchemaForm renders mask fields
+ *   isError → collapsed warning, form still submittable without dynamic fields
+ *   isPending → loading spinner
  */
-function InstanceSizeFormFields({ isCreate }: { isCreate: boolean }) {
+function InstanceSizeSpecSection({
+    formRef,
+    disabled,
+}: {
+    formRef: React.RefObject<DynamicSchemaFormHandle | null>;
+    disabled?: boolean;
+}) {
+    const { t } = useTranslation(['admin', 'common']);
+    const { data, isError, isPending } = useDynamicSchema('instancesize');
+
+    if (isPending) {
+        return (
+            <Card size="small" style={{ textAlign: 'center', padding: 24 }}>
+                <Spin size="small" />
+                <Text type="secondary" style={{ marginLeft: 8 }}>
+                    {t('instanceSizes.schema_loading', 'Loading spec schema…')}
+                </Text>
+            </Card>
+        );
+    }
+
+    if (isError || !data) {
+        return (
+            <Alert
+                type="warning"
+                showIcon
+                message={t(
+                    'instanceSizes.schema_unavailable',
+                    'Spec schema unavailable — advanced KubeVirt settings cannot be configured right now.'
+                )}
+                style={{ marginBottom: 8 }}
+            />
+        );
+    }
+
+    return (
+        <Form.Item
+            name="spec_text"
+            // valuePropName="value" is injected by Form.Item automatically
+            noStyle
+        >
+            <DynamicSchemaForm
+                ref={formRef}
+                schema={data.schema as SchemaNode}
+                mask={data.mask as SchemaMask}
+                disabled={disabled}
+            />
+        </Form.Item>
+    );
+}
+
+/**
+ * Shared form fields for InstanceSize create/edit modals.
+ *
+ * Architecture:
+ * - Metadata fields (cpu_cores, memory_mb, overcommit, etc.) remain as
+ *   explicit Ant Design Form.Items — these are InstanceSize-specific API fields.
+ * - Spec overrides (hugepages, GPU devices, CPU model, etc.) are rendered
+ *   schema-driven via DynamicSchemaForm (ADR-0023 Stage 1).
+ *
+ * The `formRef` is passed down so the parent Form's onValuesChange can
+ * call formRef.current?.sync() to keep spec_text in sync (antd best practice:
+ * side effects in event handlers, not in render).
+ */
+function InstanceSizeFormFields({
+    isCreate,
+    formRef,
+}: {
+    isCreate: boolean;
+    formRef: React.RefObject<DynamicSchemaFormHandle | null>;
+}) {
     const { t } = useTranslation(['admin', 'common']);
 
     return (
@@ -97,7 +179,7 @@ function InstanceSizeFormFields({ isCreate }: { isCreate: boolean }) {
                 <InputNumber min={1} style={{ width: '100%' }} addonAfter={t('instanceSizes.cores')} />
             </Form.Item>
 
-            {/* CPU Overcommit: conditional reveal */}
+            {/* CPU Overcommit: conditional reveal using shouldUpdate (rendering only, no side effects) */}
             <Form.Item name="cpu_overcommit_enabled" valuePropName="checked">
                 <Checkbox>{t('instanceSizes.enable_cpu_overcommit')}</Checkbox>
             </Form.Item>
@@ -148,78 +230,27 @@ function InstanceSizeFormFields({ isCreate }: { isCreate: boolean }) {
                 <InputNumber min={1} style={{ width: '100%' }} addonAfter="GB" />
             </Form.Item>
 
-            {/* ── Advanced Settings ── */}
-            <Divider orientation="left" plain>
-                {t('instanceSizes.section_advanced')}
-            </Divider>
-
-            {/* Hugepages: Single Select replacing Switch + text input */}
-            <Form.Item name="hugepages_setting" label={t('instanceSizes.hugepages')}>
-                <Select
-                    options={[
-                        { value: 'none', label: 'None' },
-                        { value: '2Mi', label: '2Mi' },
-                        { value: '1Gi', label: '1Gi' },
-                    ]}
-                    placeholder={t('instanceSizes.hugepages_placeholder')}
-                />
-            </Form.Item>
-
-            <Form.Item name="dedicated_cpu" label={t('instanceSizes.dedicated')} valuePropName="checked">
-                <Switch />
-            </Form.Item>
-
             <Form.Item name="requires_sriov" label={t('instanceSizes.sriov')} valuePropName="checked">
                 <Switch />
             </Form.Item>
 
-            {/* GPU devices: dynamic Form.List */}
-            <Form.Item label={t('instanceSizes.gpu_devices')}>
-                <Form.List name="gpu_devices">
-                    {(fields, { add, remove }) => (
-                        <>
-                            {fields.map((field) => (
-                                <Space key={field.key} style={{ display: 'flex', marginBottom: 8 }} align="baseline">
-                                    <Form.Item
-                                        {...field}
-                                        name={[field.name, 'name']}
-                                        rules={[{ required: true, message: t('instanceSizes.gpu_name_required') }]}
-                                        style={{ margin: 0 }}
-                                    >
-                                        <Input placeholder="gpu1" style={{ width: 120 }} />
-                                    </Form.Item>
-                                    <Form.Item
-                                        {...field}
-                                        name={[field.name, 'deviceName']}
-                                        rules={[{ required: true, message: t('instanceSizes.gpu_device_required') }]}
-                                        style={{ margin: 0 }}
-                                    >
-                                        <Input placeholder="nvidia.com/GA102GL_A10" style={{ width: 280 }} />
-                                    </Form.Item>
-                                    <MinusCircleOutlined
-                                        onClick={() => remove(field.name)}
-                                        style={{ color: '#ff4d4f' }}
-                                    />
-                                </Space>
-                            ))}
-                            <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
-                                {t('instanceSizes.add_gpu')}
-                            </Button>
-                        </>
-                    )}
-                </Form.List>
-            </Form.Item>
+            {/* ── Spec Overrides (Schema-driven, ADR-0023 Stage 1) ── */}
+            <Divider orientation="left" plain>
+                {t('instanceSizes.section_advanced')}
+            </Divider>
 
-            {/* spec_overrides JSON (for advanced/escape-hatch usage) */}
-            <Form.Item
-                name="spec_overrides_text"
-                label={t('instanceSizes.spec_overrides')}
-                extra={t('instanceSizes.spec_overrides_help')}
-            >
-                <Input.TextArea rows={6} style={{ fontFamily: 'monospace', fontSize: 13 }} />
-            </Form.Item>
+            {/*
+             * DynamicSchemaForm renders KubeVirt spec fields driven by the
+             * mask from GET /schemas/instancesize.  This replaces the previous
+             * hardcoded Hugepages Select + GPU Form.List + JSON textarea.
+             *
+             * Data flow:
+             *   spec_text (JSON string in Form) ←→ DynamicSchemaForm
+             *   onValuesChange → formRef.current?.sync() → spec_text updated
+             */}
+            <InstanceSizeSpecSection formRef={formRef} disabled={false} />
 
-            <Form.Item name="enabled" label={t('instanceSizes.enabled')} valuePropName="checked" initialValue={true}>
+            <Form.Item name="enabled" label={t('instanceSizes.enabled')} valuePropName="checked" initialValue={true} style={{ marginTop: 16 }}>
                 <Switch />
             </Form.Item>
         </>
@@ -230,6 +261,11 @@ export function AdminInstanceSizesContent() {
     const { t } = useTranslation(['admin', 'common']);
     const sizes = useAdminInstanceSizesController({ t });
     const searchInputRef = useRef<InputRef>(null);
+
+    // Refs for DynamicSchemaForm imperative sync (antd best practice).
+    // formRef.current?.sync() is called in onValuesChange to update spec_text.
+    const createFormRef = useRef<DynamicSchemaFormHandle>(null);
+    const editFormRef = useRef<DynamicSchemaFormHandle>(null);
 
     const getColumnSearchProps = (dataIndex: keyof InstanceSize): Partial<ColumnsType<InstanceSize>[number]> => ({
         filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters }: FilterDropdownProps) => (
@@ -438,7 +474,7 @@ export function AdminInstanceSizesContent() {
                     </Button>
                     <Button
                         type="primary"
-                        icon={<PlusOutlined />}
+                        icon={<HddOutlined />}
                         data-testid="instance-size-create-button"
                         onClick={sizes.openCreateModal}
                     >
@@ -488,12 +524,21 @@ export function AdminInstanceSizesContent() {
                 onCancel={sizes.closeCreateModal}
                 confirmLoading={sizes.createPending}
                 destroyOnHidden={true}
-                width={680}
+                width={720}
                 data-testid="instance-size-create-modal"
             >
-                    <Form form={sizes.createForm} layout="vertical" preserve={false}>
-                        <InstanceSizeFormFields isCreate={true} />
-                    </Form>
+                <Form
+                    form={sizes.createForm}
+                    layout="vertical"
+                    preserve={false}
+                    onValuesChange={() => {
+                        // antd best practice: side effects in event callbacks, not in render.
+                        // Sync spec_text JSON whenever any dynamic schema field changes.
+                        createFormRef.current?.sync();
+                    }}
+                >
+                    <InstanceSizeFormFields isCreate={true} formRef={createFormRef} />
+                </Form>
             </Modal>
 
             {/* Edit Modal */}
@@ -504,12 +549,19 @@ export function AdminInstanceSizesContent() {
                 onCancel={sizes.closeEditModal}
                 confirmLoading={sizes.updatePending}
                 destroyOnHidden={true}
-                width={680}
+                width={720}
                 data-testid="instance-size-edit-modal"
             >
-                    <Form form={sizes.editForm} layout="vertical" preserve={false}>
-                        <InstanceSizeFormFields isCreate={false} />
-                    </Form>
+                <Form
+                    form={sizes.editForm}
+                    layout="vertical"
+                    preserve={false}
+                    onValuesChange={() => {
+                        editFormRef.current?.sync();
+                    }}
+                >
+                    <InstanceSizeFormFields isCreate={false} formRef={editFormRef} />
+                </Form>
             </Modal>
 
             {/* Delete Modal */}

--- a/web/src/features/admin-instance-sizes/hooks/useAdminInstanceSizesController.test.tsx
+++ b/web/src/features/admin-instance-sizes/hooks/useAdminInstanceSizesController.test.tsx
@@ -73,7 +73,18 @@ describe('useAdminInstanceSizesController', () => {
     });
   });
 
-  it('submits create payload with parsed spec_overrides JSON', async () => {
+  /**
+   * Since ADR-0023 Stage 1, spec fields are driven by DynamicSchemaForm.
+   * The controller receives `spec_text` (JSON string from the form) and
+   * parses it into `spec_overrides` for the API payload.
+   *
+   * spec_text is a raw JSON string produced by DynamicSchemaForm.
+   * Valid object JSON → parsed into spec_overrides.
+   * Invalid / non-object JSON → silently ignored (spec_overrides: undefined).
+   *   This is intentional: DynamicSchemaForm already validates individual fields;
+   *   the controller does not show a toast for malformed spec_text.
+   */
+  it('submits create payload with spec_overrides parsed from spec_text', async () => {
     const createMutate = vi.fn();
     const updateMutate = vi.fn();
     const deleteMutate = vi.fn();
@@ -83,12 +94,13 @@ describe('useAdminInstanceSizesController', () => {
       .mockReturnValueOnce({ mutate: updateMutate, isPending: false });
     useApiActionMock.mockReturnValue({ mutate: deleteMutate, isPending: false });
 
+    // spec_text replaces spec_overrides_text; content is KubeVirt VirtualMachineSpec JSON.
     createFormState.validateFields.mockResolvedValue({
       name: 'm4.large',
       cpu_cores: 4,
       memory_mb: 8192,
       enabled: true,
-      spec_overrides_text: '{"spec":{"template":{"spec":{"domain":{"resources":{"limits":{"memory":"8Gi"}}}}}}}',
+      spec_text: '{"spec":{"template":{"spec":{"domain":{"resources":{"limits":{"memory":"8Gi"}}}}}}}',
     });
 
     const { result } = renderHook(() => useAdminInstanceSizesController({ t }));
@@ -103,8 +115,8 @@ describe('useAdminInstanceSizesController', () => {
       cpu_cores: 4,
       memory_mb: 8192,
       enabled: true,
-      requires_gpu: false,
-      requires_hugepages: false,
+      // requires_gpu / requires_hugepages removed from formToPayload (ADR-0023 Stage 1).
+      // Those fields are now part of spec_overrides (KubeVirt spec), not top-level metadata.
       spec_overrides: {
         spec: {
           template: {
@@ -123,7 +135,16 @@ describe('useAdminInstanceSizesController', () => {
     }));
   });
 
-  it('rejects invalid spec_overrides JSON and does not mutate', async () => {
+  /**
+   * When spec_text is non-object JSON (array, null, primitive), spec_overrides is
+   * silently set to undefined — no error toast is shown.  DynamicSchemaForm handles
+   * field-level validation; the controller trusts its output.
+   *
+   * Contrast with old behaviour: spec_overrides_text triggered a user-facing
+   * error toast for invalid JSON.  That UX belonged to the raw textarea escape-hatch
+   * which has since been removed in favour of schema-driven rendering.
+   */
+  it('ignores non-object spec_text and still calls mutate with spec_overrides undefined', async () => {
     const createMutate = vi.fn();
 
     useApiMutationMock
@@ -135,7 +156,8 @@ describe('useAdminInstanceSizesController', () => {
       name: 'm4.large',
       cpu_cores: 4,
       memory_mb: 8192,
-      spec_overrides_text: '[]',
+      // Array JSON is non-object — controller ignores it silently.
+      spec_text: '[]',
     });
 
     const { result } = renderHook(() => useAdminInstanceSizesController({ t }));
@@ -144,7 +166,12 @@ describe('useAdminInstanceSizesController', () => {
       await result.current.submitCreate();
     });
 
-    expect(createMutate).not.toHaveBeenCalled();
-    expect(messageErrorMock).toHaveBeenCalledWith('instanceSizes.spec_overrides_invalid');
+    // mutate IS called — invalid spec_text does not block submission.
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
+      spec_overrides: undefined,
+    }));
+    // No error toast — DynamicSchemaForm owns field validation, not the controller.
+    expect(messageErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/admin-instance-sizes/hooks/useAdminInstanceSizesController.ts
+++ b/web/src/features/admin-instance-sizes/hooks/useAdminInstanceSizesController.ts
@@ -19,10 +19,6 @@ interface UseAdminInstanceSizesControllerArgs {
     t: TFunction;
 }
 
-interface GpuDevice {
-    name: string;
-    deviceName: string;
-}
 
 interface InstanceSizeFormValues {
     name: string;
@@ -35,64 +31,43 @@ interface InstanceSizeFormValues {
     memory_request_mb?: number;
     cpu_overcommit_enabled?: boolean;
     memory_overcommit_enabled?: boolean;
-    hugepages_setting?: string;
+    // legacy hugepages_setting removed: now driven by DynamicSchemaForm spec_text
     dedicated_cpu?: boolean;
     requires_sriov?: boolean;
-    gpu_devices?: GpuDevice[];
-    spec_overrides_text?: string;
+    /**
+     * spec_text: JSON string produced by DynamicSchemaForm (spec_overrides fields).
+     * Contains spec.template.* keys matching the KubeVirt VirtualMachineSpec schema.
+     * Replaces the previous free-form spec_overrides_text textarea (ADR-0023 Stage 1).
+     */
+    spec_text?: string;
     sort_order?: number;
     enabled?: boolean;
 }
 
-function parseJSONMap(raw: string, onError: () => void): Record<string, unknown> | undefined {
-    const text = raw.trim();
-    if (!text) {
-        return undefined;
-    }
-    try {
-        const parsed = JSON.parse(text) as unknown;
-        if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
-            onError();
-            return undefined;
-        }
-        return parsed as Record<string, unknown>;
-    } catch {
-        onError();
-        return undefined;
-    }
-}
 
 /**
  * Maps UI form values to API request payload.
- * Handles: hugepages_setting → requires_hugepages + hugepages_size,
- *          gpu_devices → requires_gpu + merged into spec_overrides,
- *          overcommit checkboxes → cpu_request / memory_request_mb.
+ * spec_text (produced by DynamicSchemaForm) is parsed into spec_overrides.
+ * Overcommit checkboxes → cpu_request / memory_request_mb.
  */
 function formToPayload(
     values: InstanceSizeFormValues,
-    specOverrides: Record<string, unknown> | undefined,
 ): Omit<InstanceSizeCreateRequest, 'name'> & { name?: string } {
-    const {
-        hugepages_setting,
-        gpu_devices,
-        ...rest
-    } = values;
-
-    // Hugepages mapping
-    const requires_hugepages = !!hugepages_setting && hugepages_setting !== 'none';
-    const hugepages_size = requires_hugepages ? hugepages_setting : undefined;
-
-    // GPU devices mapping
-    const requires_gpu = (gpu_devices?.length ?? 0) > 0;
-    let mergedOverrides = specOverrides;
-    if (requires_gpu && gpu_devices && gpu_devices.length > 0) {
-        mergedOverrides = {
-            ...(mergedOverrides ?? {}),
-            gpus: gpu_devices,
-        };
+    // Parse DynamicSchemaForm spec_text → spec_overrides map
+    let specOverrides: Record<string, unknown> | undefined;
+    if (values.spec_text && values.spec_text.trim() && values.spec_text.trim() !== '{}') {
+        try {
+            const parsed = JSON.parse(values.spec_text) as unknown;
+            if (parsed !== null && !Array.isArray(parsed) && typeof parsed === 'object') {
+                specOverrides = parsed as Record<string, unknown>;
+            }
+        } catch {
+            // Malformed spec_text — ignore, send without spec_overrides
+        }
     }
 
     // If overcommit not enabled, clear the request fields
+    const rest = { ...values };
     if (!values.cpu_overcommit_enabled) {
         rest.cpu_request = undefined;
     }
@@ -100,12 +75,13 @@ function formToPayload(
         rest.memory_request_mb = undefined;
     }
 
+    // Exclude form-only fields from the API payload
+    const { spec_text, cpu_overcommit_enabled, memory_overcommit_enabled, ...apiFields } = rest;
+    void spec_text; void cpu_overcommit_enabled; void memory_overcommit_enabled;
+
     return {
-        ...rest,
-        requires_hugepages,
-        hugepages_size,
-        requires_gpu,
-        spec_overrides: mergedOverrides,
+        ...apiFields,
+        spec_overrides: specOverrides,
     };
 }
 
@@ -194,8 +170,7 @@ export function useAdminInstanceSizesController({ t }: UseAdminInstanceSizesCont
         createForm.setFieldsValue({
             enabled: true,
             sort_order: 0,
-            hugepages_setting: 'none',
-            spec_overrides_text: '{}',
+            spec_text: '{}',
         });
         setCreateOpen(true);
     };
@@ -207,17 +182,6 @@ export function useAdminInstanceSizesController({ t }: UseAdminInstanceSizesCont
             sort_order?: number;
         };
 
-        // Derive hugepages_setting from API fields
-        let hugepages_setting = 'none';
-        if (item.requires_hugepages && item.hugepages_size) {
-            hugepages_setting = item.hugepages_size;
-        }
-
-        // Extract gpu_devices from spec_overrides if present
-        const specOverrides = item.spec_overrides ?? {};
-        const gpuDevices = (specOverrides.gpus as GpuDevice[] | undefined) ?? [];
-        const cleanOverrides = { ...specOverrides };
-        delete cleanOverrides.gpus;
 
         setEditingItem(item);
         editForm.setFieldsValue({
@@ -232,11 +196,10 @@ export function useAdminInstanceSizesController({ t }: UseAdminInstanceSizesCont
             memory_request_mb: hydrated.memory_request_mb,
             cpu_overcommit_enabled: !!hydrated.cpu_request,
             memory_overcommit_enabled: !!hydrated.memory_request_mb,
-            hugepages_setting,
             requires_sriov: item.requires_sriov,
-            gpu_devices: gpuDevices,
             sort_order: hydrated.sort_order,
-            spec_overrides_text: JSON.stringify(cleanOverrides, null, 2),
+            // spec_text: DynamicSchemaForm will parse this JSON string on mount
+            spec_text: JSON.stringify(item.spec_overrides ?? {}, null, 2),
             enabled: item.enabled,
         });
         setEditOpen(true);
@@ -249,13 +212,7 @@ export function useAdminInstanceSizesController({ t }: UseAdminInstanceSizesCont
 
     const submitCreate = async () => {
         const values = await createForm.validateFields();
-        const specOverrides = parseJSONMap(values.spec_overrides_text ?? '', () => {
-            messageApi.error(t('instanceSizes.spec_overrides_invalid'));
-        });
-        if (values.spec_overrides_text && values.spec_overrides_text.trim() && !specOverrides) {
-            return;
-        }
-        const payload = formToPayload(values, specOverrides);
+        const payload = formToPayload(values);
         createMutation.mutate(payload as InstanceSizeCreateRequest);
     };
 
@@ -264,13 +221,7 @@ export function useAdminInstanceSizesController({ t }: UseAdminInstanceSizesCont
             return;
         }
         const values = await editForm.validateFields();
-        const specOverrides = parseJSONMap(values.spec_overrides_text ?? '', () => {
-            messageApi.error(t('instanceSizes.spec_overrides_invalid'));
-        });
-        if (values.spec_overrides_text && values.spec_overrides_text.trim() && !specOverrides) {
-            return;
-        }
-        const payload = formToPayload(values, specOverrides);
+        const payload = formToPayload(values);
         updateMutation.mutate({
             id: editingItem.id,
             body: payload as InstanceSizeUpdateRequest,

--- a/web/src/features/admin-templates/components/AdminTemplatesContent.tsx
+++ b/web/src/features/admin-templates/components/AdminTemplatesContent.tsx
@@ -4,10 +4,12 @@ import { useRef } from 'react';
 import {
     Button,
     Card,
+    Divider,
     Empty,
     Form,
     Input,
     Modal,
+    Radio,
     Space,
     Switch,
     Table,
@@ -55,7 +57,7 @@ function highlightText(text: string, highlight: string): React.ReactNode {
 }
 
 export function AdminTemplatesContent() {
-    const { t } = useTranslation(['admin', 'common']);
+    const { t } = useTranslation(['admin', 'common', 'error']);
     const templates = useAdminTemplatesController({ t });
     const searchInputRef = useRef<InputRef>(null);
 
@@ -289,6 +291,7 @@ export function AdminTemplatesContent() {
                 </div>
             </Card>
 
+            {/* ── Create Modal (master-flow Step 3) ── */}
             <Modal
                 title={t('common:button.add')}
                 open={templates.createOpen}
@@ -296,37 +299,83 @@ export function AdminTemplatesContent() {
                 onCancel={templates.closeCreateModal}
                 confirmLoading={templates.createPending}
                 destroyOnHidden={true}
+                width={640}
                 data-testid="template-create-modal"
             >
-                    <Form form={templates.createForm} layout="vertical" preserve={false}>
-                        <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="display_name" label={t('common:table.display_name')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="os_family" label={t('templates.os_family')}>
-                            <Input placeholder={t('templates.os_family_placeholder')} />
-                        </Form.Item>
-                        <Form.Item name="os_version" label={t('templates.os_version')}>
-                            <Input placeholder={t('templates.os_version_placeholder')} />
-                        </Form.Item>
-                        <Form.Item name="description" label={t('common:table.description')}>
-                            <Input.TextArea rows={3} />
-                        </Form.Item>
-                        <Form.Item
-                            name="spec_text"
-                            label={t('templates.spec')}
-                            extra={t('templates.spec_help')}
-                        >
-                            <Input.TextArea rows={10} style={{ fontFamily: 'monospace' }} />
-                        </Form.Item>
-                        <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked" initialValue={true}>
-                            <Switch />
-                        </Form.Item>
-                    </Form>
+                <Form form={templates.createForm} layout="vertical" preserve={false}>
+                    <Form.Item name="name" label={t('common:table.name')} rules={[{ required: true }]}>
+                        <Input placeholder="centos7-standard" />
+                    </Form.Item>
+                    <Form.Item name="display_name" label={t('common:table.display_name')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="os_family" label={t('templates.os_family')}>
+                        <Input placeholder={t('templates.os_family_placeholder')} />
+                    </Form.Item>
+                    <Form.Item name="os_version" label={t('templates.os_version')}>
+                        <Input placeholder={t('templates.os_version_placeholder')} />
+                    </Form.Item>
+                    <Form.Item name="description" label={t('common:table.description')}>
+                        <Input.TextArea rows={3} />
+                    </Form.Item>
+
+                    {/* Image Source — master-flow Step 3: containerdisk vs pvc toggle */}
+                    <Divider orientation="left" plain>{t('templates.image_source')}</Divider>
+                    <Form.Item name="source_type" label={t('templates.source_type')} initialValue="image">
+                        <Radio.Group>
+                            <Radio value="image">{t('templates.source_containerdisk')}</Radio>
+                            <Radio value="pvc">{t('templates.source_pvc')}</Radio>
+                        </Radio.Group>
+                    </Form.Item>
+                    <Form.Item noStyle shouldUpdate={(prev, cur) => prev.source_type !== cur.source_type}>
+                        {({ getFieldValue }) =>
+                            getFieldValue('source_type') === 'pvc' ? (
+                                <>
+                                    <Form.Item
+                                        name="pvc_namespace"
+                                        label={t('templates.pvc_namespace')}
+                                        rules={[{ required: true, message: t('templates.pvc_namespace_required') }]}
+                                        extra={t('templates.pvc_namespace_help')}
+                                    >
+                                        <Input placeholder="default" />
+                                    </Form.Item>
+                                    <Form.Item
+                                        name="pvc_name"
+                                        label={t('templates.pvc_name')}
+                                        rules={[{ required: true, message: t('templates.pvc_name_required') }]}
+                                        extra={t('templates.pvc_name_help')}
+                                    >
+                                        <Input placeholder="centos7-base-disk" />
+                                    </Form.Item>
+                                </>
+                            ) : (
+                                <Form.Item name="image_url" label={t('templates.image_url')} rules={[{ required: true }]}>
+                                    <Input placeholder="docker.io/kubevirt/centos:7" />
+                                </Form.Item>
+                            )
+                        }
+                    </Form.Item>
+
+                    {/* cloud-init config — master-flow Step 3: YAML text, NOT JSON spec */}
+                    <Divider orientation="left" plain>{t('templates.cloud_init')}</Divider>
+                    <Form.Item
+                        name="cloud_init"
+                        extra={t('templates.cloud_init_help', 'YAML cloud-init configuration. Provides one-time password and initial OS setup.')}
+                    >
+                        <Input.TextArea
+                            rows={8}
+                            style={{ fontFamily: 'monospace', fontSize: 13 }}
+                            placeholder={'#cloud-config\nusers:\n  - name: admin\n    sudo: ALL=(ALL) NOPASSWD:ALL\nchpasswd:\n  expire: true\n  users:\n    - name: admin\n      password: changeme123'}
+                        />
+                    </Form.Item>
+
+                    <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked" initialValue={true}>
+                        <Switch />
+                    </Form.Item>
+                </Form>
             </Modal>
 
+            {/* ── Edit Modal (master-flow Step 3) ── */}
             <Modal
                 title={t('common:button.edit')}
                 open={templates.editOpen}
@@ -334,32 +383,77 @@ export function AdminTemplatesContent() {
                 onCancel={templates.closeEditModal}
                 confirmLoading={templates.updatePending}
                 destroyOnHidden={true}
+                width={640}
                 data-testid="template-edit-modal"
             >
-                    <Form form={templates.editForm} layout="vertical" preserve={false}>
-                        <Form.Item name="display_name" label={t('common:table.display_name')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="os_family" label={t('templates.os_family')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="os_version" label={t('templates.os_version')}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item name="description" label={t('common:table.description')}>
-                            <Input.TextArea rows={3} />
-                        </Form.Item>
-                        <Form.Item
-                            name="spec_text"
-                            label={t('templates.spec')}
-                            extra={t('templates.spec_help')}
-                        >
-                            <Input.TextArea rows={10} style={{ fontFamily: 'monospace' }} />
-                        </Form.Item>
-                        <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked">
-                            <Switch />
-                        </Form.Item>
-                    </Form>
+                <Form form={templates.editForm} layout="vertical" preserve={false}>
+                    <Form.Item name="display_name" label={t('common:table.display_name')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="os_family" label={t('templates.os_family')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="os_version" label={t('templates.os_version')}>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item name="description" label={t('common:table.description')}>
+                        <Input.TextArea rows={3} />
+                    </Form.Item>
+
+                    {/* Image Source toggle */}
+                    <Divider orientation="left" plain>{t('templates.image_source')}</Divider>
+                    <Form.Item name="source_type" label={t('templates.source_type')}>
+                        <Radio.Group>
+                            <Radio value="image">{t('templates.source_containerdisk')}</Radio>
+                            <Radio value="pvc">{t('templates.source_pvc')}</Radio>
+                        </Radio.Group>
+                    </Form.Item>
+                    <Form.Item noStyle shouldUpdate={(prev, cur) => prev.source_type !== cur.source_type}>
+                        {({ getFieldValue }) =>
+                            getFieldValue('source_type') === 'pvc' ? (
+                                <>
+                                    <Form.Item
+                                        name="pvc_namespace"
+                                        label={t('templates.pvc_namespace')}
+                                        rules={[{ required: true, message: t('templates.pvc_namespace_required') }]}
+                                        extra={t('templates.pvc_namespace_help')}
+                                    >
+                                        <Input placeholder="default" />
+                                    </Form.Item>
+                                    <Form.Item
+                                        name="pvc_name"
+                                        label={t('templates.pvc_name')}
+                                        rules={[{ required: true, message: t('templates.pvc_name_required') }]}
+                                        extra={t('templates.pvc_name_help')}
+                                    >
+                                        <Input placeholder="centos7-base-disk" />
+                                    </Form.Item>
+                                </>
+                            ) : (
+                                <Form.Item name="image_url" label={t('templates.image_url')}>
+                                    <Input placeholder="docker.io/kubevirt/centos:7" />
+                                </Form.Item>
+                            )
+                        }
+                    </Form.Item>
+
+                    {/* cloud-init YAML editor */}
+                    <Divider orientation="left" plain>{t('templates.cloud_init')}</Divider>
+                    <Form.Item
+                        name="cloud_init"
+                        extra={t('templates.cloud_init_help', 'YAML cloud-init configuration. Provides one-time password and initial OS setup.')}
+                    >
+                        <Input.TextArea
+                            rows={8}
+                            style={{ fontFamily: 'monospace', fontSize: 13 }}
+                            placeholder={'#cloud-config\nusers:\n  - name: admin'}
+                        />
+                    </Form.Item>
+
+                    <Form.Item name="enabled" label={t('templates.enabled')} valuePropName="checked">
+                        <Switch />
+                    </Form.Item>
+                </Form>
             </Modal>
 
             <Modal

--- a/web/src/features/admin-templates/components/DynamicSchemaForm.tsx
+++ b/web/src/features/admin-templates/components/DynamicSchemaForm.tsx
@@ -1,0 +1,474 @@
+import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'react';
+import {
+    Alert,
+    Button,
+    Card,
+    Checkbox,
+    Collapse,
+    Form,
+    Input,
+    InputNumber,
+    Select,
+    Space,
+    Typography,
+} from 'antd';
+import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+
+const { Text } = Typography;
+
+// ─── Shared Types ────────────────────────────────────────────────────────────
+// These types are co-located because DynamicSchemaForm owns the rendering contract.
+// Consumers (hooks, parent components) import from this file.
+
+export interface MaskField {
+    path: string;
+    display_name: string;
+}
+
+export interface SchemaMask {
+    quick_fields: MaskField[];
+    advanced_fields?: MaskField[];
+}
+
+export interface SchemaNode {
+    type?: string;
+    properties?: Record<string, SchemaNode>;
+    items?: SchemaNode;
+    enum?: (string | number)[];
+    [key: string]: unknown;
+}
+
+export interface DynamicSchemaFormProps {
+    /** JSON string stored in the outer Form field (spec_text). Injected by Form.Item. */
+    value?: string;
+    /** Callback to notify outer Form.Item of new JSON string. Injected by Form.Item. */
+    onChange?: (value: string) => void;
+    /** Standard OpenAPI JSON Schema format providing field types and constraints. */
+    schema: SchemaNode;
+    /** UI projection — defines which paths to expose and how to label them. */
+    mask: SchemaMask;
+    disabled?: boolean;
+}
+
+/**
+ * Imperative handle exposed via ref so parent Form.onValuesChange can trigger
+ * serialization without any render-phase side effects.
+ *
+ * Usage in parent:
+ *   const formRef = useRef<DynamicSchemaFormHandle>(null);
+ *   <Form onValuesChange={() => formRef.current?.sync()}>
+ *     <Form.Item name="spec_text"><DynamicSchemaForm ref={formRef} ... /></Form.Item>
+ *   </Form>
+ */
+export interface DynamicSchemaFormHandle {
+    /** Serialize current dynamic field values → spec_text JSON string. */
+    sync: () => void;
+}
+
+// ─── Spec Overrides Serialisation ─────────────────────────────────────────────
+
+/**
+ * Flattens a nested object produced by Ant Design Form into flat dot-notation keys.
+ *
+ * master-flow.md §Stage 3 Step 4 defines spec_overrides as flat dot-notation keys:
+ *   { "spec.template.spec.domain.cpu.dedicatedCpuPlacement": true }
+ *
+ * Ant Design Form.Item with namePath=["spec","template","..."] stores values as nested:
+ *   { spec: { template: { spec: { domain: { cpu: { dedicatedCpuPlacement: true } } } } } }
+ *
+ * This function converts the nested Ant Design representation back to the flat format
+ * required by the backend spec_overrides validator and the database JSONB storage.
+ *
+ * Arrays are preserved as-is (not flattened) because spec_overrides array values
+ * (e.g., GPU device lists) represent entire resource lists that must remain intact.
+ */
+function flattenToSpecOverrides(
+    obj: Record<string, unknown>,
+    prefix = '',
+    result: Record<string, unknown> = {},
+): Record<string, unknown> {
+    for (const [key, value] of Object.entries(obj)) {
+        const fullKey = prefix ? `${prefix}.${key}` : key;
+        if (
+            value !== null &&
+            value !== undefined &&
+            typeof value === 'object' &&
+            !Array.isArray(value)
+        ) {
+            // Recurse into nested plain objects.
+            flattenToSpecOverrides(value as Record<string, unknown>, fullKey, result);
+        } else if (value !== null && value !== undefined) {
+            // Leaf value (primitive, array, etc.) — emit as flat key.
+            result[fullKey] = value;
+        }
+        // Skip null/undefined values — those represent unset form fields.
+    }
+    return result;
+}
+
+// ─── Schema Path Resolution ───────────────────────────────────────────────────
+
+/**
+ * Deeply resolves a dot-notation path against a standard JSON Object Schema.
+ * Returns null for invalid paths (caller must handle gracefully — no throwing).
+ * Stage 1 design: "Invalid mask paths must fail validation before deployment."
+ * At runtime we degrade rather than crash.
+ */
+const resolveSchemaNode = (schema: SchemaNode, path: string): SchemaNode | null => {
+    if (!schema) return null;
+    const parts = path.split('.');
+    let current: SchemaNode = schema;
+    for (const part of parts) {
+        if (current?.properties?.[part]) {
+            current = current.properties[part];
+        } else if (current?.items?.properties?.[part]) {
+            // Allow one level of array traversal for UI mask paths.
+            current = current.items.properties[part];
+        } else {
+            return null; // Path not found — caller renders a degraded placeholder.
+        }
+    }
+    return current;
+};
+
+// ─── Field Renderers ──────────────────────────────────────────────────────────
+
+interface DynamicFieldGroupProps {
+    node: SchemaNode;
+    namePath: (string | number)[];
+    label: string;
+    disabled?: boolean;
+}
+
+/**
+ * Pure rendering component — renders a single schema node as the appropriate
+ * Ant Design form control.  No Form instance is created here; this component
+ * lives inside the outer Form provided by the parent page.
+ *
+ * Mapping per master-flow.md Stage 1:
+ *   array   → dynamic add/remove list  (Form.List)
+ *   enum    → dropdown                 (Select, options from schema)
+ *   integer → numeric input            (InputNumber)
+ *   boolean → toggle                   (Switch)
+ *   string  → text input               (Input)   [default]
+ */
+const DynamicFieldGroup: React.FC<DynamicFieldGroupProps> = ({
+    node,
+    namePath,
+    label,
+    disabled,
+}) => {
+    const { t } = useTranslation(['admin', 'common']);
+
+    if (!node) return null;
+
+    // array → dynamic add/remove table
+    if (node.type === 'array' && node.items?.properties) {
+        const itemKeys = Object.keys(node.items.properties);
+        return (
+            <Card size="small" title={<Text strong>{label}</Text>} style={{ marginBottom: 16 }}>
+                <Form.List name={namePath}>
+                    {(fields, { add, remove }) => (
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                            {fields.map((field) => (
+                                <Space
+                                    key={field.key}
+                                    style={{ display: 'flex', marginBottom: 8, alignItems: 'flex-start' }}
+                                    align="baseline"
+                                >
+                                    <div
+                                        style={{
+                                            flex: 1,
+                                            padding: 8,
+                                            border: '1px solid #f0f0f0',
+                                            borderRadius: 4,
+                                        }}
+                                    >
+                                        {itemKeys.map((itemKey) => {
+                                            const subNode = node.items!.properties![itemKey];
+                                            return (
+                                                <DynamicFieldGroup
+                                                    key={itemKey}
+                                                    node={subNode}
+                                                    namePath={[field.name, itemKey]}
+                                                    label={itemKey}
+                                                    disabled={disabled}
+                                                />
+                                            );
+                                        })}
+                                    </div>
+                                    <Button
+                                        type="text"
+                                        danger
+                                        icon={<MinusCircleOutlined />}
+                                        onClick={() => remove(field.name)}
+                                        disabled={disabled}
+                                    />
+                                </Space>
+                            ))}
+                            {!disabled && (
+                                <Button
+                                    type="dashed"
+                                    onClick={() => add()}
+                                    block
+                                    icon={<PlusOutlined />}
+                                >
+                                    {t('dynamic_form.add_item', { label })}
+                                </Button>
+                            )}
+                        </div>
+                    )}
+                </Form.List>
+            </Card>
+        );
+    }
+
+    // enum → dropdown (options from schema, not developer-defined — Stage 1 constraint)
+    if (node.enum && Array.isArray(node.enum)) {
+        return (
+            <Form.Item label={label} name={namePath} style={{ marginBottom: 8 }}>
+                <Select
+                    disabled={disabled}
+                    data-testid={`dynamic-form-${namePath.join('.')}`}
+                >
+                    {node.enum.map((opt: string | number) => (
+                        <Select.Option key={String(opt)} value={opt}>
+                            {String(opt)}
+                        </Select.Option>
+                    ))}
+                </Select>
+            </Form.Item>
+        );
+    }
+
+    // integer/number → numeric input
+    // boolean → checkbox  (master-flow.md:167: "boolean → checkbox")
+    // string (default) → text input
+    return (
+        <Form.Item
+            label={label}
+            name={namePath}
+            valuePropName={node.type === 'boolean' ? 'checked' : 'value'}
+            style={{ marginBottom: 8 }}
+        >
+            {node.type === 'integer' || node.type === 'number' ? (
+                <InputNumber
+                    style={{ width: '100%' }}
+                    disabled={disabled}
+                    data-testid={`dynamic-form-${namePath.join('.')}`}
+                />
+            ) : node.type === 'boolean' ? (
+                // master-flow.md Stage 1: "boolean → checkbox" (not Switch).
+                // Checkbox communicates a binary on/off choice matching spec field semantics.
+                <Checkbox
+                    disabled={disabled}
+                    data-testid={`dynamic-form-${namePath.join('.')}`}
+                >
+                    {label}
+                </Checkbox>
+            ) : (
+                <Input
+                    disabled={disabled}
+                    data-testid={`dynamic-form-${namePath.join('.')}`}
+                />
+            )}
+        </Form.Item>
+    );
+};
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+/**
+ * DynamicSchemaForm — Schema-driven form widget, designed as an Ant Design
+ * custom Form control.
+ *
+ * ARCHITECTURE NOTE:
+ * This component does NOT create its own Form instance.  It renders Form.Item /
+ * Form.List elements that attach directly to the *outer* Form provided by the
+ * parent page (create modal / edit modal).  This is the correct Ant Design
+ * custom-control pattern: value + onChange are injected by Form.Item; all field
+ * values live in the single outer FormStore and are available when the parent
+ * calls form.validateFields() or form.getFieldsValue().
+ *
+ * Data flow:
+ *   outer Form field "spec_text" (JSON string)
+ *     → value prop   → parsed → form.setFieldsValue() on mount/update
+ *     ← onChange     ← JSON.stringify(allFields)   ← outer Form onValuesChange
+ *
+ * The parent MUST wrap this component in a <Form.Item name="spec_text"> with
+ * valuePropName="value" so that Ant Design's FormStore injects value/onChange.
+ */
+export const DynamicSchemaForm = React.forwardRef<DynamicSchemaFormHandle, DynamicSchemaFormProps>(
+    function DynamicSchemaForm(
+        {
+            value,
+            onChange,
+            schema,
+            mask,
+            disabled,
+        },
+        ref
+    ) {
+        const { t } = useTranslation(['admin', 'common']);
+        const outerForm = Form.useFormInstance();
+        const isInitializedRef = useRef(false);
+        const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+        // Initialise outer form fields from the JSON string value on first render
+        // or when the modal opens with a different record.
+        // NOTE: hooks must be called unconditionally (React rules-of-hooks).
+        // The guard check for !schema || !mask happens after all hooks.
+        useEffect(() => {
+            if (!outerForm || !schema || !mask) return;
+            isInitializedRef.current = false; // reset on value change (modal re-open)
+            if (!value) {
+                // Nothing to pre-fill; leave fields at their defaults.
+                isInitializedRef.current = true;
+                return;
+            }
+            try {
+                const parsed = JSON.parse(value) as Record<string, unknown>;
+                // setFieldsValue merges — it does not reset unrelated fields.
+                outerForm.setFieldsValue(parsed);
+            } catch {
+                // Malformed stored value — log and continue with empty fields.
+                console.warn('DynamicSchemaForm: failed to parse stored value:', value);
+            }
+            isInitializedRef.current = true;
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [value]);
+
+        // Sync outer Form values back to the JSON string.
+        // Called imperatively via ref.sync() — invoked by the parent Form's
+        // onValuesChange callback, NOT during render (React best practice).
+        //
+        // Antd docs: shouldUpdate is for conditional rendering only.
+        // Side effects (data sync) belong in event callbacks (onValuesChange).
+        //
+        // IMPORTANT — spec_overrides serialisation format:
+        // master-flow.md §Stage 3 Step 4 specifies spec_overrides as flat dot-notation keys:
+        //   { "spec.template.spec.domain.cpu.dedicatedCpuPlacement": true }
+        // NOT nested objects:
+        //   { "spec": { "template": { ... } } }
+        //
+        // Ant Design Form stores field values under nested keys when the namePath is an array
+        // (e.g., name={["spec", "template", "spec", "domain", "cpu", "dedicatedCpuPlacement"]}).
+        // We MUST flatten back to dot-notation before emitting onChange so the backend
+        // validator (HasDedicatedCPUInSpecOverrides) receives the expected format.
+        const syncToParent = useCallback(() => {
+            if (!outerForm || !onChange || !schema) return;
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+            debounceRef.current = setTimeout(() => {
+                const allValues = outerForm.getFieldsValue(true) as Record<string, unknown>;
+                // Strip non-spec fields (display_name, os_family, etc.) so we only
+                // serialise the dynamic spec fields.  The spec fields are those
+                // whose top-level keys map to schema.properties keys.
+                const specKeys = Object.keys(schema.properties ?? {});
+                const nestedSpecValues: Record<string, unknown> = {};
+                for (const k of specKeys) {
+                    if (k in allValues) nestedSpecValues[k] = allValues[k];
+                }
+                // Flatten nested Ant Design Form values → flat dot-notation spec_overrides.
+                // This converts { spec: { template: { spec: { domain: { cpu: { dedicatedCpuPlacement: true } } } } } }
+                // back to { "spec.template.spec.domain.cpu.dedicatedCpuPlacement": true }
+                // as required by master-flow.md §Stage 3 Step 4 and the backend validator.
+                const flatSpecOverrides = flattenToSpecOverrides(nestedSpecValues);
+                onChange(JSON.stringify(flatSpecOverrides, null, 2));
+            }, 300);
+        }, [outerForm, onChange, schema]);
+
+        // Expose sync() imperatively so the parent Form's onValuesChange can call it.
+        // This is the Ant Design recommended pattern: side effects in event handlers,
+        // not in render. ref.sync() is called from outside; no render-phase side effects.
+        useImperativeHandle(ref, () => ({ sync: syncToParent }), [syncToParent]);
+
+        // Guard: render a hard error if required props are missing.
+        // This is a developer error — schema and mask must always be provided.
+        // IMPORTANT: placed AFTER all hooks to comply with react-hooks/rules-of-hooks.
+        if (!schema || !mask) {
+            return (
+                <Alert
+                    type="error"
+                    banner
+                    message="Frontend Standard Violation: DynamicSchemaForm rendered without schema or mask."
+                />
+            );
+        }
+
+        // ── Mask field rendering ──────────────────────────────────────────────────
+
+        /**
+         * Render mask fields.  Invalid paths degrade to a warning Alert rather than
+         * throwing — consistent with the Stage 1 principle that runtime mask path
+         * errors should never crash the UI.
+         */
+        const renderMaskElements = (fields: MaskField[]) => {
+            return fields.map((field) => {
+                const node = resolveSchemaNode(schema, field.path);
+                if (!node) {
+                    // Stage 1 degradation: warn, do not crash.
+                    return (
+                        <Alert
+                            key={field.path}
+                            type="warning"
+                            showIcon
+                            message={t('dynamic_form.invalid_path', {
+                                path: field.path,
+                                defaultValue: `Field path not found in schema: ${field.path}`,
+                            })}
+                            style={{ marginBottom: 8 }}
+                        />
+                    );
+                }
+                const namePath = field.path.split('.');
+                return (
+                    <DynamicFieldGroup
+                        key={field.path}
+                        node={node}
+                        namePath={namePath}
+                        label={field.display_name}
+                        disabled={disabled}
+                    />
+                );
+            });
+        };
+
+        return (
+            <Card
+                size="small"
+                title={t('templates.spec')}
+                bodyStyle={{ padding: '16px 8px' }}
+            >
+                {/*
+                 * No shouldUpdate side-effect hack here.
+                 * sync() is called by the parent Form's onValuesChange via ref.
+                 * This follows Ant Design's recommended pattern:
+                 *   - shouldUpdate: conditional rendering only
+                 *   - onValuesChange: data synchronization (side effects)
+                 */}
+                {mask.quick_fields && mask.quick_fields.length > 0 && (
+                    <div className="quick-fields-section">
+                        {renderMaskElements(mask.quick_fields)}
+                    </div>
+                )}
+
+                {mask.advanced_fields && mask.advanced_fields.length > 0 && (
+                    <Collapse
+                        ghost
+                        items={[
+                            {
+                                key: 'advanced',
+                                label: t('dynamic_form.advanced_settings', 'Advanced Settings'),
+                                children: renderMaskElements(mask.advanced_fields),
+                            },
+                        ]}
+                        style={{ marginTop: 16 }}
+                    />
+                )}
+            </Card>
+        );
+    }
+);
+
+DynamicSchemaForm.displayName = 'DynamicSchemaForm';

--- a/web/src/features/admin-templates/hooks/useAdminTemplatesController.test.tsx
+++ b/web/src/features/admin-templates/hooks/useAdminTemplatesController.test.tsx
@@ -73,7 +73,12 @@ describe('useAdminTemplatesController', () => {
     });
   });
 
-  it('submits create payload with parsed spec JSON', async () => {
+  /**
+   * master-flow Step 3: Template create submits cloud_init as-is (YAML text, NOT JSON).
+   * cloud_init is a first-class Template field edited directly by the admin.
+   * No JSON parsing, no spec_text intermediary.
+   */
+  it('submits create payload with cloud_init YAML directly', async () => {
     const createMutate = vi.fn();
     const updateMutate = vi.fn();
     const deleteMutate = vi.fn();
@@ -83,11 +88,14 @@ describe('useAdminTemplatesController', () => {
       .mockReturnValueOnce({ mutate: updateMutate, isPending: false });
     useApiActionMock.mockReturnValue({ mutate: deleteMutate, isPending: false });
 
+    const yamlCloudInit = '#cloud-config\nusers:\n  - name: admin\n    sudo: ALL=(ALL) NOPASSWD:ALL';
     createFormState.validateFields.mockResolvedValue({
       name: 'ubuntu-base',
       display_name: 'Ubuntu Base',
       enabled: true,
-      spec_text: '{"domain":{"cpu":{"cores":4}}}',
+      source_type: 'image',
+      image_url: 'docker.io/kubevirt/ubuntu:22.04',
+      cloud_init: yamlCloudInit,
     });
 
     const { result } = renderHook(() => useAdminTemplatesController({ t }));
@@ -96,14 +104,21 @@ describe('useAdminTemplatesController', () => {
       await result.current.submitCreate();
     });
 
+    // cloud_init is passed verbatim — it is YAML text, not parsed JSON.
+    // source_type='image' → pvc_name and pvc_namespace are cleared (undefined).
     expect(createMutate).toHaveBeenCalledWith({
       name: 'ubuntu-base',
       display_name: 'Ubuntu Base',
       enabled: true,
+      source_type: 'image',
+      image_url: 'docker.io/kubevirt/ubuntu:22.04',
+      cloud_init: yamlCloudInit,
+      pvc_name: undefined,
+      pvc_namespace: undefined,
     });
   });
 
-  it('rejects invalid create spec JSON and does not mutate', async () => {
+  it('clears image_url when source_type is pvc', async () => {
     const createMutate = vi.fn();
 
     useApiMutationMock
@@ -112,8 +127,12 @@ describe('useAdminTemplatesController', () => {
     useApiActionMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
 
     createFormState.validateFields.mockResolvedValue({
-      name: 'ubuntu-base',
-      spec_text: '[]',
+      name: 'centos7-pvc',
+      enabled: true,
+      source_type: 'pvc',
+      pvc_name: 'centos7-base-disk',
+      pvc_namespace: 'default',
+      image_url: 'docker.io/stale/image',  // stale value that should be cleared
     });
 
     const { result } = renderHook(() => useAdminTemplatesController({ t }));
@@ -122,7 +141,9 @@ describe('useAdminTemplatesController', () => {
       await result.current.submitCreate();
     });
 
-    expect(createMutate).not.toHaveBeenCalled();
-    expect(messageErrorMock).toHaveBeenCalledWith('templates.spec_invalid');
+    // source_type='pvc' → image_url is cleared (undefined); pvc_namespace is preserved.
+    expect(createMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ source_type: 'pvc', pvc_name: 'centos7-base-disk', pvc_namespace: 'default', image_url: undefined }),
+    );
   });
 });

--- a/web/src/features/admin-templates/hooks/useAdminTemplatesController.ts
+++ b/web/src/features/admin-templates/hooks/useAdminTemplatesController.ts
@@ -13,31 +13,22 @@ interface UseAdminTemplatesControllerArgs {
     t: TFunction;
 }
 
-interface TemplateCreateFormValues extends TemplateCreateRequest {
-    spec_text?: string;
-}
+/**
+ * master-flow Step 3: Configure Template
+ *
+ * Template fields per design:
+ *   - name, display_name, description, os_family, os_version, enabled
+ *   - source_type: 'image' (containerdisk) | 'pvc'
+ *   - image_url: ContainerDisk image URL (when source_type='image')
+ *   - pvc_name:  DataVolume/PVC name    (when source_type='pvc')
+ *   - cloud_init: YAML cloud-init config (admin-editable plain text, NOT JSON)
+ *
+ * cloud_init is a first-class Template field — it is a plain YAML string stored
+ * verbatim. The admin edits it directly in a monospace textarea. There is no
+ * JSON spec or DynamicSchemaForm on the Template page (that belongs to InstanceSize,
+ * Step 4, via spec_overrides).
+ */
 
-interface TemplateEditFormValues extends TemplateUpdateRequest {
-    spec_text?: string;
-}
-
-function parseJSONMap(raw: string, onError: () => void): Record<string, unknown> | undefined {
-    const text = raw.trim();
-    if (!text) {
-        return undefined;
-    }
-    try {
-        const parsed = JSON.parse(text) as unknown;
-        if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
-            onError();
-            return undefined;
-        }
-        return parsed as Record<string, unknown>;
-    } catch {
-        onError();
-        return undefined;
-    }
-}
 
 export function useAdminTemplatesController({ t }: UseAdminTemplatesControllerArgs) {
     const [messageApi, messageContextHolder] = message.useMessage();
@@ -55,8 +46,8 @@ export function useAdminTemplatesController({ t }: UseAdminTemplatesControllerAr
     const [searchedColumn, setSearchedColumn] = useState('');
     const [searchText, setSearchText] = useState('');
 
-    const [createForm] = Form.useForm<TemplateCreateFormValues>();
-    const [editForm] = Form.useForm<TemplateEditFormValues>();
+    const [createForm] = Form.useForm<TemplateCreateRequest>();
+    const [editForm] = Form.useForm<TemplateUpdateRequest>();
 
     const templatesQuery = useApiGet<TemplateList>(
         ['admin-templates', page],
@@ -136,13 +127,12 @@ export function useAdminTemplatesController({ t }: UseAdminTemplatesControllerAr
         createForm.resetFields();
         createForm.setFieldsValue({
             enabled: true,
-            spec_text: '{}',
+            source_type: 'image', // default to containerdisk mode per master-flow Step 3
         });
         setCreateOpen(true);
     };
 
     const openEditModal = (template: Template) => {
-        const hydrated = template as Template & { spec?: Record<string, unknown> };
         setEditingTemplate(template);
         editForm.setFieldsValue({
             display_name: template.display_name,
@@ -150,7 +140,15 @@ export function useAdminTemplatesController({ t }: UseAdminTemplatesControllerAr
             os_family: template.os_family,
             os_version: template.os_version,
             enabled: template.enabled,
-            spec_text: JSON.stringify(hydrated.spec ?? {}, null, 2),
+            source_type: template.source_type,
+            image_url: template.image_url,
+            pvc_name: template.pvc_name,
+            // pvc_namespace: must be populated so the required validation passes
+            // when editing an existing PVC-type template (master-flow Step 3).
+            pvc_namespace: template.pvc_namespace,
+            // cloud_init is the YAML cloud-init config (plain text, not JSON).
+            // master-flow Step 3: admin can freely edit this YAML text.
+            cloud_init: template.cloud_init,
         });
         setEditOpen(true);
     };
@@ -160,41 +158,41 @@ export function useAdminTemplatesController({ t }: UseAdminTemplatesControllerAr
         setDeleteOpen(true);
     };
 
+    /**
+     * Submit create: pass form values directly to the API.
+     *
+     * cloud_init is submitted as-is (YAML string). The source_type toggle
+     * determines which of image_url / pvc_name is relevant — clear the other
+     * to avoid sending stale data.
+     *
+     * master-flow Step 3: no spec JSON processing here. cloud_init is YAML.
+     */
     const submitCreate = async () => {
-        const values = await createForm.validateFields();
-        const spec = parseJSONMap(values.spec_text ?? '', () => {
-            messageApi.error(t('templates.spec_invalid'));
-        });
-        if (values.spec_text && !spec) {
-            return;
-        }
-        const { spec_text, ...payloadWithoutSpecText } = values;
-        void spec_text;
-        const payload: TemplateCreateRequest = { ...payloadWithoutSpecText };
+        const values = await createForm.validateFields() as TemplateCreateRequest;
+        const payload: TemplateCreateRequest = { ...values };
         if (payload.source_type === 'image') {
+            // Clear PVC fields so stale values are not sent to the API.
             payload.pvc_name = undefined;
+            payload.pvc_namespace = undefined;
         } else if (payload.source_type === 'pvc') {
             payload.image_url = undefined;
         }
         createMutation.mutate(payload);
     };
 
+    /**
+     * Submit edit: same as create, cloud_init passed verbatim.
+     */
     const submitEdit = async () => {
         if (!editingTemplate) {
             return;
         }
-        const values = await editForm.validateFields();
-        const spec = parseJSONMap(values.spec_text ?? '', () => {
-            messageApi.error(t('templates.spec_invalid'));
-        });
-        if (values.spec_text && !spec) {
-            return;
-        }
-        const { spec_text, ...payloadWithoutSpecText } = values;
-        void spec_text;
-        const payload: TemplateUpdateRequest = { ...payloadWithoutSpecText };
+        const values = await editForm.validateFields() as TemplateUpdateRequest;
+        const payload: TemplateUpdateRequest = { ...values };
         if (payload.source_type === 'image') {
+            // Clear PVC fields so stale values are not sent to the API.
             payload.pvc_name = undefined;
+            payload.pvc_namespace = undefined;
         } else if (payload.source_type === 'pvc') {
             payload.image_url = undefined;
         }

--- a/web/src/features/admin-templates/hooks/useDynamicSchema.ts
+++ b/web/src/features/admin-templates/hooks/useDynamicSchema.ts
@@ -1,0 +1,94 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api/client';
+import type { SchemaMask } from '../components/DynamicSchemaForm';
+
+export interface DynamicSchemaResponse {
+    /** Raw OpenAPI JSON Schema returned from backend cache or embedded fallback. */
+    schema: Record<string, unknown>;
+    /** Admin/developer-configured UI mask dictating which paths and labels to expose. */
+    mask: SchemaMask;
+    /**
+     * Schema version string for drift detection and cache audit.
+     * Populated when backend implements ADR-0023 response headers.
+     */
+    schema_version?: string;
+    /**
+     * Data source of the schema: cache | embedded | remote.
+     * ADR-0023: enables frontend to display appropriate degradation indicator.
+     */
+    source?: 'cache' | 'embedded' | 'remote';
+    /**
+     * Whether the response is using a degraded/fallback schema.
+     * ADR-0023: frontend MUST show a warning when this is true.
+     */
+    degraded?: boolean;
+    /** ISO timestamp when the schema was fetched or last cached. */
+    fetched_at?: string;
+}
+
+/**
+ * Fetches schema-driven configurations per master-flow.md Stage 1.
+ *
+ * Error handling contract (TanStack Query v5 best practice):
+ *   - On fetch failure: the queryFn throws, query enters `isError` state.
+ *   - Callers check `isError` to render the ADR-0023 degraded UI.
+ *   - This hook does NOT swallow errors — silent degradation hides problems.
+ *
+ * Degradation strategy (FRONTEND.md ADR-0023):
+ *   - Normal:   schema from server cache              → full dynamic form
+ *   - Fallback: embedded schema, degraded=true        → ⚠️ warning banner
+ *   - Error:    isError=true                          → caller shows text fallback
+ *
+ * Backend note (for future implementation):
+ *   The response should include schema_version, source, degraded, fetched_at
+ *   fields so the frontend can render the correct degradation level indicator.
+ */
+/**
+ * Supported entity types for the dynamic schema endpoint.
+ *
+ * Only entity types with a real KubeVirt spec_overrides schema are listed:
+ *   - instancesize: KubeVirt v1.7.0 VirtualMachineSpec sub-schema (cpu/memory/gpu/hugepages).
+ *
+ * Intentionally excluded:
+ *   - template: cloud_init is a static YAML textarea only (master-flow Step 3, no spec_overrides).
+ *   - cluster:  schema not yet designed (ADR-0023 phase 2).
+ */
+export type DynamicSchemaEntityType = 'instancesize';
+
+export const useDynamicSchema = (entityType: DynamicSchemaEntityType) => {
+    return useQuery({
+        queryKey: ['dynamic-schema', entityType],
+        queryFn: async (): Promise<DynamicSchemaResponse> => {
+            const response = await api.GET('/schemas/{entity_type}', {
+                params: {
+                    path: { entity_type: entityType },
+                },
+            });
+
+            // TanStack Query v5: queryFn MUST throw for the query to enter
+            // the `isError` state.  Returning a fallback value here would
+            // silently set status='success' and hide the error from callers.
+            if (response.error) {
+                const msg =
+                    response.error &&
+                        typeof response.error === 'object' &&
+                        'message' in response.error
+                        ? (response.error as { message: string }).message
+                        : `Failed to fetch schema for entity type: ${entityType}`;
+                throw new Error(msg);
+            }
+
+            return {
+                schema: response.data?.schema as Record<string, unknown>,
+                mask: response.data?.mask as SchemaMask,
+                // ADR-0023 optional metadata — present only when backend implements them.
+                schema_version: (response.data as DynamicSchemaResponse | undefined)?.schema_version,
+                source: (response.data as DynamicSchemaResponse | undefined)?.source,
+                degraded: (response.data as DynamicSchemaResponse | undefined)?.degraded ?? false,
+                fetched_at: (response.data as DynamicSchemaResponse | undefined)?.fetched_at,
+            };
+        },
+        staleTime: 5 * 60 * 1000, // 5 min — schema changes are infrequent
+        retry: 0, // Fail fast: backend endpoint is not yet released; no retries needed.
+    });
+};

--- a/web/src/i18n/locales/en/admin.json
+++ b/web/src/i18n/locales/en/admin.json
@@ -155,6 +155,11 @@
     "templates.pvc_name": "PVC / DataVolume Name",
     "templates.pvc_name_required": "PVC name is required for PVC mode",
     "templates.pvc_name_help": "Name of the PersistentVolumeClaim or DataVolume in the target namespace",
+    "templates.source_containerdisk": "Container Disk",
+    "templates.source_pvc": "PVC / DataVolume",
+    "templates.pvc_namespace": "PVC Namespace",
+    "templates.pvc_namespace_help": "Kubernetes namespace where the PVC/DataVolume is located (e.g. default)",
+    "templates.pvc_namespace_required": "PVC namespace is required",
     "templates.cloud_init": "Cloud-init Userdata (YAML)",
     "templates.cloud_init_help": "Cloud-config YAML applied at VM boot time (users, packages, etc.)",
     "templates.image_source": "Image Source",
@@ -260,5 +265,9 @@
     "authProviders.env.test": "Test",
     "authProviders.env.prod": "Production",
     "authProviders.mapping.delete_confirm": "Delete this mapping?",
-    "authProviders.mapping.edit_title": "Edit Mapping"
+    "authProviders.mapping.edit_title": "Edit Mapping",
+    "templates.spec": "Spec Overrides (Schema-driven)",
+    "dynamic_form.add_item": "Add {{label}}",
+    "dynamic_form.invalid_path": "Field path not found in schema: {{path}}",
+    "dynamic_form.advanced_settings": "Advanced Settings"
 }

--- a/web/src/i18n/locales/zh-CN/admin.json
+++ b/web/src/i18n/locales/zh-CN/admin.json
@@ -155,6 +155,11 @@
     "templates.pvc_name": "PVC / DataVolume 名称",
     "templates.pvc_name_required": "PVC 模式下名称必填",
     "templates.pvc_name_help": "目标命名空间中 PersistentVolumeClaim 或 DataVolume 的名称",
+    "templates.source_containerdisk": "容器镜像盘",
+    "templates.source_pvc": "PVC / DataVolume",
+    "templates.pvc_namespace": "PVC 命名空间",
+    "templates.pvc_namespace_help": "PVC/DataVolume 所在的 Kubernetes 命名空间（如 default）",
+    "templates.pvc_namespace_required": "PVC 命名空间必填",
     "templates.cloud_init": "Cloud-init 用户数据（YAML）",
     "templates.cloud_init_help": "VM 启动时应用的 cloud-config YAML（用户、软件包等）",
     "templates.image_source": "镜像源",
@@ -260,5 +265,9 @@
     "authProviders.env.test": "测试",
     "authProviders.env.prod": "生产",
     "authProviders.mapping.delete_confirm": "确定删除该映射吗？",
-    "authProviders.mapping.edit_title": "编辑映射"
+    "authProviders.mapping.edit_title": "编辑映射",
+    "templates.spec": "规格覆写（Schema 驱动）",
+    "dynamic_form.add_item": "添加 {{label}}",
+    "dynamic_form.invalid_path": "Schema 中未找到字段路径：{{path}}",
+    "dynamic_form.advanced_settings": "高级设置"
 }

--- a/web/src/types/api.gen.ts
+++ b/web/src/types/api.gen.ts
@@ -38,6 +38,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/schemas/{entity_type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Retrieve dynamic schema and UI mask for an entity */
+        get: operations["getDynamicSchema"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/systems": {
         parameters: {
             query?: never;
@@ -1222,6 +1239,48 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        MaskField: {
+            /** @description Dot-notation JSON path resolving within the provided unified schema. */
+            path: string;
+            /** @description Desired localized or standardized label for the UI form projection. */
+            display_name: string;
+        };
+        SchemaMask: {
+            quick_fields: components["schemas"]["MaskField"][];
+            advanced_fields?: components["schemas"]["MaskField"][];
+        };
+        DynamicSchemaResponse: {
+            /** @description Full structure representing the requested JSON Schema payload. */
+            schema: {
+                [key: string]: unknown;
+            };
+            mask: components["schemas"]["SchemaMask"];
+            /**
+             * @description Semantic version of the schema (e.g. "1.2.0").
+             *     Frontend uses this for cache drift detection and audit (ADR-0023).
+             * @example 1.2.0
+             */
+            schema_version?: string;
+            /**
+             * @description Data source of the schema response (ADR-0023 degradation strategy):
+             *     - cache:    Served from server-side schema cache (nominal path).
+             *     - embedded: Backend fell back to a bundled embedded schema (warn user).
+             *     - remote:   Fetched live from KubeVirt API (slow path, no cache).
+             * @enum {string}
+             */
+            source?: "cache" | "embedded" | "remote";
+            /**
+             * @description When true, the response uses an older or embedded fallback schema.
+             *     Frontend MUST display a warning banner per ADR-0023 UI Degradation States.
+             * @default false
+             */
+            degraded: boolean;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp when the schema was fetched or last cached.
+             */
+            fetched_at?: string;
+        };
         Health: {
             /** @enum {string} */
             status: "ok" | "degraded" | "error";
@@ -1265,9 +1324,11 @@ export interface components {
         SystemCreateRequest: {
             /** @description RFC 1035 compliant name (ADR-0019) */
             name: string;
+            /** @description Markdown supported */
             description?: string;
         };
         SystemUpdateRequest: {
+            /** @description Markdown supported */
             description: string;
         };
         SystemList: {
@@ -1285,9 +1346,11 @@ export interface components {
         };
         ServiceCreateRequest: {
             name: string;
+            /** @description Markdown supported */
             description?: string;
         };
         ServiceUpdateRequest: {
+            /** @description Markdown supported */
             description: string;
         };
         ServiceList: {
@@ -1561,6 +1624,8 @@ export interface components {
             image_url?: string;
             /** @description PVC/DataVolume name for PVC mode */
             pvc_name?: string;
+            /** @description Kubernetes namespace where the PVC/DataVolume is located (required when source_type is 'pvc') */
+            pvc_namespace?: string;
             /** @description Cloud-init userdata YAML (applied at VM boot) */
             cloud_init?: string;
             os_family?: string;
@@ -1582,6 +1647,8 @@ export interface components {
             image_url?: string;
             /** @description Required when source_type is 'pvc' */
             pvc_name?: string;
+            /** @description Kubernetes namespace where the PVC/DataVolume is located. Required when source_type is 'pvc'. */
+            pvc_namespace?: string;
             /** @description Cloud-init userdata YAML */
             cloud_init?: string;
             os_family?: string;
@@ -1595,6 +1662,8 @@ export interface components {
             source_type?: "image" | "pvc";
             image_url?: string;
             pvc_name?: string;
+            /** @description Kubernetes namespace where the PVC/DataVolume is located */
+            pvc_namespace?: string;
             cloud_init?: string;
             os_family?: string;
             os_version?: string;
@@ -2119,6 +2188,15 @@ export interface components {
                 "application/json": components["schemas"]["Error"];
             };
         };
+        /** @description Internal server error */
+        InternalServerError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
     };
     parameters: {
         /** @description Page number (1-indexed) */
@@ -2204,6 +2282,30 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+        };
+    };
+    getDynamicSchema: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                entity_type: "instancesize";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dynamic schema retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DynamicSchemaResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            500: components["responses"]["InternalServerError"];
         };
     };
     listSystems: {


### PR DESCRIPTION
## Summary

This PR implements Stage-1 schema-driven admin behavior and closes consistency gaps in template/instancesize handling:

1. adds `GET /schemas/{entity_type}` for `instancesize`
2. embeds schema/mask and validates mask paths in tests
3. migrates admin InstanceSize form to dynamic schema rendering
4. hardens `dedicated_cpu` vs `spec_overrides` checks
5. enforces PVC source consistency and propagates `pvc_namespace`

## Linked Issue

Closes #273

## Validation

- `go test ./internal/service ./internal/api/handlers ./internal/pkg/schema ./internal/jobs -count=1`
- `cd web && npm run -s test -- useAdminInstanceSizesController.test.tsx useAdminTemplatesController.test.tsx`
- `cd web && npm run -s typecheck`
- `cd web && npm run -s lint`
