### PR TITLE
feat(approval): stage-2.e provider router wiring for vm request submission

### DIFF
--- a/internal/api/handlers/server.go
+++ b/internal/api/handlers/server.go
@@ -27,33 +27,35 @@ var _ generated.ServerInterface = (*Server)(nil)
 
 // Server implements all API handlers satisfying generated.ServerInterface.
 type Server struct {
-	client      *ent.Client
-	pool        *pgxpool.Pool
-	jwtCfg      middleware.JWTConfig
-	audit       *audit.Logger
-	vmService   *service.VMService
-	vncTokens   *service.VNCTokenManager
-	createVMUC  *usecase.CreateVMUseCase
-	deleteVMUC  *usecase.DeleteVMUseCase
-	gateway     *approval.Gateway
-	riverClient *river.Client[pgx.Tx]
-	notifier    *notification.Triggers // Optional: notification trigger service
+	client         *ent.Client
+	pool           *pgxpool.Pool
+	jwtCfg         middleware.JWTConfig
+	audit          *audit.Logger
+	vmService      *service.VMService
+	vncTokens      *service.VNCTokenManager
+	createVMUC     *usecase.CreateVMUseCase
+	deleteVMUC     *usecase.DeleteVMUseCase
+	gateway        *approval.Gateway
+	approvalRouter *approval.ApprovalProviderRouter // Stage 2.E: provider router
+	riverClient    *river.Client[pgx.Tx]
+	notifier       *notification.Triggers // Optional: notification trigger service
 }
 
 // ServerDeps holds all dependencies for creating a Server.
 // ADR-0013: Manual DI, no Wire/Dig.
 type ServerDeps struct {
-	EntClient   *ent.Client
-	Pool        *pgxpool.Pool
-	JWTCfg      middleware.JWTConfig
-	Audit       *audit.Logger
-	VMService   *service.VMService
-	VNCTokens   *service.VNCTokenManager
-	CreateVMUC  *usecase.CreateVMUseCase
-	DeleteVMUC  *usecase.DeleteVMUseCase
-	Gateway     *approval.Gateway
-	RiverClient *river.Client[pgx.Tx]  // ISSUE-001: needed for async VM delete/power operations
-	Notifier    *notification.Triggers // Optional: notification trigger service
+	EntClient      *ent.Client
+	Pool           *pgxpool.Pool
+	JWTCfg         middleware.JWTConfig
+	Audit          *audit.Logger
+	VMService      *service.VMService
+	VNCTokens      *service.VNCTokenManager
+	CreateVMUC     *usecase.CreateVMUseCase
+	DeleteVMUC     *usecase.DeleteVMUseCase
+	Gateway        *approval.Gateway
+	ApprovalRouter *approval.ApprovalProviderRouter // Stage 2.E: provider router
+	RiverClient    *river.Client[pgx.Tx]            // ISSUE-001: needed for async VM delete/power operations
+	Notifier       *notification.Triggers           // Optional: notification trigger service
 }
 
 // NewServer creates a new Server with all dependencies.
@@ -68,17 +70,18 @@ func NewServer(deps ServerDeps) *Server {
 	}
 
 	return &Server{
-		client:      deps.EntClient,
-		pool:        deps.Pool,
-		jwtCfg:      deps.JWTCfg,
-		audit:       deps.Audit,
-		vmService:   deps.VMService,
-		vncTokens:   vncTokens,
-		createVMUC:  deps.CreateVMUC,
-		deleteVMUC:  deps.DeleteVMUC,
-		gateway:     deps.Gateway,
-		riverClient: deps.RiverClient,
-		notifier:    deps.Notifier,
+		client:         deps.EntClient,
+		pool:           deps.Pool,
+		jwtCfg:         deps.JWTCfg,
+		audit:          deps.Audit,
+		vmService:      deps.VMService,
+		vncTokens:      vncTokens,
+		createVMUC:     deps.CreateVMUC,
+		deleteVMUC:     deps.DeleteVMUC,
+		gateway:        deps.Gateway,
+		approvalRouter: deps.ApprovalRouter, // Stage 2.E: provider router
+		riverClient:    deps.RiverClient,
+		notifier:       deps.Notifier,
 	}
 }
 

