### PR TITLE
docs(adr): propose ADR-0037 validation policy

### DIFF
--- a/docs/adr/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md
+++ b/docs/adr/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md
@@ -1,0 +1,137 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+date: 2026-02-26
+deciders:
+  - jindyzhao
+consulted: []
+informed: []
+---
+
+# ADR-0037: OpenAPI Validation Architecture and Enforcement Policy
+
+> **Review Period**: Until 2026-02-28 (48-hour minimum)<br>
+> **Discussion**: [Issue #280](https://github.com/kv-shepherd/shepherd/issues/280)<br>
+> **Amends**: [ADR-0021](./ADR-0021-api-contract-first.md), [ADR-0029](./ADR-0029-openapi-toolchain-governance.md)
+
+---
+
+## Context and Problem Statement
+
+The project has an accepted Contract-First direction (ADR-0021) and OpenAPI toolchain governance direction (ADR-0029), but implementation and acceptance criteria are still partially inconsistent. We need one explicit policy for runtime validation, business validation, and CI enforcement that can be executed and verified end-to-end.
+
+This decision is made before production rollout, so architecture can be optimized for best-state consistency instead of migration minimization.
+
+## Decision Drivers
+
+* Contract correctness must be enforced before merge, not by convention.
+* Validation rules should be spec-driven to avoid duplicated handler logic.
+* Runtime behavior must be deterministic across environments.
+* Governance controls (required checks/branch protection) must be mandatory.
+* Decision quality should be evidence-first and measurable.
+
+## Considered Options
+
+* **Option 1**: Keep current mixed state (`kin-openapi` runtime + scattered handler checks)
+* **Option 2**: Best-state target (`libopenapi-validator` strict runtime + spec-driven business validation + enforced CI gates)
+* **Option 3**: Hybrid deferment (keep current runtime now, evaluate strict runtime later)
+
+## Decision Outcome
+
+**Chosen option**: "Option 2", because it provides the strongest contract enforcement model and removes known consistency gaps while the project still has no production migration constraints.
+
+### Core Policy
+
+1. **Runtime OpenAPI validation**: use `github.com/pb33f/libopenapi-validator` with strict mode.
+2. **Business validation**: use `github.com/go-playground/validator/v10`.
+3. **Validation source-of-truth**: define `validate` tags via `x-oapi-codegen-extra-tags` in OpenAPI schema.
+4. **Lint and diff enforcement**:
+   - keep Vacuum as linter
+   - fail CI on lint errors
+   - enforce breaking-change checks on PRs
+5. **Governance enforcement**:
+   - required status checks on `main`
+   - no bypass as default policy
+6. **Compatibility guardrail**:
+   - provide `make api-diff` alias to `api-breaking` for workflow and issue compatibility.
+
+### Consequences
+
+* ✅ Good, because spec-to-runtime consistency becomes enforceable and testable.
+* ✅ Good, because validation logic moves from duplicated handlers to generated contract + unified validator layer.
+* ✅ Good, because strict runtime checks surface schema drift early in CI and tests.
+* ✅ Good, because branch governance becomes measurable and auditable.
+* 🟡 Neutral, because initial implementation scope is broader and requires staged PR rollout.
+* ❌ Bad, because strict validation may initially reject requests previously tolerated by permissive checks.
+
+### Confirmation
+
+This ADR is considered correctly implemented when all items below are true:
+
+1. `main` branch has required checks for API contract workflow and core CI workflow.
+2. `make api-lint` reports `0 errors`.
+3. Runtime middleware uses `libopenapi-validator` strict mode and has coverage for:
+   - undeclared body fields
+   - undeclared query parameters
+   - production-safe error responses
+4. `internal/api/validator` is used for business validation and produces standardized field error output.
+5. Request schema validation tags are declared in OpenAPI via `x-oapi-codegen-extra-tags`.
+6. PR pipeline performs breaking-change detection and blocks on violations.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Keep Current Mixed State
+
+* ✅ Good, because immediate implementation churn is low.
+* ❌ Bad, because validation remains fragmented and inconsistent.
+* ❌ Bad, because governance and acceptance remain ambiguous.
+
+### Option 2: Best-State Target (Selected)
+
+* ✅ Good, because contract enforcement becomes complete across lint/runtime/business/CI.
+* ✅ Good, because rules are spec-driven and maintainable.
+* ✅ Good, because it matches pre-launch optimization conditions.
+* ❌ Bad, because rollout requires disciplined serial PR execution.
+
+### Option 3: Hybrid Deferment
+
+* ✅ Good, because initial risk appears lower.
+* ❌ Bad, because known consistency debt is intentionally retained.
+* ❌ Bad, because issue closure criteria remain partially non-verifiable.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* [ADR-0021](./ADR-0021-api-contract-first.md) - Contract-First API direction
+* [ADR-0029](./ADR-0029-openapi-toolchain-governance.md) - OpenAPI toolchain governance baseline
+
+### References
+
+* [Issue #280](https://github.com/kv-shepherd/shepherd/issues/280)
+* [oapi-codegen: x-oapi-codegen-extra-tags](https://github.com/oapi-codegen/oapi-codegen#x-oapi-codegen-extra-tags---generate-arbitrary-struct-tags-to-fields)
+* [libopenapi-validator](https://github.com/pb33f/libopenapi-validator)
+* [go-playground/validator](https://github.com/go-playground/validator)
+
+### Implementation Notes
+
+1. Detailed rollout and file-level execution are tracked in:
+   - `docs/design/notes/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md`
+2. During `proposed` review period, normative design specs should not be rewritten directly.
+3. After acceptance, append amendment blocks to prior ADRs as needed.
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-26 | @jindyzhao | Initial draft |
+
+---
+
+_End of ADR-0037_

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@
 | [ADR-0034](./ADR-0034-master-flow-spec-driven-test-first.md) | Master-Flow Spec-Driven Test-First Execution Standard | **Accepted** | - |
 | [ADR-0035](./ADR-0035-auth-provider-plugin-boundary.md) | Auth Provider Plugin Boundary and Type Discovery | **Accepted** | - |
 | [ADR-0036](./ADR-0036-template-instancesize-boundary-enforcement.md) | Template / InstanceSize Boundary Enforcement | **Accepted** | - |
+| [ADR-0037](./ADR-0037-openapi-validation-architecture-and-enforcement-policy.md) | OpenAPI Validation Architecture and Enforcement Policy | **Proposed** | - |
 
 > ⚠️ **¹ ADR-0009 Partial Supersession Notice**:
 >

--- a/docs/design/notes/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md
+++ b/docs/design/notes/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md
@@ -1,0 +1,72 @@
+# ADR-0037 Implementation Note: OpenAPI Validation Architecture and Enforcement Policy
+
+Status: Draft implementation note for ADR-0037 (`proposed`)  
+Linked ADR: `docs/adr/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md`
+
+## Purpose
+
+This note captures implementation impacts while ADR-0037 is in review. It is intentionally operational and file-oriented.
+
+## Scope
+
+1. Runtime validator migration to `libopenapi-validator` strict mode.
+2. Business validator unification (`validator/v10`).
+3. Spec-driven validation tags (`x-oapi-codegen-extra-tags`).
+4. CI enforcement and branch protection hardening.
+
+## Planned Change Set
+
+### 1. API contract and lint baseline
+
+- `api/openapi.yaml`
+  - replace OpenAPI 3.0 `nullable: true` style with OpenAPI 3.1-compatible union types.
+  - add/normalize validation tags on request schemas via `x-oapi-codegen-extra-tags`.
+- `api/.vacuum.yaml`
+  - keep Vacuum ruleset.
+  - enforce project naming policy (snake_case) without opening naming drift.
+
+### 2. Runtime validation
+
+- `internal/api/middleware/openapi_validator.go`
+  - migrate runtime request validation to `libopenapi-validator` strict mode.
+  - use embedded spec source (`generated.GetSwagger()`) instead of runtime file path dependency.
+- `internal/api/middleware/openapi_validator_test.go`
+  - add strict coverage for undeclared fields/params and production-safe error behavior.
+
+### 3. Business validation
+
+- `internal/api/validator/validator.go` (new)
+  - centralize `validator/v10` initialization.
+  - standardize field-level error mapping for API responses.
+- `internal/api/validator/validator_test.go` (new)
+  - cover required/format/cross-field scenarios.
+- `internal/api/handlers/*.go`
+  - gradually replace duplicated request checks with centralized validator path.
+
+### 4. CI and governance
+
+- `build/api.mk`
+  - ensure compatibility alias: `api-diff -> api-breaking`.
+- `.github/workflows/api-contract.yaml`
+  - enforce lint, sync, and breaking gates.
+  - add PR visibility for API changelog output.
+- GitHub branch protection (repository settings)
+  - require status checks on `main`.
+
+## Verification Plan
+
+1. `make api-lint` -> `0 errors`
+2. `make api-generate && make api-check`
+3. `go test ./internal/api/middleware/...`
+4. `go test ./internal/api/validator/...`
+5. PR-level breaking-check blocking behavior verified
+
+## Rollout Strategy
+
+Use sequential atomic PRs, one concern per PR, with baseline refresh between each merge.
+
+## Deferred Until ADR Acceptance
+
+1. Amendment block append in ADR-0029.
+2. Normative documentation rewrite beyond minimal references.
+


### PR DESCRIPTION
## Summary
- add proposed `ADR-0037` for OpenAPI validation architecture and enforcement policy
- add matching implementation note under `docs/design/notes/`
- register ADR-0037 in ADR index

## Why
This establishes a single decision baseline for runtime validation, business validation, and CI enforcement before execution PRs.

## Validation
- docs-only change (no runtime code changes)

## Issue
Refs #280