### PR TITLE
docs(adr): minimal ADR-0037 acceptance + i18n Gi label sync

### DIFF
--- a/docs/adr/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md
+++ b/docs/adr/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md
@@ -1,7 +1,7 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"  # proposed | accepted | deprecated | superseded by ADR-XXXX
-date: 2026-02-26
+status: "accepted"  # proposed | accepted | deprecated | superseded by ADR-XXXX
+date: 2026-02-28
 deciders:
   - jindyzhao
 consulted: []
@@ -10,7 +10,7 @@ informed: []
 
 # ADR-0037: OpenAPI Validation Architecture and Enforcement Policy
 
-> **Review Period**: Until 2026-02-28 (48-hour minimum)<br>
+> **Status**: Accepted<br>
 > **Discussion**: [Issue #280](https://github.com/kv-shepherd/shepherd/issues/280)<br>
 > **Amends**: [ADR-0021](./ADR-0021-api-contract-first.md), [ADR-0029](./ADR-0029-openapi-toolchain-governance.md)
 
@@ -131,7 +131,7 @@ This ADR is considered correctly implemented when all items below are true:
 
 1. Detailed rollout and file-level execution are tracked in:
    - `docs/design/notes/ADR-0037-openapi-validation-architecture-and-enforcement-policy.md`
-2. During `proposed` review period, normative design specs should not be rewritten directly.
+2. Normative design specs follow this accepted ADR.
 3. After acceptance, append amendment blocks to prior ADRs as needed.
 
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,9 +46,9 @@
 | [ADR-0034](./ADR-0034-master-flow-spec-driven-test-first.md) | Master-Flow Spec-Driven Test-First Execution Standard | **Accepted** | - |
 | [ADR-0035](./ADR-0035-auth-provider-plugin-boundary.md) | Auth Provider Plugin Boundary and Type Discovery | **Accepted** | - |
 | [ADR-0036](./ADR-0036-template-instancesize-boundary-enforcement.md) | Template / InstanceSize Boundary Enforcement | **Accepted** | - |
-| [ADR-0037](./ADR-0037-openapi-validation-architecture-and-enforcement-policy.md) | OpenAPI Validation Architecture and Enforcement Policy | **Proposed** | - |
+| [ADR-0037](./ADR-0037-openapi-validation-architecture-and-enforcement-policy.md) | OpenAPI Validation Architecture and Enforcement Policy | **Accepted** | - |
 
-> ℹ️ **ADR-0037 (Proposed) Review Sync Notes**:
+> ℹ️ **ADR-0037 Sync Notes**:
 >
 > - Runtime validator spec source is canonical `internal/api/specembed/openapi.yaml` (not `generated.GetSwagger()`).
 > - `libopenapi-validator` lifecycle policy is per-validation instance creation (no shared/sync.Pool reuse).
@@ -110,7 +110,7 @@ For newcomers, we recommend reading ADRs in this order:
 11. **ADR-0018** (Instance Size Abstraction) → Schema-driven VM sizing
 12. **ADR-0021** (API Contract-First) → Contract-first API lifecycle
 13. **ADR-0029** (OpenAPI Toolchain Governance) → Lint/generate/diff enforcement baseline
-14. **ADR-0037** (OpenAPI Validation Architecture, **Proposed**) → Runtime/business validation architecture and compat bridge governance
+14. **ADR-0037** (OpenAPI Validation Architecture, **Accepted**) → Runtime/business validation architecture and compat bridge governance
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/web/src/i18n/locales/en/admin.json
+++ b/web/src/i18n/locales/en/admin.json
@@ -170,7 +170,7 @@
     "instanceSizes.memory": "Memory",
     "instanceSizes.disk": "Disk",
     "instanceSizes.cpu_request": "CPU Request (cores)",
-    "instanceSizes.memory_request": "Memory Request (MB)",
+    "instanceSizes.memory_request": "Memory Request (Gi)",
     "instanceSizes.sort_order": "Sort Order",
     "instanceSizes.capabilities": "Capabilities",
     "instanceSizes.dedicated": "Dedicated CPU",

--- a/web/src/i18n/locales/zh-CN/admin.json
+++ b/web/src/i18n/locales/zh-CN/admin.json
@@ -170,7 +170,7 @@
     "instanceSizes.memory": "内存",
     "instanceSizes.disk": "磁盘",
     "instanceSizes.cpu_request": "CPU 请求值（核）",
-    "instanceSizes.memory_request": "内存请求值（MB）",
+    "instanceSizes.memory_request": "内存请求值（Gi）",
     "instanceSizes.sort_order": "排序值",
     "instanceSizes.capabilities": "特殊能力",
     "instanceSizes.dedicated": "独占 CPU",


### PR DESCRIPTION
## Summary
- mark ADR-0037 as accepted with minimal metadata/state updates
- update ADR index references from Proposed -> Accepted for ADR-0037
- sync admin instance-size memory-request labels from MB to Gi (en/zh)

## Scope control
- no ADR amendment bundles
- no unrelated docs/notes/template files

## Validation
- `cd web && npm run typecheck`

Refs #280