--- a/internal/api/handlers/server_vm.go
+++ b/internal/api/handlers/server_vm.go
@@ -22,6 +22,7 @@ import (
 	"kv-shepherd.io/shepherd/internal/jobs"
 	apperrors "kv-shepherd.io/shepherd/internal/pkg/errors"
 	"kv-shepherd.io/shepherd/internal/pkg/logger"
+	"kv-shepherd.io/shepherd/internal/provider"
 	"kv-shepherd.io/shepherd/internal/usecase"
 )
 
@@ -278,6 +279,24 @@ func (s *Server) CreateVMRequest(c *gin.Context) {
 		return
 	}
 
+	// Stage 2.E: Route the submission through the approval provider router.
+	// V1: router always selects the built-in provider (no-op other than logging).
+	// V2+: an external provider adapter can delegate to a third-party system here.
+	// Non-fatal: ticket is already PENDING in DB; log the error but do not unwind the user response.
+	if s.approvalRouter != nil {
+		if _, routerErr := s.approvalRouter.SubmitForApproval(ctx, &provider.ApprovalRequest{
+			EventID:   output.TicketID, // ticket_id echoed as event_id for provider correlation
+			Requester: actor,
+			Action:    "create",
+			Reason:    req.Reason,
+		}); routerErr != nil {
+			logger.Warn("approval router SubmitForApproval failed (ticket already PENDING in DB)",
+				zap.String("ticket_id", output.TicketID),
+				zap.Error(routerErr),
+			)
+		}
+	}
+
 	// Notification trigger: APPROVAL_PENDING → notify approvers (master-flow.md Stage 5.F).
 	if s.notifier != nil {
 		s.notifier.OnTicketSubmitted(ctx, output.TicketID, actor, req.Namespace)
@@ -382,6 +401,21 @@ func (s *Server) DeleteVM(c *gin.Context, vmId generated.VMID, params generated.
 	}
 
 	_ = result.Status // Keep use case output field for backward compatibility.
+
+	// Stage 2.E: Route the delete submission through the approval provider router.
+	// Same semantics as CreateVMRequest: ticket is already PENDING; router call is best-effort.
+	if s.approvalRouter != nil {
+		if _, routerErr := s.approvalRouter.SubmitForApproval(ctx, &provider.ApprovalRequest{
+			EventID:   result.TicketID,
+			Requester: actor,
+			Action:    "delete",
+		}); routerErr != nil {
+			logger.Warn("approval router SubmitForApproval failed for delete ticket (already PENDING in DB)",
+				zap.String("ticket_id", result.TicketID),
+				zap.Error(routerErr),
+			)
+		}
+	}
 
 	// Notification trigger: APPROVAL_PENDING → notify approvers for delete request.
 	if s.notifier != nil {

--- a/internal/app/modules/approval.go
+++ b/internal/app/modules/approval.go
@@ -12,11 +12,18 @@ import (
 
 // ApprovalModule wires governance approval gateway with ADR-0012 atomic writer.
 type ApprovalModule struct {
-	gateway  *approval.Gateway
-	notifier *notification.Triggers
+	gateway        *approval.Gateway
+	providerRouter *approval.ApprovalProviderRouter
+	notifier       *notification.Triggers
 }
 
 // NewApprovalModule creates the approval module after River client is initialized.
+//
+// Stage 2.E wiring:
+//  1. Gateway is created (the atomic approval executor).
+//  2. BuiltinApprovalProvider wraps Gateway — implements provider.ApprovalProvider.
+//  3. ApprovalProviderRouter is created with the builtin provider as the default.
+//     V2+ external providers can be registered on the router after this point.
 func NewApprovalModule(infra *Infrastructure) (*ApprovalModule, error) {
 	if infra == nil || infra.EntClient == nil || infra.Pool == nil || infra.RiverClient == nil {
 		return nil, fmt.Errorf("approval module requires ent client, pgx pool, and river client")
@@ -30,7 +37,17 @@ func NewApprovalModule(infra *Infrastructure) (*ApprovalModule, error) {
 	notifier := notification.NewTriggers(inboxSender, infra.EntClient)
 	gateway.SetNotifier(notifier)
 
-	return &ApprovalModule{gateway: gateway, notifier: notifier}, nil
+	// Stage 2.E: wire the provider router over the gateway.
+	// V1: only the built-in provider is registered; the router always selects it.
+	// V2+: external providers can be added via router.Register(externalProvider).
+	builtinProvider := approval.NewBuiltinApprovalProvider(gateway)
+	providerRouter := approval.NewApprovalProviderRouter(builtinProvider)
+
+	return &ApprovalModule{
+		gateway:        gateway,
+		providerRouter: providerRouter,
+		notifier:       notifier,
+	}, nil
 }
 
 func (m *ApprovalModule) Name() string { return "approval" }
@@ -41,6 +58,9 @@ func (m *ApprovalModule) ContributeServerDeps(deps *handlers.ServerDeps) {
 	}
 	deps.Gateway = m.gateway
 	deps.Notifier = m.notifier
+	// Stage 2.E: expose the provider router so handlers can route submissions
+	// through the correct backend (builtin in V1, external in V2+).
+	deps.ApprovalRouter = m.providerRouter
 }
 
 func (m *ApprovalModule) Shutdown(context.Context) error { return nil }

--- a/internal/governance/approval/provider_router.go
+++ b/internal/governance/approval/provider_router.go
@@ -1,0 +1,206 @@
+// Package approval — Stage 2.E: Approval Provider Router
+//
+// master-flow.md §Stage 2.E defines a canonical provider-router contract with pluggable backends.
+//
+//   V1 go-live path (required):
+//     1) User submits request → approval_tickets=PENDING
+//     2) Router selects built-in provider ("builtin-default", only provider in V1)
+//     3) Built-in approver decides APPROVED / REJECTED
+//     4) Shepherd executes decision path and appends audit logs
+//
+//   V2+ external plugin route (roadmap):
+//     1) External adapter is registered via router.Register(provider)
+//     2) Router delegates ticket via ExternalApprovalProvider.SubmitForApproval
+//     3) Callback/polling maps external decision to canonical APPROVED/REJECTED
+//     4) Provider timeout/unavailable → controlled fallback to built-in queue
+//
+// Design:
+//   - ApprovalProviderRouter wraps Gateway; it selects the right backend per ticket.
+//   - V1 ships with BuiltinApprovalProvider only (direct Gateway delegation).
+//   - V2+ registers external providers; a "type" field on the ticket (or policy)
+//     determines routing.  The router falls back to the built-in on error or timeout.
+//
+// Go interface compliance: compile-time guard at bottom of file.
+// ADR-0013: manual DI, no Wire.
+// ADR-0016: import path kv-shepherd.io/shepherd/internal/governance/approval
+
+package approval
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap"
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+	"kv-shepherd.io/shepherd/internal/provider"
+)
+
+// ─── Built-in Provider (V1) ───────────────────────────────────────────────────
+
+// BuiltinApprovalProvider is the V1 mandatory provider that delegates all
+// approval decisions to the Gateway's internal logic.
+//
+// It implements provider.ApprovalProvider so that the router can treat it as
+// one of N possible backends without the router knowing any approval details.
+//
+// This design lets V2+ external adapters slot in alongside the built-in
+// without modifying the Gateway or existing call sites.
+type BuiltinApprovalProvider struct {
+	gateway *Gateway
+}
+
+// Compile-time interface compliance check (Go FAQ recommended pattern).
+var _ provider.ApprovalProvider = (*BuiltinApprovalProvider)(nil)
+
+// NewBuiltinApprovalProvider creates the V1 built-in provider backed by gateway.
+func NewBuiltinApprovalProvider(gw *Gateway) *BuiltinApprovalProvider {
+	if gw == nil {
+		panic("approval: BuiltinApprovalProvider requires a non-nil Gateway")
+	}
+	return &BuiltinApprovalProvider{gateway: gw}
+}
+
+// Type returns the canonical identifier for this provider.
+// "builtin-default" matches the label in master-flow.md §Stage 2.E.
+func (p *BuiltinApprovalProvider) Type() string { return "builtin-default" }
+
+// SubmitForApproval creates a PENDING ticket and routes to the Gateway's built-in
+// approval queue.  In V1 this is a no-op because ticket creation happens upstream
+// (at the request-submission handler), so this method simply validates the request.
+//
+// V2+ external providers will POST to an external queue here instead.
+func (p *BuiltinApprovalProvider) SubmitForApproval(ctx context.Context, req *provider.ApprovalRequest) (*provider.ApprovalResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("approval: SubmitForApproval: request must not be nil")
+	}
+	if strings.TrimSpace(req.EventID) == "" {
+		return nil, fmt.Errorf("approval: SubmitForApproval: event_id is required")
+	}
+
+	// V1: ticket is already created by the handler before this is called.
+	// The built-in provider delegates to the internal queue (admin UI) — no external
+	// call needed.  We return PENDING to signal that the ticket is in the queue.
+	logger.Info("builtin approval provider: ticket submitted to internal queue",
+		zap.String("event_id", req.EventID),
+		zap.String("requester", req.Requester),
+		zap.String("action", req.Action),
+	)
+	return &provider.ApprovalResponse{
+		TicketID: req.EventID, // echoed; actual ticket ID is set by the handler upstream
+		Status:   "PENDING",
+	}, nil
+}
+
+// ProcessApproval executes an approval decision through the Gateway.
+// opts is passed as the zero-value ApproveOpts; callers that need cluster/storage-class
+// selection should call Gateway.Approve directly (the admin approval handler).
+//
+// This method exists to satisfy the ApprovalProvider interface so that the
+// router can dispatch decisions uniformly across providers.
+func (p *BuiltinApprovalProvider) ProcessApproval(ctx context.Context, ticketID string, decision provider.ApprovalDecision) error {
+	if strings.TrimSpace(ticketID) == "" {
+		return fmt.Errorf("approval: ProcessApproval: ticket_id is required")
+	}
+	if decision.Approved {
+		// Built-in provider uses zero-value ApproveOpts for router-initiated approvals.
+		// Admin-initiated approvals with full opts go through Gateway.Approve directly.
+		return p.gateway.Approve(ctx, ticketID, decision.Approver, ApproveOpts{})
+	}
+	return p.gateway.Reject(ctx, ticketID, decision.Approver, decision.RejectReason)
+}
+
+// ─── Approval Provider Router (Stage 2.E) ────────────────────────────────────
+
+// ApprovalProviderRouter selects the active approval backend for each ticket.
+//
+// V1: always routes to the built-in provider.
+// V2+: consults the registered provider registry; falls back to built-in on error
+//
+// Thread-safe; providers are registered at startup and immutable during operation.
+type ApprovalProviderRouter struct {
+	mu       sync.RWMutex
+	builtin  provider.ApprovalProvider
+	external map[string]provider.ApprovalProvider // key = provider.Type()
+}
+
+// NewApprovalProviderRouter creates a router pre-wired with the V1 built-in provider.
+// The built-in provider is always present and acts as the fallback for V2+.
+func NewApprovalProviderRouter(builtinProvider provider.ApprovalProvider) *ApprovalProviderRouter {
+	if builtinProvider == nil {
+		panic("approval: ApprovalProviderRouter requires a non-nil builtin provider")
+	}
+	return &ApprovalProviderRouter{
+		builtin:  builtinProvider,
+		external: make(map[string]provider.ApprovalProvider),
+	}
+}
+
+// Register adds an external provider to the router (V2+ extension point).
+// Returns an error if the type key is already registered or is the reserved
+// "builtin-default" type used exclusively by the built-in provider.
+func (r *ApprovalProviderRouter) Register(p provider.ApprovalProvider) error {
+	if p == nil {
+		return fmt.Errorf("approval router: provider must not be nil")
+	}
+	key := strings.TrimSpace(strings.ToLower(p.Type()))
+	if key == "" {
+		return fmt.Errorf("approval router: provider.Type() must not be empty")
+	}
+	if key == "builtin-default" {
+		return fmt.Errorf("approval router: \"builtin-default\" is reserved for the built-in provider")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.external[key]; exists {
+		return fmt.Errorf("approval router: provider type %q is already registered", key)
+	}
+	r.external[key] = p
+	logger.Info("approval router: external provider registered", zap.String("type", key))
+	return nil
+}
+
+// Resolve returns the provider for the given type key, or the built-in fallback.
+// This implements the master-flow.md §Stage 2.E routing contract:
+//
+//	"Router selects built-in provider (`builtin-default`, only provider in V1)"
+//
+// V2+: if a matching external provider is registered, it is returned instead.
+// If the type is unknown, the built-in provider is returned as a safe fallback.
+func (r *ApprovalProviderRouter) Resolve(providerType string) provider.ApprovalProvider {
+	key := strings.TrimSpace(strings.ToLower(providerType))
+	if key == "" || key == "builtin-default" {
+		return r.builtin
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if p, ok := r.external[key]; ok {
+		return p
+	}
+	// Unknown type → controlled fallback to built-in (Stage 2.E §4).
+	logger.Warn("approval router: unknown provider type, falling back to builtin",
+		zap.String("requested_type", key),
+	)
+	return r.builtin
+}
+
+// SubmitForApproval routes a submission through the resolved provider.
+// Uses the built-in provider (V1), or an external provider if registered (V2+).
+func (r *ApprovalProviderRouter) SubmitForApproval(ctx context.Context, req *provider.ApprovalRequest) (*provider.ApprovalResponse, error) {
+	// V1: always builtin.  V2+: providerType would come from policy/config.
+	p := r.Resolve("builtin-default")
+	resp, err := p.SubmitForApproval(ctx, req)
+	if err != nil {
+		// Stage 2.E fallback: provider error → route to built-in queue.
+		if p.Type() != r.builtin.Type() {
+			logger.Warn("approval router: external provider SubmitForApproval failed, falling back",
+				zap.String("provider", p.Type()),
+				zap.Error(err),
+			)
+			return r.builtin.SubmitForApproval(ctx, req)
+		}
+		return nil, err
+	}
+	return resp, nil
+}

--- a/internal/governance/approval/provider_router_test.go
+++ b/internal/governance/approval/provider_router_test.go
@@ -1,0 +1,126 @@
+package approval_test
+
+import (
+	"context"
+	"testing"
+
+	"kv-shepherd.io/shepherd/internal/governance/approval"
+	"kv-shepherd.io/shepherd/internal/provider"
+)
+
+// ─── Fake provider for testing ────────────────────────────────────────────────
+
+type fakeApprovalProvider struct {
+	typeKey      string
+	submitErr    error
+	processErr   error
+	submitCalled int
+}
+
+func (f *fakeApprovalProvider) Type() string { return f.typeKey }
+
+func (f *fakeApprovalProvider) SubmitForApproval(_ context.Context, req *provider.ApprovalRequest) (*provider.ApprovalResponse, error) {
+	f.submitCalled++
+	if f.submitErr != nil {
+		return nil, f.submitErr
+	}
+	return &provider.ApprovalResponse{TicketID: req.EventID, Status: "PENDING"}, nil
+}
+
+func (f *fakeApprovalProvider) ProcessApproval(_ context.Context, _ string, _ provider.ApprovalDecision) error {
+	return f.processErr
+}
+
+// Compile-time interface check.
+var _ provider.ApprovalProvider = (*fakeApprovalProvider)(nil)
+
+// ─── Tests: ApprovalProviderRouter ────────────────────────────────────────────
+
+func TestApprovalProviderRouter_V1AlwaysBuiltin(t *testing.T) {
+	builtin := &fakeApprovalProvider{typeKey: "builtin-default"}
+	router := approval.NewApprovalProviderRouter(builtin)
+
+	// In V1, requesting any type (including empty) resolves to builtin.
+	p := router.Resolve("")
+	if p.Type() != "builtin-default" {
+		t.Errorf("Resolve(\"\") = %q, want \"builtin-default\"", p.Type())
+	}
+
+	p = router.Resolve("builtin-default")
+	if p.Type() != "builtin-default" {
+		t.Errorf("Resolve(\"builtin-default\") = %q, want \"builtin-default\"", p.Type())
+	}
+}
+
+func TestApprovalProviderRouter_UnknownTypeFallsBackToBuiltin(t *testing.T) {
+	builtin := &fakeApprovalProvider{typeKey: "builtin-default"}
+	router := approval.NewApprovalProviderRouter(builtin)
+
+	// Unknown provider type → controlled fallback to builtin (Stage 2.E §4).
+	p := router.Resolve("external-jira")
+	if p.Type() != "builtin-default" {
+		t.Errorf("Resolve(\"external-jira\") = %q, want \"builtin-default\"", p.Type())
+	}
+}
+
+func TestApprovalProviderRouter_RegisterExternal(t *testing.T) {
+	builtin := &fakeApprovalProvider{typeKey: "builtin-default"}
+	external := &fakeApprovalProvider{typeKey: "jira"}
+	router := approval.NewApprovalProviderRouter(builtin)
+
+	if err := router.Register(external); err != nil {
+		t.Fatalf("Register external: %v", err)
+	}
+
+	// Known external type resolves to the external provider.
+	p := router.Resolve("jira")
+	if p.Type() != "jira" {
+		t.Errorf("Resolve(\"jira\") = %q, want \"jira\"", p.Type())
+	}
+
+	// Builtin still resolves normally.
+	p = router.Resolve("builtin-default")
+	if p.Type() != "builtin-default" {
+		t.Errorf("Resolve(\"builtin-default\") = %q, want \"builtin-default\"", p.Type())
+	}
+}
+
+func TestApprovalProviderRouter_DuplicateRegistrationRejected(t *testing.T) {
+	builtin := &fakeApprovalProvider{typeKey: "builtin-default"}
+	external := &fakeApprovalProvider{typeKey: "jira"}
+	router := approval.NewApprovalProviderRouter(builtin)
+
+	if err := router.Register(external); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := router.Register(external); err == nil {
+		t.Error("duplicate Register should have returned error, got nil")
+	}
+}
+
+func TestApprovalProviderRouter_BuiltinTypeReserved(t *testing.T) {
+	builtin := &fakeApprovalProvider{typeKey: "builtin-default"}
+	router := approval.NewApprovalProviderRouter(builtin)
+
+	impostor := &fakeApprovalProvider{typeKey: "builtin-default"}
+	if err := router.Register(impostor); err == nil {
+		t.Error("registering \"builtin-default\" should have returned error, got nil")
+	}
+}
+
+func TestApprovalProviderRouter_SubmitForApproval_V1(t *testing.T) {
+	builtin := &fakeApprovalProvider{typeKey: "builtin-default"}
+	router := approval.NewApprovalProviderRouter(builtin)
+
+	req := &provider.ApprovalRequest{EventID: "evt-001", Requester: "user-1", Action: "create"}
+	resp, err := router.SubmitForApproval(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SubmitForApproval: %v", err)
+	}
+	if resp.Status != "PENDING" {
+		t.Errorf("expected status PENDING, got %q", resp.Status)
+	}
+	if builtin.submitCalled != 1 {
+		t.Errorf("builtin.SubmitForApproval called %d times, want 1", builtin.submitCalled)
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces Stage-2.E approval provider router baseline:

1. adds `ApprovalProviderRouter` with builtin provider default
2. supports external provider registration and safe fallback behavior
3. wires router into modules/server deps
4. routes VM create/delete submissions through `SubmitForApproval` hook
5. adds router-focused tests

## Linked Issue

Closes #274

## Validation

- `go test ./internal/governance/approval ./internal/api/handlers ./internal/app/modules -count=1`
