### PR TITLE
test(e2e-live): stabilize live suites and deterministic seeding

### DIFF
--- a/cmd/e2e-seed/main.go
+++ b/cmd/e2e-seed/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"kv-shepherd.io/shepherd/ent"
 	entapprovalticket "kv-shepherd.io/shepherd/ent/approvalticket"
@@ -30,17 +32,19 @@ import (
 	entuser "kv-shepherd.io/shepherd/ent/user"
 	entvm "kv-shepherd.io/shepherd/ent/vm"
 	"kv-shepherd.io/shepherd/internal/config"
+	"kv-shepherd.io/shepherd/internal/domain"
 	"kv-shepherd.io/shepherd/internal/infrastructure"
 	"kv-shepherd.io/shepherd/internal/pkg/logger"
 )
 
 const (
 	defaultAdminUsername = "e2e-admin"
-	defaultAdminPassword = "e2e-admin-123"
+	defaultAdminPassword = "e2e-admin-123" // #nosec G101 -- test fixture credential for local e2e seeding only.
 	defaultAdminEmail    = "e2e-admin@localhost"
 
 	defaultNamespaceName = "e2e-test"
 	defaultClusterName   = "e2e-cluster"
+	defaultClusterAPIURL = "https://e2e.invalid"
 	defaultSystemName    = "e2e-system"
 	defaultServiceName   = "e2e-service"
 	defaultTemplateName  = "e2e-template"
@@ -57,6 +61,7 @@ type fixtureConfig struct {
 
 	NamespaceName string
 	ClusterName   string
+	ClusterAPIURL string
 	SystemName    string
 	ServiceName   string
 	TemplateName  string
@@ -78,10 +83,10 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	if err := logger.Init(cfg.Log.Level, cfg.Log.Format); err != nil {
-		return fmt.Errorf("init logger: %w", err)
+	if initErr := logger.Init(cfg.Log.Level, cfg.Log.Format); initErr != nil {
+		return fmt.Errorf("init logger: %w", initErr)
 	}
-	defer logger.Sync()
+	defer func() { _ = logger.Sync() }()
 
 	ctx := context.Background()
 	db, err := infrastructure.NewDatabaseClients(ctx, cfg.Database)
@@ -97,12 +102,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("ensure admin user: %w", err)
 	}
-	if err := ensureAdminRoleBinding(ctx, client, adminID); err != nil {
-		return fmt.Errorf("ensure admin role binding: %w", err)
+	if bindErr := ensureAdminRoleBinding(ctx, client, adminID); bindErr != nil {
+		return fmt.Errorf("ensure admin role binding: %w", bindErr)
 	}
 
-	if err := ensureNamespaceRegistry(ctx, client, fx); err != nil {
-		return fmt.Errorf("ensure namespace: %w", err)
+	if nsErr := ensureNamespaceRegistry(ctx, client, fx); nsErr != nil {
+		return fmt.Errorf("ensure namespace: %w", nsErr)
 	}
 	clusterID, err := ensureCluster(ctx, client, fx)
 	if err != nil {
@@ -116,23 +121,23 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("ensure service: %w", err)
 	}
-	if err := ensureTemplate(ctx, client, fx); err != nil {
-		return fmt.Errorf("ensure template: %w", err)
+	if tplErr := ensureTemplate(ctx, client, fx); tplErr != nil {
+		return fmt.Errorf("ensure template: %w", tplErr)
 	}
-	if err := ensureInstanceSize(ctx, client, fx); err != nil {
-		return fmt.Errorf("ensure instance size: %w", err)
+	if sizeErr := ensureInstanceSize(ctx, client, fx); sizeErr != nil {
+		return fmt.Errorf("ensure instance size: %w", sizeErr)
 	}
-	if err := ensureVM(ctx, client, fx.RunningVMID, "vm-live", "01", entvm.StatusRUNNING, fx.NamespaceName, clusterID, serviceID, fx.AdminUsername); err != nil {
-		return fmt.Errorf("ensure running vm: %w", err)
+	if runningVMErr := ensureVM(ctx, client, fx.RunningVMID, "vm-live", "01", entvm.StatusRUNNING, fx.NamespaceName, clusterID, serviceID, fx.AdminUsername); runningVMErr != nil {
+		return fmt.Errorf("ensure running vm: %w", runningVMErr)
 	}
-	if err := ensureVM(ctx, client, fx.StoppedVMID, "vm-stopped", "02", entvm.StatusSTOPPED, fx.NamespaceName, clusterID, serviceID, fx.AdminUsername); err != nil {
-		return fmt.Errorf("ensure stopped vm: %w", err)
+	if stoppedVMErr := ensureVM(ctx, client, fx.StoppedVMID, "vm-stopped", "02", entvm.StatusSTOPPED, fx.NamespaceName, clusterID, serviceID, fx.AdminUsername); stoppedVMErr != nil {
+		return fmt.Errorf("ensure stopped vm: %w", stoppedVMErr)
 	}
 
 	// ── Phase 2: Extended fixtures (auth provider, extra user, notifications, approvals) ──
 
-	if err := ensureAuthProvider(ctx, client); err != nil {
-		return fmt.Errorf("ensure auth provider: %w", err)
+	if providerErr := ensureAuthProvider(ctx, client); providerErr != nil {
+		return fmt.Errorf("ensure auth provider: %w", providerErr)
 	}
 
 	secondUserID, err := ensureSecondUser(ctx, client)
@@ -141,16 +146,16 @@ func run() error {
 	}
 	_ = secondUserID // Used for member management tests; ID logged below
 
-	if err := ensureApprovalTickets(ctx, client, adminID); err != nil {
-		return fmt.Errorf("ensure approval tickets: %w", err)
+	if approvalErr := ensureApprovalTickets(ctx, client); approvalErr != nil {
+		return fmt.Errorf("ensure approval tickets: %w", approvalErr)
 	}
 
-	if err := ensureNotifications(ctx, client, adminID); err != nil {
-		return fmt.Errorf("ensure notifications: %w", err)
+	if notifyErr := ensureNotifications(ctx, client, adminID); notifyErr != nil {
+		return fmt.Errorf("ensure notifications: %w", notifyErr)
 	}
 
-	if err := ensureBatchApprovalTickets(ctx, client, fx.AdminUsername); err != nil {
-		return fmt.Errorf("ensure batch approval tickets: %w", err)
+	if batchErr := ensureBatchApprovalTickets(ctx, client, fx.AdminUsername, clusterID, fx.NamespaceName); batchErr != nil {
+		return fmt.Errorf("ensure batch approval tickets: %w", batchErr)
 	}
 
 	fmt.Printf("e2e fixtures ready (user=%s namespace=%s system=%s service=%s)\n",
@@ -166,6 +171,7 @@ func loadFixtureConfig() fixtureConfig {
 		AdminEmail:    envOrDefault("E2E_ADMIN_EMAIL", defaultAdminEmail),
 		NamespaceName: envOrDefault("E2E_NAMESPACE", defaultNamespaceName),
 		ClusterName:   envOrDefault("E2E_CLUSTER", defaultClusterName),
+		ClusterAPIURL: envOrDefault("E2E_CLUSTER_API_SERVER", defaultClusterAPIURL),
 		SystemName:    envOrDefault("E2E_SYSTEM", defaultSystemName),
 		ServiceName:   envOrDefault("E2E_SERVICE", defaultServiceName),
 		TemplateName:  envOrDefault("E2E_TEMPLATE", defaultTemplateName),
@@ -181,6 +187,56 @@ func envOrDefault(key, fallback string) string {
 		return fallback
 	}
 	return v
+}
+
+type clusterSeedInput struct {
+	Kubeconfig []byte
+	APIServer  string
+	Status     entcluster.Status
+}
+
+func resolveClusterSeedInput(fx fixtureConfig) (clusterSeedInput, error) {
+	const fallbackStub = "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\n"
+	rawB64 := strings.TrimSpace(os.Getenv("E2E_KUBECONFIG_B64"))
+	if rawB64 == "" {
+		return clusterSeedInput{
+			Kubeconfig: []byte(fallbackStub),
+			APIServer:  fx.ClusterAPIURL,
+			Status:     entcluster.StatusUNREACHABLE,
+		}, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(rawB64)
+	if err != nil {
+		return clusterSeedInput{}, fmt.Errorf("decode E2E_KUBECONFIG_B64: %w", err)
+	}
+	if strings.TrimSpace(string(decoded)) == "" {
+		return clusterSeedInput{}, fmt.Errorf("E2E_KUBECONFIG_B64 decoded to empty content")
+	}
+
+	cfg, err := clientcmd.Load(decoded)
+	if err != nil {
+		return clusterSeedInput{}, fmt.Errorf("parse kubeconfig from E2E_KUBECONFIG_B64: %w", err)
+	}
+
+	apiServer := strings.TrimSpace(fx.ClusterAPIURL)
+	if apiServer == "" || apiServer == defaultClusterAPIURL {
+		for _, cluster := range cfg.Clusters {
+			if server := strings.TrimSpace(cluster.Server); server != "" {
+				apiServer = server
+				break
+			}
+		}
+	}
+	if apiServer == "" {
+		return clusterSeedInput{}, fmt.Errorf("kubeconfig in E2E_KUBECONFIG_B64 does not contain any cluster server")
+	}
+
+	return clusterSeedInput{
+		Kubeconfig: decoded,
+		APIServer:  apiServer,
+		Status:     entcluster.StatusHEALTHY,
+	}, nil
 }
 
 func ensureAdminUser(ctx context.Context, client *ent.Client, fx fixtureConfig) (string, error) {
@@ -285,7 +341,10 @@ func ensureNamespaceRegistry(ctx context.Context, client *ent.Client, fx fixture
 }
 
 func ensureCluster(ctx context.Context, client *ent.Client, fx fixtureConfig) (string, error) {
-	kubeconfig := []byte("apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\n")
+	clusterInput, err := resolveClusterSeedInput(fx)
+	if err != nil {
+		return "", err
+	}
 
 	obj, err := client.Cluster.Query().Where(entcluster.NameEQ(fx.ClusterName)).Only(ctx)
 	if err != nil {
@@ -297,9 +356,9 @@ func ensureCluster(ctx context.Context, client *ent.Client, fx fixtureConfig) (s
 			SetID(id.String()).
 			SetName(fx.ClusterName).
 			SetDisplayName("E2E Cluster").
-			SetAPIServerURL("https://e2e.invalid").
-			SetEncryptedKubeconfig(kubeconfig).
-			SetStatus(entcluster.StatusHEALTHY).
+			SetAPIServerURL(clusterInput.APIServer).
+			SetEncryptedKubeconfig(clusterInput.Kubeconfig).
+			SetStatus(clusterInput.Status).
 			SetEnvironment(entcluster.EnvironmentTest).
 			SetEnabled(true).
 			SetCreatedBy("e2e-seed").
@@ -312,9 +371,9 @@ func ensureCluster(ctx context.Context, client *ent.Client, fx fixtureConfig) (s
 
 	updated, err := client.Cluster.UpdateOneID(obj.ID).
 		SetDisplayName("E2E Cluster").
-		SetAPIServerURL("https://e2e.invalid").
-		SetEncryptedKubeconfig(kubeconfig).
-		SetStatus(entcluster.StatusHEALTHY).
+		SetAPIServerURL(clusterInput.APIServer).
+		SetEncryptedKubeconfig(clusterInput.Kubeconfig).
+		SetStatus(clusterInput.Status).
 		SetEnvironment(entcluster.EnvironmentTest).
 		SetEnabled(true).
 		Save(ctx)
@@ -501,7 +560,7 @@ func ensureVM(
 const (
 	defaultAuthProviderName = "e2e-ldap"
 	defaultSecondUsername   = "e2e-user"
-	defaultSecondPassword   = "e2e-user-123"
+	defaultSecondPassword   = "e2e-user-123" // #nosec G101 -- test fixture credential for local e2e seeding only.
 	defaultSecondEmail      = "e2e-user@localhost"
 )
 
@@ -590,7 +649,7 @@ func ensureSecondUser(ctx context.Context, client *ent.Client) (string, error) {
 // ensureApprovalTickets creates PENDING approval tickets for tests that exercise
 // approveTicket, rejectTicket, cancelTicket, submitApprovalBatch.
 // Each ticket requires a DomainEvent (ADR-0009 claim-check pattern).
-func ensureApprovalTickets(ctx context.Context, client *ent.Client, adminID string) error {
+func ensureApprovalTickets(ctx context.Context, client *ent.Client) error {
 	// We need 3 PENDING tickets: one for approve, one for reject, one for cancel
 	for i, suffix := range []string{"approve", "reject", "cancel"} {
 		eventID := fmt.Sprintf("evt-e2e-seed-%s", suffix)
@@ -611,7 +670,7 @@ func ensureApprovalTickets(ctx context.Context, client *ent.Client, adminID stri
 				"instance_size_id": "e2e-small",
 				"reason":           fmt.Sprintf("E2E seed ticket for %s test", suffix),
 			})
-			_, err := client.DomainEvent.Create().
+			_, createEventErr := client.DomainEvent.Create().
 				SetID(eventID).
 				SetEventType("VM_CREATION_REQUESTED").
 				SetAggregateType("vm").
@@ -620,8 +679,8 @@ func ensureApprovalTickets(ctx context.Context, client *ent.Client, adminID stri
 				SetStatus(entdomainevent.StatusPENDING).
 				SetCreatedBy("e2e-seed").
 				Save(ctx)
-			if err != nil {
-				return fmt.Errorf("create domain event %s: %w", eventID, err)
+			if createEventErr != nil {
+				return fmt.Errorf("create domain event %s: %w", eventID, createEventErr)
 			}
 		}
 
@@ -633,7 +692,7 @@ func ensureApprovalTickets(ctx context.Context, client *ent.Client, adminID stri
 			return err
 		}
 		if !ticketExists {
-			_, err := client.ApprovalTicket.Create().
+			_, createTicketErr := client.ApprovalTicket.Create().
 				SetID(ticketID).
 				SetEventID(eventID).
 				SetOperationType(entapprovalticket.OperationTypeCREATE).
@@ -641,8 +700,8 @@ func ensureApprovalTickets(ctx context.Context, client *ent.Client, adminID stri
 				SetRequester("e2e-seed").
 				SetReason(fmt.Sprintf("E2E seed ticket for %s test", suffix)).
 				Save(ctx)
-			if err != nil {
-				return fmt.Errorf("create approval ticket %s: %w", ticketID, err)
+			if createTicketErr != nil {
+				return fmt.Errorf("create approval ticket %s: %w", ticketID, createTicketErr)
 			}
 		} else {
 			// Reset to PENDING if it was previously approved/rejected during a test run
@@ -723,71 +782,218 @@ func ensureNotifications(ctx context.Context, client *ent.Client, adminID string
 // ensureBatchApprovalTickets creates batch operation records for tests that
 // exercise retryVMBatch (needs a FAILED batch) and cancelVMBatch (needs an
 // IN_PROGRESS or PENDING_APPROVAL batch).
-func ensureBatchApprovalTickets(ctx context.Context, client *ent.Client, createdBy string) error {
-	batches := []struct {
-		id        string
-		batchType entbatchapprovalticket.BatchType
-		status    entbatchapprovalticket.Status
-		child     int
-		success   int
-		failed    int
-		pending   int
-	}{
+func ensureBatchApprovalTickets(
+	ctx context.Context,
+	client *ent.Client,
+	createdBy string,
+	clusterID string,
+	namespaceName string,
+) error {
+	type childFixture struct {
+		status       entapprovalticket.Status
+		rejectReason string
+	}
+	type batchFixture struct {
+		id                 string
+		parentEventStatus  entdomainevent.Status
+		parentTicketStatus entapprovalticket.Status
+		projectionStatus   entbatchapprovalticket.Status
+		children           []childFixture
+	}
+
+	serviceID := defaultServiceName
+	if svc, err := client.Service.Query().Where(entservice.NameEQ(defaultServiceName)).Only(ctx); err == nil {
+		serviceID = svc.ID
+	}
+	templateID := defaultTemplateName
+	if tpl, err := client.Template.Query().Where(enttemplate.NameEQ(defaultTemplateName)).Only(ctx); err == nil {
+		templateID = tpl.ID
+	}
+	sizeID := defaultSizeName
+	if size, err := client.InstanceSize.Query().Where(entinstancesize.NameEQ(defaultSizeName)).Only(ctx); err == nil {
+		sizeID = size.ID
+	}
+	selectedClusterID := strings.TrimSpace(clusterID)
+	selectedStorageClass := ""
+	if selectedClusterID != "" {
+		if clusterObj, err := client.Cluster.Get(ctx, selectedClusterID); err == nil {
+			selectedStorageClass = strings.TrimSpace(clusterObj.DefaultStorageClass)
+		}
+	}
+	seedNamespace := strings.TrimSpace(namespaceName)
+	if seedNamespace == "" {
+		seedNamespace = defaultNamespaceName
+	}
+
+	batches := []batchFixture{
 		{
-			id:        "batch-e2e-seed-failed",
-			batchType: entbatchapprovalticket.BatchTypeBATCH_CREATE,
-			status:    entbatchapprovalticket.StatusFAILED,
-			child:     3,
-			success:   1,
-			failed:    2,
-			pending:   0,
+			id:                 "batch-e2e-seed-failed",
+			parentEventStatus:  entdomainevent.StatusFAILED,
+			parentTicketStatus: entapprovalticket.StatusFAILED,
+			projectionStatus:   entbatchapprovalticket.StatusFAILED,
+			children: []childFixture{
+				{status: entapprovalticket.StatusSUCCESS},
+				{status: entapprovalticket.StatusFAILED, rejectReason: "seeded failed child for retry"},
+				{status: entapprovalticket.StatusREJECTED, rejectReason: "seeded rejected child for retry"},
+			},
 		},
 		{
-			id:        "batch-e2e-seed-pending",
-			batchType: entbatchapprovalticket.BatchTypeBATCH_CREATE,
-			status:    entbatchapprovalticket.StatusIN_PROGRESS,
-			child:     5,
-			success:   0,
-			failed:    0,
-			pending:   5,
+			id:                 "batch-e2e-seed-pending",
+			parentEventStatus:  entdomainevent.StatusPENDING,
+			parentTicketStatus: entapprovalticket.StatusPENDING,
+			projectionStatus:   entbatchapprovalticket.StatusIN_PROGRESS,
+			children: []childFixture{
+				{status: entapprovalticket.StatusPENDING},
+				{status: entapprovalticket.StatusPENDING},
+				{status: entapprovalticket.StatusPENDING},
+				{status: entapprovalticket.StatusPENDING},
+				{status: entapprovalticket.StatusPENDING},
+			},
 		},
 	}
 
 	for _, b := range batches {
-		exists, err := client.BatchApprovalTicket.Query().
-			Where(entbatchapprovalticket.IDEQ(b.id)).
-			Exist(ctx)
+		parentEventID := fmt.Sprintf("evt-%s-parent", b.id)
+		parentReason := "Seeded by e2e-seed for batch operation testing"
+
+		existingChildren, err := client.ApprovalTicket.Query().
+			Where(entapprovalticket.ParentTicketIDEQ(b.id)).
+			All(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("query existing child tickets for batch %s: %w", b.id, err)
 		}
-		if exists {
-			// Reset counters and status for idempotent re-runs
-			_, err := client.BatchApprovalTicket.UpdateOneID(b.id).
-				SetStatus(b.status).
-				SetChildCount(b.child).
-				SetSuccessCount(b.success).
-				SetFailedCount(b.failed).
-				SetPendingCount(b.pending).
-				Save(ctx)
-			if err != nil {
-				return fmt.Errorf("reset batch %s: %w", b.id, err)
-			}
-			continue
+		staleEventIDs := make([]string, 0, len(existingChildren)+1)
+		for _, child := range existingChildren {
+			staleEventIDs = append(staleEventIDs, child.EventID)
 		}
-		_, err = client.BatchApprovalTicket.Create().
-			SetID(b.id).
-			SetBatchType(b.batchType).
-			SetStatus(b.status).
-			SetChildCount(b.child).
-			SetSuccessCount(b.success).
-			SetFailedCount(b.failed).
-			SetPendingCount(b.pending).
+		staleEventIDs = append(staleEventIDs, parentEventID)
+
+		if _, err := client.ApprovalTicket.Delete().
+			Where(entapprovalticket.ParentTicketIDEQ(b.id)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("delete existing child tickets for batch %s: %w", b.id, err)
+		}
+		if err := client.ApprovalTicket.DeleteOneID(b.id).Exec(ctx); err != nil && !ent.IsNotFound(err) {
+			return fmt.Errorf("delete parent ticket for batch %s: %w", b.id, err)
+		}
+		if _, err := client.DomainEvent.Delete().
+			Where(entdomainevent.IDIn(staleEventIDs...)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("delete stale events for batch %s: %w", b.id, err)
+		}
+		if err := client.BatchApprovalTicket.DeleteOneID(b.id).Exec(ctx); err != nil && !ent.IsNotFound(err) {
+			return fmt.Errorf("delete projection for batch %s: %w", b.id, err)
+		}
+
+		parentPayload, _ := json.Marshal(map[string]interface{}{
+			"operation":    "CREATE",
+			"request_id":   fmt.Sprintf("seed-%s", b.id),
+			"reason":       parentReason,
+			"submitted_by": createdBy,
+			"items":        []map[string]interface{}{},
+		})
+		if _, err := client.DomainEvent.Create().
+			SetID(parentEventID).
+			SetEventType(string(domain.EventBatchCreateRequested)).
+			SetAggregateType("batch").
+			SetAggregateID(b.id).
+			SetPayload(parentPayload).
+			SetStatus(b.parentEventStatus).
 			SetCreatedBy(createdBy).
-			SetReason("Seeded by e2e-seed for batch operation testing").
-			Save(ctx)
-		if err != nil {
-			return fmt.Errorf("create batch %s: %w", b.id, err)
+			Save(ctx); err != nil {
+			return fmt.Errorf("create parent event for batch %s: %w", b.id, err)
+		}
+		parentCreate := client.ApprovalTicket.Create().
+			SetID(b.id).
+			SetEventID(parentEventID).
+			SetOperationType(entapprovalticket.OperationTypeCREATE).
+			SetStatus(b.parentTicketStatus).
+			SetRequester(createdBy).
+			SetReason(parentReason)
+		// For FAILED parent batches used by retryVMBatch, seed the selected
+		// cluster context to match real approved CREATE tickets.
+		if b.parentTicketStatus != entapprovalticket.StatusPENDING && selectedClusterID != "" {
+			parentCreate = parentCreate.SetSelectedClusterID(selectedClusterID)
+			if selectedStorageClass != "" {
+				parentCreate = parentCreate.SetSelectedStorageClass(selectedStorageClass)
+			}
+		}
+		if _, err := parentCreate.Save(ctx); err != nil {
+			return fmt.Errorf("create parent ticket for batch %s: %w", b.id, err)
+		}
+
+		successCount := 0
+		failedCount := 0
+		pendingCount := 0
+		for idx, child := range b.children {
+			childEventID := fmt.Sprintf("evt-%s-child-%02d", b.id, idx+1)
+			childTicketID := fmt.Sprintf("tkt-%s-child-%02d", b.id, idx+1)
+			childReason := fmt.Sprintf("Seeded batch child %d for %s", idx+1, b.id)
+			childPayload, _ := json.Marshal(map[string]interface{}{
+				"requester_id":      createdBy,
+				"service_id":        serviceID,
+				"template_id":       templateID,
+				"instance_size_id":  sizeID,
+				"namespace":         seedNamespace,
+				"reason":            childReason,
+				"batch_seed_ticket": childTicketID,
+			})
+
+			var childEventStatus entdomainevent.Status
+			switch child.status {
+			case entapprovalticket.StatusSUCCESS:
+				successCount++
+				childEventStatus = entdomainevent.StatusCOMPLETED
+			case entapprovalticket.StatusFAILED, entapprovalticket.StatusREJECTED:
+				failedCount++
+				childEventStatus = entdomainevent.StatusFAILED
+			default:
+				pendingCount++
+				childEventStatus = entdomainevent.StatusPENDING
+			}
+
+			if _, err := client.DomainEvent.Create().
+				SetID(childEventID).
+				SetEventType(string(domain.EventVMCreationRequested)).
+				SetAggregateType("vm").
+				SetAggregateID(serviceID).
+				SetPayload(childPayload).
+				SetStatus(childEventStatus).
+				SetCreatedBy(createdBy).
+				Save(ctx); err != nil {
+				return fmt.Errorf("create child event %s for batch %s: %w", childEventID, b.id, err)
+			}
+
+			childCreate := client.ApprovalTicket.Create().
+				SetID(childTicketID).
+				SetEventID(childEventID).
+				SetOperationType(entapprovalticket.OperationTypeCREATE).
+				SetStatus(child.status).
+				SetRequester(createdBy).
+				SetReason(childReason).
+				SetParentTicketID(b.id)
+			if child.rejectReason != "" {
+				childCreate = childCreate.SetRejectReason(child.rejectReason)
+			}
+			if _, err := childCreate.Save(ctx); err != nil {
+				return fmt.Errorf("create child ticket %s for batch %s: %w", childTicketID, b.id, err)
+			}
+		}
+
+		if _, err := client.BatchApprovalTicket.Create().
+			SetBatchType(entbatchapprovalticket.BatchTypeBATCH_CREATE).
+			SetStatus(b.projectionStatus).
+			SetChildCount(len(b.children)).
+			SetSuccessCount(successCount).
+			SetFailedCount(failedCount).
+			SetPendingCount(pendingCount).
+			SetID(b.id).
+			SetCreatedBy(createdBy).
+			SetReason(parentReason).
+			Save(ctx); err != nil {
+			return fmt.Errorf("create projection for batch %s: %w", b.id, err)
 		}
 	}
+
 	return nil
 }

--- a/cmd/e2e-seed/main_test.go
+++ b/cmd/e2e-seed/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	entcluster "kv-shepherd.io/shepherd/ent/cluster"
+)
 
 func TestEnvOrDefault(t *testing.T) {
 	t.Setenv("E2E_TEST_KEY", "")
@@ -18,6 +24,7 @@ func TestLoadFixtureConfig_Defaults(t *testing.T) {
 	t.Setenv("E2E_ADMIN_USERNAME", "")
 	t.Setenv("E2E_ADMIN_PASSWORD", "")
 	t.Setenv("E2E_NAMESPACE", "")
+	t.Setenv("E2E_CLUSTER_API_SERVER", "")
 
 	cfg := loadFixtureConfig()
 	if cfg.AdminUsername != defaultAdminUsername {
@@ -29,12 +36,16 @@ func TestLoadFixtureConfig_Defaults(t *testing.T) {
 	if cfg.NamespaceName != defaultNamespaceName {
 		t.Fatalf("NamespaceName = %q, want %q", cfg.NamespaceName, defaultNamespaceName)
 	}
+	if cfg.ClusterAPIURL != defaultClusterAPIURL {
+		t.Fatalf("ClusterAPIURL = %q, want %q", cfg.ClusterAPIURL, defaultClusterAPIURL)
+	}
 }
 
 func TestLoadFixtureConfig_Overrides(t *testing.T) {
 	t.Setenv("E2E_ADMIN_USERNAME", "tester")
 	t.Setenv("E2E_ADMIN_PASSWORD", "password-1")
 	t.Setenv("E2E_NAMESPACE", "ns-live")
+	t.Setenv("E2E_CLUSTER_API_SERVER", "https://override.cluster.invalid")
 	t.Setenv("E2E_VM_RUNNING_ID", "vm-live-x")
 
 	cfg := loadFixtureConfig()
@@ -49,5 +60,74 @@ func TestLoadFixtureConfig_Overrides(t *testing.T) {
 	}
 	if cfg.RunningVMID != "vm-live-x" {
 		t.Fatalf("RunningVMID = %q, want vm-live-x", cfg.RunningVMID)
+	}
+	if cfg.ClusterAPIURL != "https://override.cluster.invalid" {
+		t.Fatalf("ClusterAPIURL = %q, want override URL", cfg.ClusterAPIURL)
+	}
+}
+
+func TestResolveClusterSeedInput_DefaultFallback(t *testing.T) {
+	t.Setenv("E2E_KUBECONFIG_B64", "")
+
+	input, err := resolveClusterSeedInput(fixtureConfig{ClusterAPIURL: "https://seed-api.invalid"})
+	if err != nil {
+		t.Fatalf("resolveClusterSeedInput() unexpected error: %v", err)
+	}
+	if input.APIServer != "https://seed-api.invalid" {
+		t.Fatalf("APIServer = %q, want %q", input.APIServer, "https://seed-api.invalid")
+	}
+	if input.Status != entcluster.StatusUNREACHABLE {
+		t.Fatalf("Status = %q, want %q", input.Status, entcluster.StatusUNREACHABLE)
+	}
+	if got := strings.TrimSpace(string(input.Kubeconfig)); got == "" {
+		t.Fatal("Kubeconfig should use non-empty fallback stub")
+	}
+}
+
+func TestResolveClusterSeedInput_InvalidBase64(t *testing.T) {
+	t.Setenv("E2E_KUBECONFIG_B64", "%%%not-base64%%%")
+
+	_, err := resolveClusterSeedInput(fixtureConfig{ClusterAPIURL: defaultClusterAPIURL})
+	if err == nil {
+		t.Fatal("resolveClusterSeedInput() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "decode E2E_KUBECONFIG_B64") {
+		t.Fatalf("error = %v, want decode failure", err)
+	}
+}
+
+func TestResolveClusterSeedInput_UsesKubeconfigServerWhenDefaultAPIURL(t *testing.T) {
+	raw := strings.TrimSpace(`
+apiVersion: v1
+kind: Config
+clusters:
+  - name: c1
+    cluster:
+      server: https://kube-from-config.invalid
+contexts:
+  - name: c1
+    context:
+      cluster: c1
+      user: u1
+current-context: c1
+users:
+  - name: u1
+    user:
+      token: test-token
+`)
+	t.Setenv("E2E_KUBECONFIG_B64", base64.StdEncoding.EncodeToString([]byte(raw)))
+
+	input, err := resolveClusterSeedInput(fixtureConfig{ClusterAPIURL: defaultClusterAPIURL})
+	if err != nil {
+		t.Fatalf("resolveClusterSeedInput() unexpected error: %v", err)
+	}
+	if input.APIServer != "https://kube-from-config.invalid" {
+		t.Fatalf("APIServer = %q, want kubeconfig server", input.APIServer)
+	}
+	if input.Status != entcluster.StatusHEALTHY {
+		t.Fatalf("Status = %q, want %q", input.Status, entcluster.StatusHEALTHY)
+	}
+	if len(input.Kubeconfig) == 0 {
+		t.Fatal("Kubeconfig should not be empty")
 	}
 }

--- a/docs/design/traceability/master-flow-tests.json
+++ b/docs/design/traceability/master-flow-tests.json
@@ -31,15 +31,26 @@
     {
       "id": "stage-1",
       "tests": [
+        "internal/app/bootstrap_test.go",
         "internal/config/config_test.go",
-        "internal/app/bootstrap_test.go"
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 1 / Step 1",
+        "Stage 1 / Step 2"
       ]
     },
     {
       "id": "stage-1-5",
       "tests": [
+        "internal/api/handlers/server_auth_test.go",
         "internal/config/secret_bootstrap_test.go",
-        "internal/api/handlers/server_auth_test.go"
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 1.5 / Step 1",
+        "Stage 1.5 / Step 2",
+        "Stage 1.5 / Step 3"
       ]
     },
     {
@@ -47,21 +58,35 @@
       "tests": [
         "cmd/seed/main_test.go",
         "internal/api/middleware/jwt_test.go",
-        "internal/api/middleware/rbac_test.go"
+        "internal/api/middleware/rbac_test.go",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2 / Step 1",
+        "Stage 2 / Step 2"
       ]
     },
     {
       "id": "stage-2-a",
       "tests": [
         "cmd/seed/main_test.go",
-        "internal/api/middleware/rbac_test.go"
+        "internal/api/middleware/rbac_test.go",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2.A / Step 1"
       ]
     },
     {
       "id": "stage-2-a-plus",
       "tests": [
         "internal/api/middleware/rbac_test.go",
-        "internal/api/handlers/member_test.go"
+        "internal/api/handlers/server_admin_identity_test.go",
+        "web/tests/e2e/admin-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2.A+ / Step 1",
+        "Stage 2.A+ / Step 2"
       ]
     },
     {
@@ -69,7 +94,12 @@
       "tests": [
         "internal/api/middleware/jwt_test.go",
         "internal/api/handlers/server_admin_identity_test.go",
+        "web/tests/e2e/admin-flow-live.spec.ts",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2.B / Step 1",
+        "Stage 2.B / Step 2"
       ]
     },
     {
@@ -77,7 +107,10 @@
       "tests": [
         "internal/api/middleware/jwt_test.go",
         "internal/api/handlers/server_admin_identity_test.go",
-        "web/tests/e2e/master-flow-live.spec.ts"
+        "web/tests/e2e/admin-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2.C / Step 1"
       ]
     },
     {
@@ -86,6 +119,9 @@
         "internal/api/handlers/environment_visibility_test.go",
         "internal/api/middleware/jwt_test.go",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2.D / Step 1"
       ]
     },
     {
@@ -94,7 +130,14 @@
         "internal/app/modules/approval_test.go",
         "internal/governance/approval/gateway_behavior_test.go",
         "internal/governance/approval/gateway_test.go",
-        "web/src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx"
+        "web/src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 2.E / Step 1",
+        "Stage 2.E / Step 2",
+        "Stage 2.E / Step 3",
+        "Stage 2.E / Step 4"
       ]
     },
     {
@@ -105,14 +148,25 @@
         "internal/api/handlers/permission_enforcement_test.go",
         "web/src/features/admin-templates/hooks/useAdminTemplatesController.test.tsx",
         "web/src/features/admin-instance-sizes/hooks/useAdminInstanceSizesController.test.tsx",
+        "web/tests/e2e/admin-flow-live.spec.ts",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 3 / Step 1",
+        "Stage 3 / Step 2",
+        "Stage 3 / Step 3",
+        "Stage 3 / Step 4"
       ]
     },
     {
       "id": "stage-3-c",
       "tests": [
+        "internal/jobs/vm_create_test.go",
         "internal/usecase/approval_atomic_test.go",
-        "internal/jobs/vm_create_test.go"
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 3.C / Step 1"
       ]
     },
     {
@@ -120,7 +174,12 @@
       "tests": [
         "internal/jobs/vm_create_test.go",
         "internal/service/approval_validator_test.go",
-        "internal/usecase/approval_atomic_test.go"
+        "internal/usecase/approval_atomic_test.go",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 3.JIT Namespace / Step 1",
+        "Stage 3.JIT Namespace / Step 2"
       ]
     },
     {
@@ -133,6 +192,9 @@
         "web/src/features/systems-management/hooks/useSystemsManagementController.test.tsx",
         "web/src/features/systems-management/hooks/useSystemMembersController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 4.A / Step 1"
       ]
     },
     {
@@ -140,7 +202,11 @@
       "tests": [
         "internal/api/middleware/rbac_test.go",
         "internal/api/handlers/member_test.go",
-        "web/src/features/systems-management/hooks/useSystemMembersController.test.tsx"
+        "web/src/features/systems-management/hooks/useSystemMembersController.test.tsx",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 4.A+ / Step 1"
       ]
     },
     {
@@ -151,6 +217,9 @@
         "internal/api/middleware/rbac_test.go",
         "web/src/features/services-management/hooks/useServicesManagementController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 4.B / Step 1"
       ]
     },
     {
@@ -160,7 +229,12 @@
         "internal/api/handlers/server_system_stage_test.go",
         "internal/api/middleware/openapi_validator_test.go",
         "web/src/features/systems-management/hooks/useSystemsManagementController.test.tsx",
-        "web/src/features/services-management/hooks/useServicesManagementController.test.tsx"
+        "web/src/features/services-management/hooks/useServicesManagementController.test.tsx",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 4.C / Step 1",
+        "Stage 4.C / Step 2"
       ]
     },
     {
@@ -170,7 +244,12 @@
         "internal/api/handlers/server_system_stage_test.go",
         "internal/api/middleware/openapi_validator_test.go",
         "web/src/features/systems-management/hooks/useSystemsManagementController.test.tsx",
-        "web/src/features/services-management/hooks/useServicesManagementController.test.tsx"
+        "web/src/features/services-management/hooks/useServicesManagementController.test.tsx",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 4.C / Step 1",
+        "Stage 4.C / Step 2"
       ]
     },
     {
@@ -180,6 +259,11 @@
         "internal/jobs/vm_create_test.go",
         "web/src/features/vm-management/hooks/useVMManagementController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 5.A / Step 1",
+        "Stage 5.A / Step 2",
+        "Stage 5.A / Step 3"
       ]
     },
     {
@@ -188,13 +272,24 @@
         "internal/governance/approval/gateway_behavior_test.go",
         "internal/governance/approval/gateway_test.go",
         "internal/service/approval_validator_test.go",
-        "web/src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx"
+        "web/src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 5.B / Step 1",
+        "Stage 5.B / Step 2",
+        "Stage 5.B / Step 3"
       ]
     },
     {
       "id": "stage-5b-constraint-note-dedicated-cpu-vs-overcommit",
       "tests": [
-        "internal/service/approval_validator_test.go"
+        "internal/service/approval_validator_test.go",
+        "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 5.B Constraint / Step 1",
+        "Stage 5.B Constraint / Step 2"
       ]
     },
     {
@@ -206,6 +301,9 @@
         "web/src/features/systems-management/hooks/useSystemsManagementController.test.tsx",
         "web/src/features/vm-management/hooks/useVMManagementController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 5.D / Step 1"
       ]
     },
     {
@@ -215,6 +313,11 @@
         "internal/api/handlers/server_vm_batch_behavior_test.go",
         "web/src/features/vm-management/hooks/useVMManagementController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 5.E / Step 1",
+        "Stage 5.E / Step 2-5",
+        "Stage 5.E / Step 6"
       ]
     },
     {
@@ -224,6 +327,11 @@
         "internal/api/handlers/server_notification_behavior_test.go",
         "web/src/features/notifications/hooks/useNotificationsController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 5.F / Step 1",
+        "Stage 5.F / Step 2",
+        "Stage 5.F / Step 3"
       ]
     },
     {
@@ -235,6 +343,13 @@
         "internal/governance/approval/gateway_behavior_test.go",
         "web/src/features/vm-management/hooks/useVMManagementController.test.tsx",
         "web/tests/e2e/master-flow-live.spec.ts"
+      ],
+      "live_step_markers": [
+        "Stage 6 / Step 1",
+        "Stage 6 / Step 2",
+        "Stage 6 / Step 3",
+        "Stage 6 / Step 4",
+        "Stage 6 / Step 5"
       ]
     }
   ]

--- a/scripts/run_e2e_live.sh
+++ b/scripts/run_e2e_live.sh
@@ -2,6 +2,37 @@
 
 set -euo pipefail
 
+LOG_TS_FORMAT="${LOG_TS_FORMAT:-%Y-%m-%dT%H:%M:%S%z}"
+ts_now() {
+  date +"${LOG_TS_FORMAT}"
+}
+
+log_info() {
+  printf '%s INFO: %s\n' "$(ts_now)" "$*"
+}
+
+log_warn() {
+  printf '%s WARN: %s\n' "$(ts_now)" "$*"
+}
+
+log_error() {
+  printf '%s ERROR: %s\n' "$(ts_now)" "$*" >&2
+}
+
+run_live_e2e_preflight_checks() {
+  local skip="${E2E_SKIP_PREFLIGHT_GATES:-0}"
+  if [[ "${skip}" == "1" ]]; then
+    log_warn "skipping live-e2e preflight gates (E2E_SKIP_PREFLIGHT_GATES=1)"
+    return 0
+  fi
+
+  log_info "running master-flow test matrix gate (includes live_step_markers checks)"
+  go run docs/design/ci/scripts/check_master_flow_test_matrix.go
+
+  log_info "running live-e2e no-mock policy gate"
+  bash docs/design/ci/scripts/check_live_e2e_no_mock.sh
+}
+
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
@@ -33,6 +64,16 @@ Options:
   --result-file <path>   Background mode result file path (default: <output-dir>/YYYYMMDD/HHMM/live-e2e.result)
   --state-file <path>    Status metadata file (default: <output-dir>/latest.env)
   -h, --help             Show this help
+
+Environment:
+  E2E_SKIP_PREFLIGHT_GATES=1
+                         Skip preflight gates (master-flow test matrix + live-e2e no-mock policy)
+  E2E_BACKEND_CRITICAL_GUARD=0
+                         Disable backend critical-log guard (default: enabled)
+  E2E_BACKEND_STRICT_GUARD=1
+                         Enable strict backend-log patterns (default: disabled to reduce false positives)
+  E2E_BACKEND_ERROR_ALLOWLIST_REGEX=<regex>
+                         Ignore matching backend-log lines in guard checks
 EOF
 }
 
@@ -117,6 +158,77 @@ extract_result_summary() {
   echo "failed=${failed} flaky=${flaky} passed=${passed} total=${total} pass_rate=${pass_rate}%"
 }
 
+check_backend_critical_errors() {
+  local log_file="$1"
+  local allow_regex="${E2E_BACKEND_ERROR_ALLOWLIST_REGEX:-}"
+  # Strict backend pattern gate is opt-in to avoid CI flakiness from
+  # environment-dependent warnings unrelated to user-visible regressions.
+  local strict_guard="${E2E_BACKEND_STRICT_GUARD:-0}"
+  local findings=""
+  local pattern matched
+
+  if [[ ! -f "${log_file}" ]]; then
+    log_warn "backend log file not found for critical-error guard: ${log_file}"
+    return 0
+  fi
+
+  # High-signal backend failures that should fail live E2E even when Playwright UI
+  # assertions happen to pass.
+  local -a critical_patterns=(
+    "OpenAPI response validation failed"
+    "OpenAPI validator setup failed"
+    "failed to send APPROVAL_(PENDING|COMPLETED|REJECTED) notification"
+    "violates foreign key constraint \\\"notifications_users_notifications\\\""
+    "panic:"
+    "fatal error:"
+  )
+
+  # Strict guard (master-flow aligned): detect latent backend behavior drift that
+  # often slips past page-level assertions.
+  local -a strict_patterns=(
+    "Cluster health check failed"
+    "jobexecutor.JobExecutor: Job errored"
+    "no approvers found for notification"
+  )
+
+  for pattern in "${critical_patterns[@]}"; do
+    matched="$(rg -n --no-heading -e "${pattern}" "${log_file}" || true)"
+    if [[ -n "${matched}" ]]; then
+      findings+="${matched}"$'\n'
+    fi
+  done
+
+  if [[ "${strict_guard}" != "0" ]]; then
+    for pattern in "${strict_patterns[@]}"; do
+      matched="$(rg -n --no-heading -e "${pattern}" "${log_file}" || true)"
+      if [[ -n "${matched}" ]]; then
+        findings+="${matched}"$'\n'
+      fi
+    done
+  fi
+
+  if [[ -z "${findings}" ]]; then
+    return 0
+  fi
+
+  # De-duplicate and drop empty lines.
+  findings="$(printf '%s' "${findings}" | awk 'NF && !seen[$0]++')"
+
+  if [[ -n "${allow_regex}" ]]; then
+    findings="$(printf '%s\n' "${findings}" | rg -v -e "${allow_regex}" || true)"
+  fi
+
+  if [[ -n "${findings//[[:space:]]/}" ]]; then
+    log_error "critical backend errors detected in ${log_file}"
+    printf '%s\n' "${findings}" | sed 's/^/  /' >&2
+    log_error "set E2E_BACKEND_ERROR_ALLOWLIST_REGEX to suppress known non-blocking signatures"
+    log_error "set E2E_BACKEND_STRICT_GUARD=0 to disable strict backend pattern gate"
+    return 1
+  fi
+
+  return 0
+}
+
 port_in_use() {
   local port="$1"
   if command -v ss >/dev/null 2>&1; then
@@ -138,6 +250,61 @@ port_in_use() {
   fi
 
   return 1
+}
+
+port_listener_pids() {
+  local port="$1"
+  local out=""
+
+  if command -v ss >/dev/null 2>&1; then
+    out="$(ss -ltnp "sport = :${port}" 2>/dev/null | sed -n 's/.*pid=\([0-9]\+\).*/\1/p' | sort -u | tr '\n' ' ')"
+  elif command -v lsof >/dev/null 2>&1; then
+    out="$(lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null | sort -u | tr '\n' ' ')"
+  fi
+
+  echo "${out}"
+}
+
+cleanup_next_web_port() {
+  local port="${1:-}"
+  local pid cmd cwd ppid pcmd
+  if [[ -z "${port}" ]]; then
+    return 0
+  fi
+
+  for pid in $(port_listener_pids "${port}"); do
+    [[ -z "${pid}" ]] && continue
+    if ! ps -p "${pid}" -o pid= >/dev/null 2>&1; then
+      continue
+    fi
+    cmd="$(ps -p "${pid}" -o cmd= 2>/dev/null || true)"
+    cwd="$(readlink -f "/proc/${pid}/cwd" 2>/dev/null || true)"
+    ppid="$(ps -p "${pid}" -o ppid= 2>/dev/null | tr -d ' ' || true)"
+    pcmd=""
+    if [[ -n "${ppid}" ]] && ps -p "${ppid}" -o pid= >/dev/null 2>&1; then
+      pcmd="$(ps -p "${ppid}" -o cmd= 2>/dev/null || true)"
+    fi
+
+    # Only kill Next.js listeners started from this repo's web workspace (or their matching parent).
+    if [[ "${cwd}" != "${ROOT_DIR}/web" ]] && [[ "${pcmd}" != *"--port ${port}"* ]]; then
+      continue
+    fi
+
+    if [[ "${cmd}" == *"next-server"* ]] || [[ "${pcmd}" == *"next "* ]] || [[ "${pcmd}" == *"node "*".bin/next"* ]]; then
+      log_warn "cleaning residual Next.js listener on port ${port} (pid=${pid})"
+      kill "${pid}" >/dev/null 2>&1 || true
+      if [[ -n "${ppid}" ]] && [[ "${pcmd}" == *"--port ${port}"* ]] && ([[ "${pcmd}" == *"next "* ]] || [[ "${pcmd}" == *".bin/next"* ]]); then
+        kill "${ppid}" >/dev/null 2>&1 || true
+      fi
+    fi
+  done
+
+  for _ in $(seq 1 20); do
+    if ! port_in_use "${port}"; then
+      break
+    fi
+    sleep 0.2
+  done
 }
 
 cleanup_residual_pg_on_port() {
@@ -172,13 +339,39 @@ cleanup_residual_pg_on_port() {
   done < <(docker ps -aq 2>/dev/null || true)
 
   if (( ${#to_remove[@]} > 0 )); then
-    echo "INFO: removing residual PostgreSQL containers on port ${target_port}: ${to_remove[*]}"
+    log_info "removing residual PostgreSQL containers on port ${target_port}: ${to_remove[*]}"
     docker rm -f "${to_remove[@]}" >/dev/null 2>&1 || true
   fi
 }
 
+# Remove any residual shepherd E2E containers left by a previous aborted run.
+# Matches containers whose name starts with shepherd-e2e-* or shepherd-test-*.
+# Called unconditionally before the DB wrapper so stale containers cannot
+# occupy the test port and cause a confusing "port in use" error.
+cleanup_residual_e2e_containers() {
+  if ! command -v docker > /dev/null 2>&1; then
+    return 0
+  fi
+
+  local cid name
+  local to_remove=()
+
+  while IFS= read -r cid; do
+    [[ -z "${cid}" ]] && continue
+    name="$(docker inspect -f '{{.Name}}' "${cid}" 2>/dev/null | sed 's|^/||' || true)"
+    if [[ "${name}" == shepherd-e2e-* || "${name}" == shepherd-test-* ]]; then
+      to_remove+=("${cid}")
+    fi
+  done < <(docker ps -aq 2>/dev/null || true)
+
+  if (( ${#to_remove[@]} > 0 )); then
+    log_info "removing ${#to_remove[@]} residual shepherd E2E container(s): ${to_remove[*]}"
+    docker rm -f "${to_remove[@]}" > /dev/null 2>&1 || true
+  fi
+}
+
 if [[ "${BACKGROUND}" -eq 1 && "${FOREGROUND}" -eq 1 ]]; then
-  echo "ERROR: --background and --foreground cannot be used together"
+  log_error "--background and --foreground cannot be used together"
   exit 1
 fi
 
@@ -195,7 +388,7 @@ if [[ "$STATUS_ONLY" -eq 1 ]]; then
   fi
 
   if [[ -z "${BG_LOG_FILE}" || -z "${BG_PID_FILE}" ]]; then
-    echo "ERROR: status mode needs --log-file and --pid-file, or a valid --state-file"
+    log_error "status mode needs --log-file and --pid-file, or a valid --state-file"
     exit 1
   fi
 
@@ -276,15 +469,15 @@ BG_PID_FILE=${BG_PID_FILE}
 BG_RESULT_FILE=${BG_RESULT_FILE}
 BG_RUN_DIR=${run_dir}
 EOF
-  echo "INFO: started background live e2e run"
-  echo "INFO: pid=${bg_pid}"
-  echo "INFO: output root: ${BG_OUTPUT_DIR}"
-  echo "INFO: run dir: ${run_dir}"
-  echo "INFO: pid file: ${BG_PID_FILE}"
-  echo "INFO: log file: ${BG_LOG_FILE}"
-  echo "INFO: result file: ${BG_RESULT_FILE}"
-  echo "INFO: reminder: poll status every 5 minutes (not log content) until completion"
-  echo "INFO: command: bash scripts/run_e2e_live.sh --status --state-file ${BG_STATE_FILE}"
+  log_info "started background live e2e run"
+  log_info "pid=${bg_pid}"
+  log_info "output root: ${BG_OUTPUT_DIR}"
+  log_info "run dir: ${run_dir}"
+  log_info "pid file: ${BG_PID_FILE}"
+  log_info "log file: ${BG_LOG_FILE}"
+  log_info "result file: ${BG_RESULT_FILE}"
+  log_info "reminder: poll status every 5 minutes (not log content) until completion"
+  log_info "command: bash scripts/run_e2e_live.sh --status --state-file ${BG_STATE_FILE}"
   exit 0
 fi
 
@@ -294,21 +487,25 @@ if [[ "$NO_DB_WRAPPER" -eq 0 ]]; then
   # Live E2E default: always run against an isolated PostgreSQL test container.
   PG_IMAGE="${PG_IMAGE:-postgres:18}"
   E2E_PG_PORT="${E2E_PG_PORT:-55432}"
+  # First, sweep ALL shepherd E2E/test containers (catches stale DB containers
+  # from any previous aborted run regardless of port configuration).
+  cleanup_residual_e2e_containers
+  # Then do the port-specific check as a safety net.
   cleanup_residual_pg_on_port "${E2E_PG_PORT}"
   if port_in_use "${E2E_PG_PORT}"; then
-    echo "ERROR: port ${E2E_PG_PORT} is still in use after residual cleanup; stop the process and retry"
+    log_error "port ${E2E_PG_PORT} is still in use after residual cleanup; stop the process and retry"
     exit 1
   fi
   exec env PG_PORT="${E2E_PG_PORT}" ./scripts/run_with_docker_pg.sh --image "${PG_IMAGE}" -- bash ./scripts/run_e2e_live.sh --foreground --no-db-wrapper "$@"
 fi
 
 if [[ -z "${DATABASE_URL:-}" ]]; then
-  echo "ERROR: DATABASE_URL is required when --no-db-wrapper is set"
+  log_error "DATABASE_URL is required when --no-db-wrapper is set"
   exit 1
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
-  echo "ERROR: curl command not found"
+  log_error "curl command not found"
   exit 1
 fi
 
@@ -331,15 +528,37 @@ elif [[ -n "${E2E_BACKEND_PORT:-}" ]]; then
 else
   SERVER_PORT="$(pick_free_port || true)"
   if [[ -z "$SERVER_PORT" ]]; then
-    echo "ERROR: unable to allocate free backend port"
+    log_error "unable to allocate free backend port"
     exit 1
   fi
 fi
 
 API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:${SERVER_PORT}}"
-SERVER_LOG="${E2E_SERVER_LOG:-/tmp/shepherd-e2e-server.log}"
 INTERNAL_API_URL="${INTERNAL_API_URL:-http://127.0.0.1:${SERVER_PORT}}"
-SERVER_BIN="${E2E_SERVER_BIN:-/tmp/shepherd-e2e-server-bin}"
+# Resolve the run directory: prefer the parent process's BG_RUN_DIR (set when launched
+# via --background), fall back to an isolated timestamped directory so that direct
+# --foreground / --no-db-wrapper invocations also land in .run/ and never collide.
+E2E_RUN_DIR="${BG_RUN_DIR:-${BG_OUTPUT_DIR}/$(date +%Y%m%d)/$(date +%H%M)-$$}"
+mkdir -p "${E2E_RUN_DIR}"
+SERVER_LOG="${E2E_SERVER_LOG:-${E2E_RUN_DIR}/shepherd-e2e-server.log}"
+SERVER_BIN="${E2E_SERVER_BIN:-${E2E_RUN_DIR}/shepherd-e2e-server-bin}"
+# Use a per-run Next.js dist directory to avoid lock contention on
+# web/.next-e2e/dev/lock when another dev server is alive or a stale lock exists.
+E2E_RUN_ID="$(basename "${E2E_RUN_DIR}")"
+NEXT_DIST_DIR="${NEXT_DIST_DIR:-.next-e2e/${E2E_RUN_ID}}"
+# Keep Next.js tsconfig auto-mutations away from repository files during live E2E.
+NEXT_TSCONFIG_PATH="${NEXT_TSCONFIG_PATH:-.next-e2e/tsconfig.e2e.json}"
+WEB_NEXT_TSCONFIG_PATH="${ROOT_DIR}/web/${NEXT_TSCONFIG_PATH}"
+mkdir -p "$(dirname "${WEB_NEXT_TSCONFIG_PATH}")"
+cat > "${WEB_NEXT_TSCONFIG_PATH}" <<'EOF'
+{
+  "extends": "../tsconfig.json"
+}
+EOF
+log_info "run directory : ${E2E_RUN_DIR}"
+log_info "backend log   : ${SERVER_LOG}"
+log_info "next dist dir : ${NEXT_DIST_DIR}"
+log_info "next tsconfig : ${NEXT_TSCONFIG_PATH}"
 # Use same-origin API path by default to avoid browser CORS between Playwright web port
 # and backend random port. Next.js rewrite (INTERNAL_API_URL) forwards /api/v1 to backend.
 # Keep env override support for explicit direct-base testing when needed.
@@ -349,7 +568,7 @@ if [[ -n "${PW_WEB_PORT:-}" ]]; then
 else
   PW_WEB_PORT="$(pick_free_port || true)"
   if [[ -z "$PW_WEB_PORT" ]]; then
-    echo "ERROR: unable to allocate free Playwright web port"
+    log_error "unable to allocate free Playwright web port"
     exit 1
   fi
 fi
@@ -358,16 +577,44 @@ PW_BASE_URL="${PW_BASE_URL:-http://127.0.0.1:${PW_WEB_PORT}}"
 export SERVER_PORT
 export INTERNAL_API_URL
 export NEXT_PUBLIC_API_URL
+export NEXT_DIST_DIR
+export NEXT_TSCONFIG_PATH
 export PW_WEB_PORT
 export PW_BASE_URL
+# Expose run directory to Playwright config (used for webServer stdout/stderr logs).
+export E2E_RUN_DIR
 export DATABASE_AUTO_MIGRATE="${DATABASE_AUTO_MIGRATE:-true}"
 export SECURITY_SESSION_SECRET="${SECURITY_SESSION_SECRET:-0123456789abcdef0123456789abcdef}"
 export SECURITY_ENCRYPTION_KEY="${SECURITY_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
 # Strict live e2e runs on random Playwright web ports; allow all origins in this
 # test harness to prevent CORS false negatives unrelated to product behavior.
 export SERVER_UNSAFE_ALLOW_ALL_ORIGINS="${SERVER_UNSAFE_ALLOW_ALL_ORIGINS:-true}"
-export E2E_USERNAME="${E2E_USERNAME:-${E2E_ADMIN_USERNAME:-e2e-admin}}"
-export E2E_PASSWORD="${E2E_PASSWORD:-${E2E_ADMIN_PASSWORD:-e2e-admin-123}}"
+# Unified live E2E auth defaults (master-flow first-login reality):
+# default account is admin/admin, and first-login password change target is admin123.
+DEFAULT_E2E_USERNAME="${E2E_USERNAME:-${E2E_ADMIN_USERNAME:-admin}}"
+DEFAULT_E2E_PASSWORD="${E2E_PASSWORD:-${E2E_ADMIN_PASSWORD:-admin}}"
+
+export E2E_USERNAME="${DEFAULT_E2E_USERNAME}"
+export E2E_PASSWORD="${DEFAULT_E2E_PASSWORD}"
+export E2E_NEW_PASSWORD="${E2E_NEW_PASSWORD:-admin123}"
+export E2E_NAMESPACE="${E2E_NAMESPACE:-e2e-live}"
+
+if [[ -z "${E2E_KUBECONFIG_B64:-}" ]]; then
+  DEFAULT_KUBECONFIG_FILE="${ROOT_DIR}/k8s-admin.yaml"
+  if [[ -f "${DEFAULT_KUBECONFIG_FILE}" ]]; then
+    if E2E_KUBECONFIG_B64="$(base64 -w0 "${DEFAULT_KUBECONFIG_FILE}" 2>/dev/null)"; then
+      export E2E_KUBECONFIG_B64
+      log_info "using default live kubeconfig file: ${DEFAULT_KUBECONFIG_FILE}"
+    elif E2E_KUBECONFIG_B64="$(base64 <"${DEFAULT_KUBECONFIG_FILE}" 2>/dev/null | tr -d '\n')"; then
+      export E2E_KUBECONFIG_B64
+      log_info "using default live kubeconfig file: ${DEFAULT_KUBECONFIG_FILE}"
+    fi
+  fi
+fi
+
+# Keep e2e-seed aligned with the same account to avoid user/data drift.
+export E2E_ADMIN_USERNAME="${E2E_ADMIN_USERNAME:-${E2E_USERNAME}}"
+export E2E_ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-${E2E_PASSWORD}}"
 
 SERVER_PID=""
 cleanup() {
@@ -375,27 +622,28 @@ cleanup() {
     kill "$SERVER_PID" >/dev/null 2>&1 || true
     wait "$SERVER_PID" >/dev/null 2>&1 || true
   fi
+  cleanup_next_web_port "${PW_WEB_PORT:-}"
 }
 trap cleanup EXIT INT TERM
 
 if port_in_use "$SERVER_PORT"; then
-  echo "ERROR: backend port ${SERVER_PORT} is already in use"
+  log_error "backend port ${SERVER_PORT} is already in use"
   exit 1
 fi
 
-echo "INFO: building backend server binary"
+log_info "building backend server binary"
 go build -o "$SERVER_BIN" ./cmd/server
 
-echo "INFO: starting backend server on :${SERVER_PORT}"
+log_info "starting backend server on :${SERVER_PORT}"
 "$SERVER_BIN" >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
-echo "INFO: waiting for backend readiness (${API_BASE_URL}/api/v1/health/live)"
+log_info "waiting for backend readiness (${API_BASE_URL}/api/v1/health/live)"
 READY=0
 for _ in $(seq 1 120); do
   if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
-    echo "ERROR: backend server process exited before readiness"
-    echo "INFO: tailing server log ($SERVER_LOG)"
+    log_error "backend server process exited before readiness"
+    log_info "tailing server log ($SERVER_LOG)"
     tail -n 120 "$SERVER_LOG" || true
     exit 1
   fi
@@ -407,25 +655,55 @@ for _ in $(seq 1 120); do
 done
 
 if [[ "$READY" -ne 1 ]]; then
-  echo "ERROR: backend server did not become ready"
-  echo "INFO: tailing server log ($SERVER_LOG)"
+  log_error "backend server did not become ready"
+  log_info "tailing server log ($SERVER_LOG)"
   tail -n 120 "$SERVER_LOG" || true
   exit 1
 fi
 
-echo "INFO: seeding baseline data"
+log_info "seeding baseline data"
 go run ./cmd/seed
 go run ./cmd/e2e-seed
 
-echo "INFO: running live Playwright E2E suite (no mock routes)"
+log_info "running live-e2e preflight gates"
+run_live_e2e_preflight_checks
+
+log_info "running live Playwright E2E suite (no mock routes)"
+DEFAULT_PW_PROJECT="${E2E_PLAYWRIGHT_PROJECT:-live-chromium}"
+HAS_PROJECT_ARG=0
+for arg in "$@"; do
+  if [[ "${arg}" == "--project" || "${arg}" == --project=* ]]; then
+    HAS_PROJECT_ARG=1
+    break
+  fi
+done
+PLAYWRIGHT_ARGS=("$@")
+if [[ "${HAS_PROJECT_ARG}" -eq 0 ]]; then
+  PLAYWRIGHT_ARGS+=("--project=${DEFAULT_PW_PROJECT}")
+fi
+
 set +e
-CI=1 npm --prefix web run test:e2e:live -- "$@"
+CI=1 npm --prefix web run test:e2e:all -- "${PLAYWRIGHT_ARGS[@]}"
 RUN_EXIT_CODE=$?
 set -e
 
+BACKEND_GUARD_EXIT=0
+if [[ "${E2E_BACKEND_CRITICAL_GUARD:-1}" != "0" ]]; then
+  if ! check_backend_critical_errors "${SERVER_LOG}"; then
+    BACKEND_GUARD_EXIT=1
+  fi
+fi
+
+FINAL_EXIT_CODE="${RUN_EXIT_CODE}"
+if [[ "${BACKEND_GUARD_EXIT}" -ne 0 ]]; then
+  FINAL_EXIT_CODE=1
+fi
+
 if [[ -n "${RUN_RESULT_FILE:-}" ]]; then
   {
-    echo "exit_code=${RUN_EXIT_CODE}"
+    echo "exit_code=${FINAL_EXIT_CODE}"
+    echo "playwright_exit_code=${RUN_EXIT_CODE}"
+    echo "backend_guard_exit_code=${BACKEND_GUARD_EXIT}"
     if [[ -n "${RUN_LOG_FILE:-}" ]] && result_line="$(extract_result_summary "${RUN_LOG_FILE}")"; then
       echo "${result_line}"
     else
@@ -434,4 +712,4 @@ if [[ -n "${RUN_RESULT_FILE:-}" ]]; then
   } >"${RUN_RESULT_FILE}"
 fi
 
-exit "${RUN_EXIT_CODE}"
+exit "${FINAL_EXIT_CODE}"

--- a/scripts/run_with_docker_pg.sh
+++ b/scripts/run_with_docker_pg.sh
@@ -2,6 +2,23 @@
 
 set -euo pipefail
 
+LOG_TS_FORMAT="${LOG_TS_FORMAT:-%Y-%m-%dT%H:%M:%S%z}"
+ts_now() {
+  date +"${LOG_TS_FORMAT}"
+}
+
+log_info() {
+  printf '%s INFO: %s\n' "$(ts_now)" "$*"
+}
+
+log_warn() {
+  printf '%s WARN: %s\n' "$(ts_now)" "$*"
+}
+
+log_error() {
+  printf '%s ERROR: %s\n' "$(ts_now)" "$*" >&2
+}
+
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
@@ -40,12 +57,12 @@ EOF
 }
 
 if ! command -v docker >/dev/null 2>&1; then
-  echo "ERROR: docker command not found"
+  log_error "docker command not found"
   exit 1
 fi
 
 if ! docker info >/dev/null 2>&1; then
-  echo "ERROR: docker daemon is not available"
+  log_error "docker daemon is not available"
   exit 1
 fi
 
@@ -100,14 +117,14 @@ CONTAINER_NAME="shepherd-test-pg-$(date +%s)-$RANDOM"
 
 cleanup() {
   if [[ "$KEEP_CONTAINER" -eq 1 ]]; then
-    echo "INFO: keeping container ${CONTAINER_NAME}"
+    log_info "keeping container ${CONTAINER_NAME}"
     return
   fi
   docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
-echo "INFO: starting PostgreSQL test container ${CONTAINER_NAME} (${PG_IMAGE})"
+log_info "starting PostgreSQL test container ${CONTAINER_NAME} (${PG_IMAGE})"
 
 DOCKER_PORT_ARGS=()
 if [[ -n "${PG_PORT}" ]]; then
@@ -130,7 +147,7 @@ if ! docker run -d \
   --health-retries 60 \
   "${PG_IMAGE}" >/dev/null 2>"${RUN_ERR_LOG}"; then
   if [[ -n "${PG_PORT}" ]] && rg -q "Unable to enable OPEN PORT rule|failed to set up container networking" "${RUN_ERR_LOG}"; then
-    echo "WARN: bridge networking failed; retrying PostgreSQL container in host mode on port ${PG_PORT}"
+    log_warn "bridge networking failed; retrying PostgreSQL container in host mode on port ${PG_PORT}"
     docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
     if ! docker run -d \
       --name "${CONTAINER_NAME}" \
@@ -167,7 +184,7 @@ if [[ -z "${PG_PORT}" ]]; then
   done
 
   if [[ -z "${PG_PORT}" ]]; then
-    echo "ERROR: unable to determine mapped PostgreSQL port"
+    log_error "unable to determine mapped PostgreSQL port"
     docker logs "${CONTAINER_NAME}" || true
     exit 1
   fi
@@ -180,12 +197,12 @@ while true; do
     break
   fi
   if [[ "${HEALTH}" == "unhealthy" ]]; then
-    echo "ERROR: PostgreSQL container became unhealthy"
+    log_error "PostgreSQL container became unhealthy"
     docker logs "${CONTAINER_NAME}" || true
     exit 1
   fi
   if (( SECONDS >= DEADLINE )); then
-    echo "ERROR: timed out waiting for PostgreSQL health (${PG_WAIT_TIMEOUT_SEC}s)"
+    log_error "timed out waiting for PostgreSQL health (${PG_WAIT_TIMEOUT_SEC}s)"
     docker logs "${CONTAINER_NAME}" || true
     exit 1
   fi
@@ -194,10 +211,10 @@ done
 
 TEST_DSN="postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DB}?sslmode=disable"
 if [[ "${HOST_NETWORK_MODE}" -eq 1 ]]; then
-  echo "INFO: PostgreSQL is healthy on ${PG_HOST}:${PG_PORT} (host network mode)"
+  log_info "PostgreSQL is healthy on ${PG_HOST}:${PG_PORT} (host network mode)"
 else
-  echo "INFO: PostgreSQL is healthy on ${PG_HOST}:${PG_PORT}"
+  log_info "PostgreSQL is healthy on ${PG_HOST}:${PG_PORT}"
 fi
-echo "INFO: running command: ${COMMAND[*]}"
+log_info "running command: ${COMMAND[*]}"
 
 TEST_DATABASE_URL="${TEST_DSN}" DATABASE_URL="${TEST_DSN}" "${COMMAND[@]}"

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -17,6 +17,7 @@
 
 # next.js
 /.next/
+/.next-e2e/
 /out/
 
 # production

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const isCI = !!process.env.CI;
 const webPort = Number(process.env.PW_WEB_PORT ?? 3000);
 const baseURL = process.env.PW_BASE_URL ?? `http://127.0.0.1:${webPort}`;
 
@@ -12,12 +11,13 @@ const isLive = !!process.env.LIVE_E2E;
 export default defineConfig({
 	testDir: './tests/e2e',
 	fullyParallel: true,
-	forbidOnly: isCI,
+	// forbidOnly is always on: `.only` must never be merged to any branch.
+	forbidOnly: true,
 	// Global retries: smoke uses 2 in CI; live overrides to 1 at project level
 	// (live tests are stateful – excessive retries cause duplicate side-effects)
-	retries: isCI ? 2 : 0,
-	workers: isCI ? 1 : undefined,
-	reporter: isCI ? [['github'], ['html', { open: 'never' }]] : 'list',
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
 	use: {
 		baseURL,
 		trace: 'on-first-retry',
@@ -43,7 +43,7 @@ export default defineConfig({
 			testMatch: /.*-live\.spec\.ts/,
 			// Live tests: only 1 retry — they are stateful (create/delete records)
 			// and re-running a failed test may hit duplicate-key errors.
-			retries: isCI ? 1 : 0,
+			retries: process.env.CI ? 1 : 0,
 			// Per-test timeout: 90 s is enough for all CRUD flows + schema validation.
 			// waitForResponse() inherits this; the previous default of 30 s was too
 			// short for slow CI environments.
@@ -51,19 +51,30 @@ export default defineConfig({
 			use: {
 				...devices['Desktop Chrome'],
 				// Give real backend more time for action interactions (clicks, fills)
-				actionTimeout: isLive || isCI ? 20_000 : 15_000,
+				actionTimeout: isLive || process.env.CI ? 20_000 : 15_000,
 				// Navigation to pages that trigger API calls on mount needs more time
-				navigationTimeout: isLive || isCI ? 45_000 : 30_000,
+				navigationTimeout: isLive || process.env.CI ? 45_000 : 30_000,
 			},
 		},
 	],
 	webServer: {
-		command: isCI
-			? `npm run build && npm run start -- --port ${webPort}`
-			: `npm run dev -- --port ${webPort}`,
+		name: 'Next.js (dev)',
+		// Always run Next.js dev server — faster than production builds and sufficient
+		// for E2E functional coverage. HMR is irrelevant for headless test runs.
+		// When launched via run_e2e_live.sh, the process stdout is already captured
+		// by the shell (nohup redirect in background mode, or tee in foreground).
+		command: `npm run dev -- --port ${webPort}`,
 		url: baseURL,
-		reuseExistingServer: !isCI,
-		// 180 s was enough for Next.js dev; prod build may need more — bumped to 300 s
-		timeout: 300_000,
+		// MUST be false unconditionally: reusing an existing server risks pointing at
+		// a stale process bound to a different backend URL or a different database.
+		// Playwright docs: "if false, Playwright throws an error if it detects
+		// an existing process on the port" — this is the safe, isolated behaviour.
+		reuseExistingServer: false,
+		// Pipe both streams so that they flow through to the parent shell process,
+		// which is responsible for capturing logs (nohup / tee in run_e2e_live.sh).
+		stdout: 'pipe',
+		stderr: 'pipe',
+		// 180 s is ample for Next.js dev cold start; Turbopack makes it even faster.
+		timeout: 180_000,
 	},
 });

--- a/web/tests/e2e/admin-extended-live.spec.ts
+++ b/web/tests/e2e/admin-extended-live.spec.ts
@@ -35,33 +35,53 @@
  * Environment variables:
  *   E2E_USERNAME  – admin username (default: e2e-admin)
  *   E2E_PASSWORD  – admin password (default: e2e-admin-123)
+ *   E2E_NEW_PASSWORD – password used when force_password_change=true
  */
 
-import { expect, test, type Page, type Response } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
-import { urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal } from './lib/helpers';
+import {
+    getAntModal,
+    getApiTokenWithForcePasswordSupport,
+    loginWithForcePasswordSupport,
+    selectAntOption,
+    urlPathEndsWith,
+    urlPathIncludes,
+} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
 const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
+const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
+const e2eKubeconfigB64 = process.env.E2E_KUBECONFIG_B64 ?? 'dGVzdC1rdWJlY29uZmlnLWJhc2U2NA==';
+let activePassword = e2ePassword;
+let seededRateLimitUserID = '';
+
+interface ApiList<T> {
+    items?: T[];
+}
+
+async function getAdminAuthHeaders(request: APIRequestContext): Promise<{ Authorization: string }> {
+    const auth = await getApiTokenWithForcePasswordSupport(request, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
+    activePassword = auth.password;
+    return { Authorization: `Bearer ${auth.token}` };
+}
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
 
 async function login(page: Page): Promise<void> {
-    await page.goto('/login');
-    await expect(page.getByRole('heading', { name: 'KubeVirt Shepherd' })).toBeVisible();
-    await page.getByPlaceholder('Username').fill(e2eUsername);
-    await page.getByPlaceholder('Password').fill(e2ePassword);
-    // operationId: login
-    const loginRespPromise = page.waitForResponse(
-        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
-    );
-    await page.getByRole('button', { name: 'Login' }).click();
-    const loginResp = await loginRespPromise;
-    expect(loginResp.status()).toBe(200);
-    await validateApiResponse('LoginResponse', loginResp);
-    await expect(page).toHaveURL(/\/dashboard$/);
+    activePassword = await loginWithForcePasswordSupport(page, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
 }
 
 async function expectSchema(
@@ -76,9 +96,104 @@ async function expectSchema(
     return { body, resp };
 }
 
+async function seedRateLimitStatusUser(request: APIRequestContext, headers: { Authorization: string }): Promise<string> {
+    const meResp = await request.get('/api/v1/auth/me', { headers });
+    expect(meResp.status(), 'GET /api/v1/auth/me must return 200 in setup').toBe(200);
+    const me = await validateApiResponse('UserInfo', meResp) as { id?: string };
+    const userID = me.id ?? '';
+    expect(userID, 'Auth user id is required for rate-limit seed').toBeTruthy();
+
+    // Rate-limit status rows are built from batch tickets/exemptions/overrides.
+    // Seed via explicit override upsert so this row is deterministic.
+    const overrideResp = await request.put(`/api/v1/admin/rate-limits/users/${userID}`, {
+        headers,
+        data: {
+            max_pending_parents: 8,
+            reason: `admin-extended rate-limit seed ${Date.now()}`,
+        },
+    });
+    expect(overrideResp.status(), 'PUT /admin/rate-limits/users/{id} must return 200 in setup').toBe(200);
+    await validateApiResponse('RateLimitUserOverride', overrideResp);
+
+    await expect.poll(async () => {
+        const statusResp = await request.get('/api/v1/admin/rate-limits/status', { headers });
+        expect(statusResp.status(), 'GET /admin/rate-limits/status must return 200 in setup').toBe(200);
+        const statusBody = await validateApiResponse('RateLimitStatusList', statusResp) as {
+            items?: Array<{ user_id?: string }>;
+        };
+        return statusBody.items?.find((item) => item.user_id === userID)?.user_id ?? '';
+    }, {
+        timeout: 20_000,
+        intervals: [300, 500, 700, 1_000],
+        message: `Rate-limit seed did not produce status row for user ${userID}`,
+    }).toBe(userID);
+
+    return userID;
+}
+
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 test.describe('admin-extended live (contract-enforced, no mock, no skip)', () => {
+    test.beforeAll(async ({ request }) => {
+        // API-first setup (explicit, fail-fast): ensure one provider and one cluster exist.
+        const headers = await getAdminAuthHeaders(request);
+
+        const authResp = await request.get('/api/v1/admin/auth-providers', { headers });
+        expect(authResp.status(), 'GET /api/v1/admin/auth-providers must return 200 in setup').toBe(200);
+        const authData = await validateApiResponse('AuthProviderList', authResp) as ApiList<{ id?: string }>;
+        if ((authData.items ?? []).length === 0) {
+            const typeResp = await request.get('/api/v1/admin/auth-provider-types', { headers });
+            expect(typeResp.status(), 'GET /api/v1/admin/auth-provider-types must return 200 in setup').toBe(200);
+            const typeData = await validateApiResponse('AuthProviderTypeList', typeResp) as ApiList<{ type?: string }>;
+            const authType =
+                typeData.items?.find((item) => item.type === 'oidc')?.type ??
+                typeData.items?.find((item) => item.type === 'generic')?.type ??
+                typeData.items?.[0]?.type ??
+                'generic';
+            const createAuthResp = await request.post('/api/v1/admin/auth-providers', {
+                headers,
+                data: {
+                    name: `setup-auth-${Date.now().toString(36).slice(-5)}`,
+                    auth_type: authType,
+                    config: { test_endpoint: 'https://idp.example.com/healthz' },
+                    enabled: true,
+                },
+            });
+            if (createAuthResp.status() !== 201) {
+                const bodyText = await createAuthResp.text();
+                throw new Error(
+                    `Seed setup failed: POST /api/v1/admin/auth-providers returned ${createAuthResp.status()}.\n` +
+                    `Response body: ${bodyText}`
+                );
+            }
+            await validateApiResponse('AuthProvider', createAuthResp);
+        }
+
+        const clusterResp = await request.get('/api/v1/admin/clusters', { headers });
+        expect(clusterResp.status(), 'GET /api/v1/admin/clusters must return 200 in setup').toBe(200);
+        const clusterData = await validateApiResponse('ClusterList', clusterResp) as ApiList<{ id?: string }>;
+        if ((clusterData.items ?? []).length === 0) {
+            const createClusterResp = await request.post('/api/v1/admin/clusters', {
+                headers,
+                data: {
+                    name: `setup-cluster-${Date.now().toString(36).slice(-5)}`,
+                    kubeconfig: e2eKubeconfigB64,
+                },
+            });
+            if (createClusterResp.status() !== 201) {
+                const bodyText = await createClusterResp.text();
+                throw new Error(
+                    `Seed setup failed: POST /api/v1/admin/clusters returned ${createClusterResp.status()}.\n` +
+                    `Response body: ${bodyText}\n` +
+                    'If kubeconfig validation fails, set E2E_KUBECONFIG_B64 to a valid base64 kubeconfig.'
+                );
+            }
+            await validateApiResponse('Cluster', createClusterResp);
+        }
+
+        seededRateLimitUserID = await seedRateLimitStatusUser(request, headers);
+    });
+
     test.beforeEach(async ({ page }) => {
         await login(page);
     });
@@ -91,14 +206,16 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
     test('listPermissions – GET /admin/permissions conforms to PermissionList schema', async ({ request }) => {
         // operationId: listPermissions
         // The frontend page is static — test the API endpoint directly.
-        const loginResp = await request.post('/api/v1/auth/login', {
-            data: { username: e2eUsername, password: e2ePassword },
+        const auth = await getApiTokenWithForcePasswordSupport(request, {
+            username: e2eUsername,
+            primaryPassword: e2ePassword,
+            secondaryPassword: e2eNewPassword,
+            currentPasswordHint: activePassword,
         });
-        expect(loginResp.ok(), 'API login failed').toBeTruthy();
-        const { token } = await loginResp.json() as { token: string };
+        activePassword = auth.password;
 
         const resp = await request.get('/api/v1/admin/permissions', {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: { Authorization: `Bearer ${auth.token}` },
         });
         expect(resp.status(), `GET /admin/permissions returned ${resp.status()}`).toBe(200);
         const body = await resp.json();
@@ -135,9 +252,11 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         const updateRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/admin/roles/${roleID}`) && r.request().method() === 'PATCH'
         );
+        await expect(page.getByTestId(`rbac-role-action-edit-${roleID}`)).toBeVisible();
         await page.getByTestId(`rbac-role-action-edit-${roleID}`).click();
         const editModal = getAntModal(page, 'rbac-role-edit-modal');
         await expect(editModal).toBeVisible();
+        await editModal.getByRole('textbox').first().fill(`${roleName}-upd`);
         await editModal.locator('textarea').first().fill('Updated by live e2e test');
         await editModal.getByRole('button', { name: 'OK' }).click();
 
@@ -281,9 +400,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         const createModal = getAntModal(page, 'template-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(tplName);
-        // Fill minimal JSON since frontend enforces JSON parsing for spec_text
-        const specEditor = createModal.locator('textarea').last();
-        await specEditor.fill('{}');
+        await createModal.getByLabel(/container image url/i).fill('quay.io/containerdisks/ubuntu:22.04');
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'Template', 201);
@@ -297,7 +414,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         await page.getByTestId(`template-action-edit-${tplID}`).click();
         const editModal = getAntModal(page, 'template-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.locator('textarea').first().fill('Updated by live e2e test');
+        await editModal.locator('textarea').first().fill('Updated template description by live e2e test');
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'Template', 200);
@@ -327,9 +444,9 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         const createModal = getAntModal(page, 'instance-size-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(sizeName);
-        // Fill CPU and memory fields (Ant Design InputNumber uses role="spinbutton")
-        await createModal.getByRole('spinbutton').nth(1).fill('2');  // cpu_cores
-        await createModal.getByRole('spinbutton').nth(2).fill('4');    // memory_gi
+        // Use native field IDs to avoid picking wrong Antd spinbutton nodes.
+        await createModal.locator('#cpu_cores').fill('2');
+        await createModal.locator('#memory_gi').fill('4');
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'InstanceSize', 201);
@@ -343,7 +460,9 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         await page.getByTestId(`instance-size-action-edit-${sizeID}`).click();
         const editModal = getAntModal(page, 'instance-size-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.getByRole('spinbutton').nth(1).fill('4');  // cpu_cores
+        // Wait until edit form hydration finishes (destroyOnHidden + setFieldsValue timing).
+        await expect(editModal.locator('#memory_gi')).toHaveValue(/4(?:\\.0)?/);
+        await editModal.locator('#cpu_cores').fill('4');
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'InstanceSize', 200);
@@ -381,7 +500,8 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         await page.getByTestId(`auth-provider-action-edit-${providerID}`).click();
         const editModal = getAntModal(page, 'auth-provider-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.locator('textarea').first().fill('{"issuer":"https://updated-idp.example.com"}');
+        await editModal.getByLabel(/\*?\s*name/i).fill(`upd-auth-${Date.now().toString(36).slice(-5)}`);
+        await editModal.getByLabel(/provider config/i).fill('{"test_endpoint":"https://idp.example.com/healthz"}');
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'AuthProvider', 200);
@@ -541,24 +661,19 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
     test('createRateLimitExemption + deleteRateLimitExemption – full lifecycle', async ({ page }) => {
         // operationId: createRateLimitExemption, deleteRateLimitExemption
-        // Get first user to exempt (use validateApiResponse for single-read safety)
-        const usersRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
-        );
+        expect(seededRateLimitUserID, 'Rate-limit seed user is missing').toBeTruthy();
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
-        const usersBody = await validateApiResponse('UserList', await usersRespPromise) as { items?: Array<{ id?: string }> };
-        const userID = usersBody.items?.[0]?.id ?? '';
-        expect(userID, 'No users found for rate limit exemption test').toBeTruthy();
-        // Rate limit exemptions are managed at the bottom of the /admin/users page in the current UI
+        const userID = seededRateLimitUserID;
+        const exemptBtn = page.getByTestId(`ratelimit-action-exempt-${userID}`);
+        await expect(exemptBtn, `No rate-limit exemption action found for seeded user ${userID}`).toBeVisible();
 
         // ── POST /admin/rate-limits/exemptions ────────────────────────────────────
         const createRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), '/api/v1/admin/rate-limits/exemptions') && r.request().method() === 'POST'
         );
 
-        // Ensure we bypass the generic `rate-limit-exemption-create-button` which sets '' and instead select a specific table row
-        await page.getByTestId(`ratelimit-action-exempt-${userID}`).click();
+        await exemptBtn.click();
 
         const createModal = getAntModal(page, 'rate-limit-exemption-create-modal');
         await expect(createModal).toBeVisible();
@@ -581,26 +696,21 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
 
     test('updateRateLimitUserOverrides – PUT /admin/rate-limits/users/{id} conforms to RateLimitUserOverride schema', async ({ page }) => {
         // operationId: updateRateLimitUserOverrides
-        // Get first user (use validateApiResponse for single-read safety)
-        const usersRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
-        );
+        expect(seededRateLimitUserID, 'Rate-limit seed user is missing').toBeTruthy();
         await page.goto('/admin/users');
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
-        const usersBody = await validateApiResponse('UserList', await usersRespPromise) as { items?: Array<{ id?: string }> };
-        const userID = usersBody.items?.[0]?.id ?? '';
-        expect(userID, 'No users found for rate limit override test').toBeTruthy();
-
-        // Navigate to rate limit override for this user
-        // Rate limit overrides are managed at the bottom of the /admin/users page in the current UI
+        const userID = seededRateLimitUserID;
+        const overrideBtn = page.getByTestId(`rate-limit-user-action-edit-${userID}`);
+        await expect(overrideBtn, `No rate-limit override action found for seeded user ${userID}`).toBeVisible();
 
         const updateRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/admin/rate-limits/users/${userID}`) && r.request().method() === 'PUT'
         );
-        await page.getByTestId(`rate-limit-user-action-edit-${userID}`).click();
+        await overrideBtn.click();
         const editModal = getAntModal(page, 'rate-limit-user-edit-modal');
         await expect(editModal).toBeVisible();
-        await editModal.locator('input[type="number"]').first().fill('100');
+        await editModal.getByRole('spinbutton', { name: /max parent batches/i }).fill('100');
+        await editModal.getByRole('textbox', { name: /reason/i }).fill('Updated by live e2e test');
         await editModal.getByRole('button', { name: 'OK' }).click();
 
         await expectSchema(updateRespPromise, 'RateLimitUserOverride', 200);

--- a/web/tests/e2e/admin-flow-live.spec.ts
+++ b/web/tests/e2e/admin-flow-live.spec.ts
@@ -9,12 +9,12 @@
  * └─────────────────────────────────────────────────────────────────────────┘
  *
  * Coverage map (master-flow.md) — operationId index:
- *   listRoles              Stage 2.A  – GET /admin/roles
- *   createRole             Stage 2.A  – POST /admin/roles
- *   deleteRole             Stage 2.A  – DELETE /admin/roles/{id}
- *   listUsers              Stage 2.A+ – GET /admin/users
- *   createUser             Stage 2.A+ – POST /admin/users
- *   deleteUser             Stage 2.A+ – DELETE /admin/users/{id}
+ *   listRoles              Stage 2.A+ – GET /admin/roles
+ *   createRole             Stage 2.A+ – POST /admin/roles
+ *   deleteRole             Stage 2.A+ – DELETE /admin/roles/{id}
+ *   listUsers              Stage 2 (Supplemental) – GET /admin/users
+ *   createUser             Stage 2 (Supplemental) – POST /admin/users
+ *   deleteUser             Stage 2 (Supplemental) – DELETE /admin/users/{id}
  *   listAuthProviderTypes  Stage 2.B  – GET /admin/auth-provider-types
  *   listAuthProviders      Stage 2.B  – GET /admin/auth-providers
  *   createAuthProvider     Stage 2.B  – POST /admin/auth-providers
@@ -38,41 +38,47 @@
  * Environment variables:
  *   E2E_USERNAME        – admin username (default: e2e-admin)
  *   E2E_PASSWORD        – admin password (default: e2e-admin-123)
+ *   E2E_NEW_PASSWORD    – password used when force_password_change=true
  *   E2E_KUBECONFIG_B64  – base64-encoded kubeconfig for cluster registration test
  *
  * Run:
  *   PW_BASE_URL=http://localhost:3000 npx playwright test admin-flow-live
  */
 
-import { expect, test, type Page, type Response } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
-import { urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal } from './lib/helpers';
+import {
+    fetchStatusWithStoredToken,
+    getAntModal,
+    getApiTokenWithForcePasswordSupport,
+    loginWithForcePasswordSupport,
+    selectAntOption,
+    urlPathEndsWith,
+    urlPathIncludes,
+} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
 const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
+const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
 const e2eKubeconfigB64 = process.env.E2E_KUBECONFIG_B64 ?? 'dGVzdC1rdWJlY29uZmlnLWJhc2U2NA==';
+const e2eClusterName = process.env.E2E_CLUSTER ?? 'e2e-cluster';
+const e2eSystemName = process.env.E2E_SYSTEM ?? 'e2e-system';
+const e2eTemplateName = process.env.E2E_TEMPLATE ?? 'e2e-template';
+const e2eSizeName = process.env.E2E_SIZE ?? 'e2e-small';
+const e2eNamespace = process.env.E2E_NAMESPACE ?? 'e2e-test';
+let activePassword = e2ePassword;
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
 
 async function login(page: Page): Promise<void> {
-    await page.goto('/login');
-    await expect(page.getByRole('heading', { name: 'KubeVirt Shepherd' })).toBeVisible();
-    await page.getByPlaceholder('Username').fill(e2eUsername);
-    await page.getByPlaceholder('Password').fill(e2ePassword);
-
-    const loginRespPromise = page.waitForResponse(
-        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
-    );
-    await page.getByRole('button', { name: 'Login' }).click();
-
-    const loginResp = await loginRespPromise;
-    expect(loginResp.status()).toBe(200);
-    // ── CONTRACT CHECK: LoginResponse schema ──────────────────────────────────
-    await validateApiResponse('LoginResponse', loginResp);
-
-    await expect(page).toHaveURL(/\/dashboard$/);
+    activePassword = await loginWithForcePasswordSupport(page, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
 }
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -89,6 +95,323 @@ async function expectSchema(
     return { body, resp };
 }
 
+async function getAdminToken(request: APIRequestContext): Promise<string> {
+    const auth = await getApiTokenWithForcePasswordSupport(request, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
+    activePassword = auth.password;
+    return auth.token;
+}
+
+function pickIDByPreferredName<T extends { id?: string; name?: string }>(
+    items: T[] | undefined,
+    preferredName: string
+): string {
+    const preferred = (items ?? []).find((item) => (item.name ?? '').trim() === preferredName && Boolean(item.id));
+    if (preferred?.id) {
+        return preferred.id;
+    }
+    return (items ?? []).find((item) => Boolean(item.id))?.id ?? '';
+}
+
+function pickPreferredNamespace(namespaces: string[] | undefined, preferredName: string): string {
+    return namespaces?.find((ns) => ns === preferredName) ?? namespaces?.[0] ?? preferredName;
+}
+
+function escapeRegExp(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function toLooseOptionFilter(rawName: string): RegExp {
+    const tokens = rawName
+        .trim()
+        .split(/[\s_-]+/)
+        .filter(Boolean)
+        .map(escapeRegExp);
+    if (tokens.length === 0) {
+        return /.*/;
+    }
+    return new RegExp(tokens.join('\\s*[-_ ]*\\s*'), 'i');
+}
+
+async function resolveClusterOptionFilter(
+    request: APIRequestContext,
+    headers: { Authorization: string }
+): Promise<RegExp> {
+    const clustersResp = await request.get('/api/v1/admin/clusters?page=1&per_page=100', { headers });
+    expect(clustersResp.status(), `GET /admin/clusters returned ${clustersResp.status()}`).toBe(200);
+    const clustersBody = await validateApiResponse('ClusterList', clustersResp) as {
+        items?: Array<{ id?: string; name?: string; display_name?: string; displayName?: string }>;
+    };
+    const clusters = clustersBody.items ?? [];
+    expect(clusters.length, 'Stage 5.B requires at least one cluster option').toBeGreaterThan(0);
+
+    const preferred =
+        clusters.find((item) => (item.name ?? '').trim() === e2eClusterName) ??
+        clusters[0];
+    const label = String((preferred.display_name ?? preferred.displayName ?? preferred.name ?? '')).trim();
+    expect(label, 'Cluster option label cannot be empty').toBeTruthy();
+    return toLooseOptionFilter(label);
+}
+
+async function listVMBriefs(
+    request: APIRequestContext,
+    headers: { Authorization: string }
+): Promise<Array<{ id: string; status: string }>> {
+    const vmMap = new Map<string, { id: string; status: string }>();
+    let page = 1;
+    let totalPages = 1;
+    do {
+        const vmResp = await request.get(`/api/v1/vms?page=${page}&per_page=100`, { headers });
+        expect(vmResp.status(), `GET /vms?page=${page} returned ${vmResp.status()}`).toBe(200);
+        const vmBody = await validateApiResponse('VMList', vmResp) as {
+            items?: Array<{ id?: string; status?: string }>;
+            pagination?: { total_pages?: number };
+        };
+        for (const item of vmBody.items ?? []) {
+            if (!item.id) {
+                continue;
+            }
+            vmMap.set(item.id, { id: item.id, status: (item.status ?? '').toUpperCase() });
+        }
+        totalPages = Number(vmBody.pagination?.total_pages ?? 1) || 1;
+        page += 1;
+    } while (page <= totalPages);
+    return Array.from(vmMap.values());
+}
+
+async function waitForTicketStatus(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    ticketID: string,
+    expected: 'APPROVED' | 'REJECTED'
+): Promise<void> {
+    const expectedPattern = expected === 'APPROVED'
+        ? /^(APPROVED|EXECUTING|SUCCESS)$/
+        : /^REJECTED$/;
+
+    await expect.poll(async () => {
+        let page = 1;
+        const perPage = 100;
+
+        for (let guard = 0; guard < 20; guard += 1) {
+            const listResp = await request.get(`/api/v1/approvals?page=${page}&per_page=${perPage}`, { headers });
+            expect(listResp.status(), `GET /approvals returned ${listResp.status()}`).toBe(200);
+            const listBody = await validateApiResponse('ApprovalTicketList', listResp) as {
+                items?: Array<{ id?: string; status?: string }>;
+                pagination?: { total_pages?: number };
+            };
+            const found = listBody.items?.find((item) => item.id === ticketID);
+            if (found) {
+                return (found.status ?? '').toUpperCase();
+            }
+            const totalPages = Number(listBody.pagination?.total_pages ?? 1);
+            if (!Number.isFinite(totalPages) || page >= totalPages) {
+                break;
+            }
+            page += 1;
+        }
+
+        return '';
+    }, {
+        timeout: 30_000,
+        intervals: [500, 1000, 2000],
+        message: `Ticket ${ticketID} did not match status pattern ${expectedPattern}`,
+    }).toMatch(expectedPattern);
+}
+
+async function waitForApprovalNotification(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    ticketID: string,
+    expectedType: 'APPROVAL_COMPLETED' | 'APPROVAL_REJECTED'
+): Promise<void> {
+    await expect.poll(async () => {
+        let page = 1;
+        const perPage = 100;
+
+        for (let guard = 0; guard < 20; guard += 1) {
+            const listResp = await request.get(`/api/v1/notifications?page=${page}&per_page=${perPage}`, { headers });
+            expect(listResp.status(), `GET /notifications returned ${listResp.status()}`).toBe(200);
+            const listBody = await validateApiResponse('NotificationList', listResp) as {
+                items?: Array<{ type?: string; resource_id?: string; resourceId?: string }>;
+                pagination?: { total_pages?: number };
+            };
+
+            const found = (listBody.items ?? []).some((item) => {
+                const type = (item.type ?? '').toUpperCase();
+                const resourceID = String(item.resource_id ?? item.resourceId ?? '').trim();
+                return type === expectedType && resourceID === ticketID;
+            });
+            if (found) {
+                return true;
+            }
+
+            const totalPages = Number(listBody.pagination?.total_pages ?? 1);
+            if (!Number.isFinite(totalPages) || page >= totalPages) {
+                break;
+            }
+            page += 1;
+        }
+
+        return false;
+    }, {
+        timeout: 30_000,
+        intervals: [1000, 2000, 3000],
+        message: `Missing notification ${expectedType} for ticket ${ticketID}`,
+    }).toBe(true);
+}
+
+async function waitForNewVMFromApproval(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    baselineIDs: Set<string>
+): Promise<string> {
+    let createdVMID = '';
+    await expect.poll(async () => {
+        const vms = await listVMBriefs(request, headers);
+        const created = vms.find((vm) => !baselineIDs.has(vm.id));
+        createdVMID = created?.id ?? '';
+        return createdVMID;
+    }, {
+        timeout: 60_000,
+        intervals: [1000, 2000, 3000],
+        message: 'Stage 5.C requires approved ticket to materialize a VM row',
+    }).not.toBe('');
+    return createdVMID;
+}
+
+async function summarizeClusterHealth(
+    request: APIRequestContext,
+    headers: { Authorization: string }
+): Promise<string> {
+    const clustersResp = await request.get('/api/v1/admin/clusters?page=1&per_page=100', { headers });
+    if (clustersResp.status() !== 200) {
+        return `clusters_http_${clustersResp.status()}`;
+    }
+    const clustersBody = await validateApiResponse('ClusterList', clustersResp) as {
+        items?: Array<{ id?: string; name?: string; status?: string; enabled?: boolean }>;
+    };
+    const summary = (clustersBody.items ?? [])
+        .map((cluster) => {
+            const name = cluster.name ?? cluster.id ?? 'unknown';
+            const status = (cluster.status ?? 'UNKNOWN').toUpperCase();
+            const enabledSuffix = cluster.enabled === false ? ':DISABLED' : '';
+            return `${name}:${status}${enabledSuffix}`;
+        })
+        .join(', ');
+    return summary || 'no-clusters';
+}
+
+async function waitForVMExecutionOutcome(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    vmID: string
+): Promise<void> {
+    await expect.poll(async () => {
+        const vmResp = await request.get(`/api/v1/vms/${vmID}`, { headers });
+        if (vmResp.status() !== 200) {
+            return `HTTP_${vmResp.status()}`;
+        }
+        const vmBody = await validateApiResponse('VM', vmResp) as { status?: string };
+        const status = (vmBody.status ?? '').toUpperCase();
+        if (status === 'CREATING') {
+            const health = await summarizeClusterHealth(request, headers);
+            return `CREATING|${health}`;
+        }
+        return status;
+    }, {
+        timeout: 120_000,
+        intervals: [1000, 2000, 4000, 8000],
+        message: `VM ${vmID} did not reach RUNNING/FAILED from CREATING`,
+    }).toMatch(/^(RUNNING|FAILED)$/);
+}
+
+async function seedPendingApprovalTicket(request: APIRequestContext): Promise<string> {
+    const token = await getAdminToken(request);
+    const headers = { Authorization: `Bearer ${token}` };
+
+    const systemsResp = await request.get('/api/v1/systems', { headers });
+    expect(systemsResp.status(), 'GET /systems must return 200 for approval seed').toBe(200);
+    const systems = await validateApiResponse('SystemList', systemsResp) as { items?: Array<{ id?: string; name?: string }> };
+    const systemId = pickIDByPreferredName(systems.items, e2eSystemName);
+    expect(systemId, 'Approval seed requires at least one existing system').toBeTruthy();
+
+    const approvalSeedServiceName = `s5b-${Date.now().toString(36).slice(-8)}`;
+    const createServiceResp = await request.post(`/api/v1/systems/${systemId}/services`, {
+        headers,
+        data: {
+            name: approvalSeedServiceName,
+            description: 'temporary service for Stage 5.B approval seed isolation',
+        },
+    });
+    expect(
+        createServiceResp.status(),
+        `POST /systems/{id}/services returned ${createServiceResp.status()} for Stage 5.B approval seed`
+    ).toBe(201);
+    await validateApiResponse('Service', createServiceResp);
+
+    const [servicesResp, contextResp] = await Promise.all([
+        request.get(`/api/v1/systems/${systemId}/services`, { headers }),
+        request.get('/api/v1/vms/request-context', { headers }),
+    ]);
+    expect(servicesResp.status(), 'GET /systems/{id}/services must return 200 for approval seed').toBe(200);
+    expect(contextResp.status(), 'GET /vms/request-context must return 200 for approval seed').toBe(200);
+
+    const services = await validateApiResponse('ServiceList', servicesResp) as { items?: Array<{ id?: string; name?: string }> };
+    const ctx = await validateApiResponse('VMRequestContext', contextResp) as {
+        templates?: Array<{ id?: string; name?: string }>;
+        instance_sizes?: Array<{ id?: string; name?: string }>;
+        namespaces?: string[];
+    };
+
+    const serviceId = pickIDByPreferredName(services.items, approvalSeedServiceName);
+    const templateId = pickIDByPreferredName(ctx.templates, e2eTemplateName);
+    const sizeId = pickIDByPreferredName(ctx.instance_sizes, e2eSizeName);
+    const namespace = pickPreferredNamespace(ctx.namespaces, e2eNamespace);
+    expect(serviceId, 'Approval seed requires an existing service').toBeTruthy();
+    expect(templateId, 'Approval seed requires an existing template').toBeTruthy();
+    expect(sizeId, 'Approval seed requires an existing instance size').toBeTruthy();
+
+    const createReqData = {
+        service_id: serviceId,
+        template_id: templateId,
+        instance_size_id: sizeId,
+        namespace,
+    };
+
+    const createResp = await request.post('/api/v1/vms/request', {
+        headers,
+        data: { ...createReqData, reason: `admin-flow approval seed ${Date.now()}` },
+    });
+    if (createResp.status() === 400) {
+        const errBody = await validateApiResponse('Error', createResp) as {
+            code?: string;
+            message?: string;
+            params?: Record<string, unknown>;
+        };
+        if (errBody.code === 'DUPLICATE_PENDING_REQUEST') {
+            const existingTicketID =
+                typeof errBody.params?.existing_ticket_id === 'string' ? errBody.params.existing_ticket_id.trim() : '';
+            throw new Error(
+                `unexpected DUPLICATE_PENDING_REQUEST in approval seed (service=${approvalSeedServiceName}, existing_ticket_id=${existingTicketID || 'unknown'})`
+            );
+        }
+        throw new Error(
+            `POST /vms/request failed in approval seed: ${errBody.code ?? 'UNKNOWN'} (${errBody.message ?? 'no message'})`
+        );
+    }
+
+    expect(createResp.status(), 'POST /vms/request must return 202 for approval seed').toBe(202);
+    const ticket = await validateApiResponse('ApprovalTicketResponse', createResp) as { ticket_id?: string; id?: string };
+    const ticketID = ticket.ticket_id ?? ticket.id ?? '';
+    expect(ticketID, 'ApprovalTicketResponse missing ticket id').toBeTruthy();
+    return ticketID;
+}
+
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 test.describe('admin-flow live (contract-enforced, no mock)', () => {
@@ -96,54 +419,59 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         await login(page);
     });
 
-    // ── Stage 2.A: RBAC custom role lifecycle ────────────────────────────────────
+    // ── Stage 2.A+: RBAC custom role lifecycle ───────────────────────────────────
 
-    test('Stage 2.A – listRoles + createRole + deleteRole (schema-validated)', async ({ page }) => {
+    test('Stage 2.A+ – listRoles + createRole + deleteRole (schema-validated)', async ({ page }) => {
         // operationId: listRoles, createRole, deleteRole
-        // ── CONTRACT CHECK: listRoles → RoleList ──────────────────────────────────
-        const listRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'GET'
-        );
-        await page.goto('/admin/rbac');
-        await expect(page.getByTestId('admin-rbac-page')).toBeVisible();
-        await expectSchema(listRespPromise, 'RoleList', 200);
-
-        // ── CONTRACT CHECK: createRole → Role ─────────────────────────────────────
         const roleName = `e2e-role-${Date.now().toString(36).slice(-6)}`;
-        const createRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'POST'
-        );
+        let roleID = '';
 
-        await page.getByTestId('rbac-role-create-button').click();
-        const createModal = getAntModal(page, 'rbac-role-create-modal');
-        await expect(createModal).toBeVisible();
-        await createModal.getByRole('textbox').first().fill(roleName);
-        await selectAntOption(page, createModal.locator('.ant-select-selector').first());
-        await createModal.getByRole('button', { name: 'OK' }).click();
+        await test.step('Stage 2.A+ / Step 1: create custom role from role management page', async () => {
+            // ── CONTRACT CHECK: listRoles → RoleList ──────────────────────────────
+            const listRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'GET'
+            );
+            await page.goto('/admin/rbac');
+            await expect(page.getByTestId('admin-rbac-page')).toBeVisible();
+            await expectSchema(listRespPromise, 'RoleList', 200);
 
-        const { body: created } = await expectSchema(createRespPromise, 'Role', 201);
-        const roleID = (created as { id?: string }).id ?? '';
-        expect(roleID).toBeTruthy();
+            // ── CONTRACT CHECK: createRole → Role ─────────────────────────────────
+            const createRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'POST'
+            );
 
-        await expect(page.locator('tr').filter({ hasText: roleName }).first()).toBeVisible();
+            await page.getByTestId('rbac-role-create-button').click();
+            const createModal = getAntModal(page, 'rbac-role-create-modal');
+            await expect(createModal).toBeVisible();
+            await createModal.getByRole('textbox').first().fill(roleName);
+            await selectAntOption(page, createModal.locator('.ant-select-selector').first());
+            await createModal.getByRole('button', { name: 'OK' }).click();
 
-        // ── CONTRACT CHECK: deleteRole → 204 ──────────────────────────────────────
-        const deleteRespPromise = page.waitForResponse(
-            (r) => urlPathIncludes(r.url(), `/api/v1/admin/roles/${roleID}`) && r.request().method() === 'DELETE'
-        );
-        await page.getByTestId(`rbac-role-action-delete-${roleID}`).click();
-        const confirmBtn = page.getByRole('button', { name: /ok|confirm|delete/i }).last();
-        await expect(confirmBtn).toBeVisible();
-        await confirmBtn.click();
+            const { body: created } = await expectSchema(createRespPromise, 'Role', 201);
+            roleID = (created as { id?: string }).id ?? '';
+            expect(roleID).toBeTruthy();
+            await expect(page.locator('tr').filter({ hasText: roleName }).first()).toBeVisible();
+        });
 
-        const deleteResp = await deleteRespPromise;
-        expect(deleteResp.status()).toBe(204);
-        await expect(page.locator('tr').filter({ hasText: roleName })).toHaveCount(0);
+        await test.step('Stage 2.A+ / Step 2: role permission binding persists and role is deletable', async () => {
+            // ── CONTRACT CHECK: deleteRole → 204 ──────────────────────────────────
+            const deleteRespPromise = page.waitForResponse(
+                (r) => urlPathIncludes(r.url(), `/api/v1/admin/roles/${roleID}`) && r.request().method() === 'DELETE'
+            );
+            await page.getByTestId(`rbac-role-action-delete-${roleID}`).click();
+            const confirmBtn = page.getByRole('button', { name: /ok|confirm|delete/i }).last();
+            await expect(confirmBtn).toBeVisible();
+            await confirmBtn.click();
+
+            const deleteResp = await deleteRespPromise;
+            expect(deleteResp.status()).toBe(204);
+            await expect(page.locator('tr').filter({ hasText: roleName })).toHaveCount(0);
+        });
     });
 
-    // ── Stage 2.A+: User management lifecycle ────────────────────────────────────
+    // ── Stage 2 (Supplemental): User management lifecycle ────────────────────────
 
-    test('Stage 2.A+ – listUsers + createUser + deleteUser (schema-validated)', async ({ page }) => {
+    test('Stage 2 (Supplemental) – listUsers + createUser + deleteUser (schema-validated)', async ({ page }) => {
         // operationId: listUsers, createUser, deleteUser
         // ── CONTRACT CHECK: listUsers → UserList ──────────────────────────────────
         const listRespPromise = page.waitForResponse(
@@ -203,6 +531,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         expect((typesPayload.items ?? []).length).toBeGreaterThan(0);
 
         const preferredType =
+            (typesPayload.items ?? []).find((item) => item.type === 'oidc') ??
             (typesPayload.items ?? []).find((item) => item.type === 'generic') ??
             typesPayload.items?.[0];
         expect(preferredType?.type).toBeTruthy();
@@ -226,7 +555,10 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(providerName);
         await selectAntOption(page, createModal.locator('.ant-select-selector').first(), providerTypeLabel);
-        await createModal.getByRole('textbox').nth(1).fill('{"issuer":"https://idp.example.com"}');
+        const configText = '{"test_endpoint":"https://idp.example.com/healthz"}';
+        const configInput = createModal.locator('textarea').first();
+        await configInput.fill(configText);
+        await expect(configInput).toHaveValue(configText);
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'AuthProvider', 201);
@@ -255,100 +587,104 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
     test('Stage 2.C – listAuthProviderGroupMappings: IdP group mapping list conforms to IdPGroupMappingList schema', async ({ page }) => {
         // operationId: listAuthProviderGroupMappings
-        // Contract: seed data MUST include at least one auth provider.
-        await page.goto('/admin/auth-providers');
-        await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
+        await test.step('Stage 2.C / Step 1: fetch provider group-mapping sample list', async () => {
+            // Contract: seed data MUST include at least one auth provider.
+            await page.goto('/admin/auth-providers');
+            await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
 
-        const firstProviderRow = page.locator('tr[data-row-key]').first();
-        await expect(firstProviderRow, 'No auth providers found — seed data must include at least one provider').toBeVisible();
+            const firstProviderRow = page.locator('tr[data-row-key]').first();
+            await expect(firstProviderRow, 'No auth providers found — seed data must include at least one provider').toBeVisible();
 
-        // Click into the provider's group mappings
-        const mappingLink = firstProviderRow.locator('[data-testid^="auth-provider-action-mappings-"]').first();
-        await expect(mappingLink, 'No group mapping action found on provider row — UI must expose this action').toBeVisible();
+            // Click into the provider's group mappings
+            const mappingLink = firstProviderRow.locator('[data-testid^="auth-provider-action-mappings-"]').first();
+            await expect(mappingLink, 'No group mapping action found on provider row — UI must expose this action').toBeVisible();
 
-        const providerID = (await mappingLink.getAttribute('data-testid'))
-            ?.replace('auth-provider-action-mappings-', '') ?? '';
+            const providerID = (await mappingLink.getAttribute('data-testid'))
+                ?.replace('auth-provider-action-mappings-', '') ?? '';
 
-        const mappingsRespPromise = page.waitForResponse(
-            (r) =>
-                urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}/group-mappings`) &&
-                r.request().method() === 'GET'
-        );
-        await mappingLink.click();
+            const mappingsRespPromise = page.waitForResponse(
+                (r) =>
+                    urlPathIncludes(r.url(), `/api/v1/admin/auth-providers/${providerID}/group-mappings`) &&
+                    r.request().method() === 'GET'
+            );
+            await mappingLink.click();
 
-        // ── CONTRACT CHECK: listAuthProviderGroupMappings → IdPGroupMappingList ───
-        const mappingsResp = await mappingsRespPromise;
-        expect(mappingsResp.status()).toBe(200);
-        await validateApiResponse('IdPGroupMappingList', mappingsResp);
+            // ── CONTRACT CHECK: listAuthProviderGroupMappings → IdPGroupMappingList ─
+            const mappingsResp = await mappingsRespPromise;
+            expect(mappingsResp.status()).toBe(200);
+            await validateApiResponse('IdPGroupMappingList', mappingsResp);
+        });
     });
 
     // ── Stage 3: Namespace management lifecycle ───────────────────────────────────
 
     test('Stage 3 – listNamespaces + createNamespace + updateNamespace + deleteNamespace (schema-validated)', async ({ page }) => {
         // operationId: listNamespaces, createNamespace, updateNamespace, deleteNamespace
-        // ── CONTRACT CHECK: listNamespaces → NamespaceRegistryList ───────────────
-        const listRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
-        );
-        await page.goto('/admin/namespaces');
-        await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
-        await expectSchema(listRespPromise, 'NamespaceRegistryList', 200);
+        await test.step('Stage 3 / Step 2: configure namespace registry with full lifecycle checks', async () => {
+            // ── CONTRACT CHECK: listNamespaces → NamespaceRegistryList ───────────
+            const listRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
+            );
+            await page.goto('/admin/namespaces');
+            await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
+            await expectSchema(listRespPromise, 'NamespaceRegistryList', 200);
 
-        // ── CONTRACT CHECK: createNamespace → NamespaceRegistry ──────────────────
-        const nsName = `e2e-ns-${Date.now().toString(36).slice(-6)}`;
-        const createRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'POST'
-        );
+            // ── CONTRACT CHECK: createNamespace → NamespaceRegistry ──────────────
+            const nsName = `e2e-ns-${Date.now().toString(36).slice(-6)}`;
+            const createRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'POST'
+            );
 
-        await page.getByTestId('namespace-create-button').click();
-        const createModal = getAntModal(page, 'namespace-create-modal');
-        await expect(createModal).toBeVisible();
-        await createModal.getByRole('textbox').first().fill(nsName);
-        await selectAntOption(page, createModal.locator('.ant-select-selector').first(), /test/i);
-        await createModal.getByRole('button', { name: 'OK' }).click();
+            await page.getByTestId('namespace-create-button').click();
+            const createModal = getAntModal(page, 'namespace-create-modal');
+            await expect(createModal).toBeVisible();
+            await createModal.getByRole('textbox').first().fill(nsName);
+            await selectAntOption(page, createModal.locator('.ant-select-selector').first(), /test/i);
+            await createModal.getByRole('button', { name: 'OK' }).click();
 
-        const { body: created } = await expectSchema(createRespPromise, 'NamespaceRegistry', 201);
-        const nsID = (created as { id?: string }).id ?? '';
-        expect(nsID).toBeTruthy();
+            const { body: created } = await expectSchema(createRespPromise, 'NamespaceRegistry', 201);
+            const nsID = (created as { id?: string }).id ?? '';
+            expect(nsID).toBeTruthy();
 
-        await expect(page.locator('tr').filter({ hasText: nsName }).first()).toBeVisible();
+            await expect(page.locator('tr').filter({ hasText: nsName }).first()).toBeVisible();
 
-        // ── CONTRACT CHECK: updateNamespace → NamespaceRegistry ──────────────────
-        // Note: OpenAPI spec uses PUT for updateNamespace
-        const updateRespPromise = page.waitForResponse(
-            (r) =>
-                urlPathIncludes(r.url(), `/api/v1/admin/namespaces/${nsID}`) &&
-                (r.request().method() === 'PUT' || r.request().method() === 'PATCH')
-        );
-        await page.getByTestId(`namespace-action-edit-${nsID}`).click();
-        const editModal = getAntModal(page, 'namespace-edit-modal');
-        await expect(editModal).toBeVisible();
-        await editModal.locator('textarea').first().fill('Updated by live e2e test');
-        await editModal.getByRole('button', { name: 'OK' }).click();
+            // ── CONTRACT CHECK: updateNamespace → NamespaceRegistry ──────────────
+            // Note: OpenAPI spec uses PUT for updateNamespace
+            const updateRespPromise = page.waitForResponse(
+                (r) =>
+                    urlPathIncludes(r.url(), `/api/v1/admin/namespaces/${nsID}`) &&
+                    (r.request().method() === 'PUT' || r.request().method() === 'PATCH')
+            );
+            await page.getByTestId(`namespace-action-edit-${nsID}`).click();
+            const editModal = getAntModal(page, 'namespace-edit-modal');
+            await expect(editModal).toBeVisible();
+            await editModal.locator('textarea').first().fill('Updated by live e2e test');
+            await editModal.getByRole('button', { name: 'OK' }).click();
 
-        await expectSchema(updateRespPromise, 'NamespaceRegistry', 200);
+            await expectSchema(updateRespPromise, 'NamespaceRegistry', 200);
 
-        // ── CONTRACT CHECK: deleteNamespace with confirm_name guard ───────────────
-        await page.getByTestId(`namespace-action-delete-${nsID}`).click();
-        const deleteModal = getAntModal(page, 'namespace-delete-modal');
-        await expect(deleteModal).toBeVisible();
+            // ── CONTRACT CHECK: deleteNamespace with confirm_name guard ───────────
+            await page.getByTestId(`namespace-action-delete-${nsID}`).click();
+            const deleteModal = getAntModal(page, 'namespace-delete-modal');
+            await expect(deleteModal).toBeVisible();
 
-        const deleteBtn = deleteModal.getByRole('button', { name: /delete/i });
-        await expect(deleteBtn).toBeDisabled();
+            const deleteBtn = deleteModal.getByRole('button', { name: /delete/i });
+            await expect(deleteBtn).toBeDisabled();
 
-        await page.getByTestId('namespace-delete-confirm-input').fill(nsName);
-        await expect(deleteBtn).toBeEnabled();
+            await page.getByTestId('namespace-delete-confirm-input').fill(nsName);
+            await expect(deleteBtn).toBeEnabled();
 
-        const deleteRespPromise = page.waitForResponse(
-            (r) =>
-                urlPathIncludes(r.url(), `/api/v1/admin/namespaces/${nsID}`) &&
-                r.request().method() === 'DELETE'
-        );
-        await deleteBtn.click();
+            const deleteRespPromise = page.waitForResponse(
+                (r) =>
+                    urlPathIncludes(r.url(), `/api/v1/admin/namespaces/${nsID}`) &&
+                    r.request().method() === 'DELETE'
+            );
+            await deleteBtn.click();
 
-        const deleteResp = await deleteRespPromise;
-        expect(deleteResp.status()).toBe(204);
-        await expect(page.locator('tr').filter({ hasText: nsName })).toHaveCount(0);
+            const deleteResp = await deleteRespPromise;
+            expect(deleteResp.status()).toBe(204);
+            await expect(page.locator('tr').filter({ hasText: nsName })).toHaveCount(0);
+        });
     });
 
     // ── Stage 3: Cluster registration ────────────────────────────────────────────
@@ -364,109 +700,95 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         await expectSchema(listRespPromise, 'ClusterList', 200);
     });
 
-    test('Stage 3 – createCluster: cluster create (schema-validated, accepts 201 or 422)', async ({ page }) => {
+    test('Stage 3 – createCluster: cluster create must succeed with valid kubeconfig', async ({ page }) => {
         // operationId: createCluster
-        await page.goto('/admin/clusters');
-        await expect(page.getByTestId('admin-clusters-page')).toBeVisible();
+        await test.step('Stage 3 / Step 1: register cluster and verify auto-detection contract', async () => {
+            await page.goto('/admin/clusters');
+            await expect(page.getByTestId('admin-clusters-page')).toBeVisible();
 
-        const clusterName = `e2e-cluster-${Date.now().toString(36).slice(-6)}`;
-        const createRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/clusters') && r.request().method() === 'POST'
-        );
+            const clusterName = `e2e-cluster-${Date.now().toString(36).slice(-6)}`;
+            const createRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/clusters') && r.request().method() === 'POST'
+            );
 
-        await page.getByTestId('cluster-create-button').click();
-        const createModal = getAntModal(page, 'cluster-create-modal');
-        await expect(createModal).toBeVisible();
-        await createModal.getByRole('textbox').first().fill(clusterName);
-        await createModal.locator('textarea').last().fill(e2eKubeconfigB64);
-        await createModal.getByRole('button', { name: 'OK' }).click();
+            await page.getByTestId('cluster-create-button').click();
+            const createModal = getAntModal(page, 'cluster-create-modal');
+            await expect(createModal).toBeVisible();
+            await createModal.getByRole('textbox').first().fill(clusterName);
+            await createModal.locator('textarea').last().fill(e2eKubeconfigB64);
+            await createModal.getByRole('button', { name: 'OK' }).click();
 
-        // ── CONTRACT CHECK: createCluster → Cluster (201) or Error (422) ─────────
-        const createResp = await createRespPromise;
-        // 201 = valid kubeconfig, 400 = invalid kubeconfig (expected in CI with placeholder)
-        expect([201, 400]).toContain(createResp.status());
-        if (createResp.status() === 201) {
+            // ── CONTRACT CHECK: strict success path (must create cluster) ──────────
+            const createResp = await createRespPromise;
+            expect(createResp.status(), `POST /admin/clusters returned ${createResp.status()}`).toBe(201);
             await validateApiResponse('Cluster', createResp);
-        }
+        });
     });
 
     // ── Stage 3: Template management ─────────────────────────────────────────────
 
     test('Stage 3 – listAdminTemplates + createAdminTemplate (schema-validated)', async ({ page }) => {
         // operationId: listAdminTemplates, createAdminTemplate
-        // ── CONTRACT CHECK: listAdminTemplates → TemplateList ────────────────────
-        const listRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'GET'
-        );
-        await page.goto('/admin/templates');
-        await expect(page.getByRole('heading', { name: 'Templates' })).toBeVisible();
-        await expectSchema(listRespPromise, 'TemplateList', 200);
+        await test.step('Stage 3 / Step 3: configure template catalog entry', async () => {
+            // ── CONTRACT CHECK: listAdminTemplates → TemplateList ──────────────────
+            const listRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'GET'
+            );
+            await page.goto('/admin/templates');
+            await expect(page.getByRole('heading', { name: 'Templates' })).toBeVisible();
+            await expectSchema(listRespPromise, 'TemplateList', 200);
 
-        // ── CONTRACT CHECK: createAdminTemplate → Template ───────────────────────
-        const templateName = `e2e-tpl-${Date.now().toString(36).slice(-6)}`;
-        const createRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'POST'
-        );
+            // ── CONTRACT CHECK: createAdminTemplate → Template ─────────────────────
+            const templateName = `e2e-tpl-${Date.now().toString(36).slice(-6)}`;
+            const createRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'POST'
+            );
 
-        await page.getByTestId('template-create-button').click();
-        const createModal = getAntModal(page, 'template-create-modal');
-        await expect(createModal).toBeVisible();
-        await createModal.getByRole('textbox').first().fill(templateName);
-        // Fill required fields (image, etc.) with test values
-        const textboxes = createModal.getByRole('textbox');
-        const count = await textboxes.count();
-        if (count > 1) {
-            await textboxes.nth(1).fill('registry.example.com/test:latest');
-        }
-        await createModal.getByRole('button', { name: 'OK' }).click();
+            await page.getByTestId('template-create-button').click();
+            const createModal = getAntModal(page, 'template-create-modal');
+            await expect(createModal).toBeVisible();
+            await createModal.getByRole('textbox').first().fill(templateName);
+            await createModal.getByLabel(/container image url/i).fill('quay.io/containerdisks/ubuntu:22.04');
+            await createModal.getByRole('button', { name: 'OK' }).click();
 
-        const createResp = await createRespPromise;
-        // 201 = success, 400/422 = validation error (acceptable in CI)
-        expect([201, 400, 422]).toContain(createResp.status());
-        if (createResp.status() === 201) {
+            const createResp = await createRespPromise;
+            expect(createResp.status(), `POST /admin/templates returned ${createResp.status()}`).toBe(201);
             await validateApiResponse('Template', createResp);
-        }
+        });
     });
 
     // ── Stage 3: Instance Size management ────────────────────────────────────────
 
     test('Stage 3 – listAdminInstanceSizes + createAdminInstanceSize (schema-validated)', async ({ page }) => {
         // operationId: listAdminInstanceSizes, createAdminInstanceSize
-        // ── CONTRACT CHECK: listAdminInstanceSizes → InstanceSizeList ────────────
-        const listRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
-        );
-        await page.goto('/admin/instance-sizes');
-        await expect(page.getByRole('heading', { name: 'Instance Sizes' })).toBeVisible();
-        await expectSchema(listRespPromise, 'InstanceSizeList', 200);
+        await test.step('Stage 3 / Step 4: create instance size from schema-driven form', async () => {
+            // ── CONTRACT CHECK: listAdminInstanceSizes → InstanceSizeList ──────────
+            const listRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
+            );
+            await page.goto('/admin/instance-sizes');
+            await expect(page.getByRole('heading', { name: 'Instance Sizes' })).toBeVisible();
+            await expectSchema(listRespPromise, 'InstanceSizeList', 200);
 
-        // ── CONTRACT CHECK: createAdminInstanceSize → InstanceSize ───────────────
-        const sizeName = `e2e-size-${Date.now().toString(36).slice(-6)}`;
-        const createRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'POST'
-        );
+            // ── CONTRACT CHECK: createAdminInstanceSize → InstanceSize ─────────────
+            const sizeName = `e2e-size-${Date.now().toString(36).slice(-6)}`;
+            const createRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'POST'
+            );
 
-        await page.getByTestId('instance-size-create-button').click();
-        const createModal = getAntModal(page, 'instance-size-create-modal');
-        await expect(createModal).toBeVisible();
-        await createModal.getByRole('textbox').first().fill(sizeName);
-        // Fill CPU and memory fields (Ant Design InputNumber uses role="spinbutton")
-        const numberInputs = createModal.getByRole('spinbutton');
-        const inputCount = await numberInputs.count();
-        if (inputCount >= 2) {
-            // First spinbutton after name is sort_order, then cpu_cores, then memory_gi
-            // Find cpu_cores and memory_gi by targeting the required InputNumber fields
-            await numberInputs.nth(1).fill('4');    // cpu_cores
-            await numberInputs.nth(2).fill('4');    // memory_gi (in Gi)
-        }
-        await createModal.getByRole('button', { name: 'OK' }).click();
+            await page.getByTestId('instance-size-create-button').click();
+            const createModal = getAntModal(page, 'instance-size-create-modal');
+            await expect(createModal).toBeVisible();
+            await createModal.getByRole('textbox').first().fill(sizeName);
+            // Fill CPU and memory fields using exact stable IDs.
+            await createModal.locator('#cpu_cores').fill('4');
+            await createModal.locator('#memory_gi').fill('4');
+            await createModal.getByRole('button', { name: 'OK' }).click();
 
-        const createResp = await createRespPromise;
-        // 201 = success, 400/422 = validation error (acceptable in CI)
-        expect([201, 400, 422]).toContain(createResp.status());
-        if (createResp.status() === 201) {
+            const createResp = await createRespPromise;
+            expect(createResp.status(), `POST /admin/instance-sizes returned ${createResp.status()}`).toBe(201);
             await validateApiResponse('InstanceSize', createResp);
-        }
+        });
     });
 
     // ── Stage 5.B: Approval workflow ─────────────────────────────────────────────
@@ -476,7 +798,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
         const listRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
         );
-        await page.goto('/approvals');
+        await page.goto('/admin/approvals');
         await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
 
         // ── CONTRACT CHECK: listApprovals → ApprovalTicketList ───────────────────
@@ -485,128 +807,62 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
     test('Stage 5.B – approveTicket: approve action calls real API', async ({ page, request }) => {
         // operationId: approveTicket
-        // API-first setup: ensure a pending ticket exists by creating a VM request via API.
-        const loginResp = await request.post(`/api/v1/auth/login`, {
-            data: { username: e2eUsername, password: e2ePassword },
-        });
-        expect(loginResp.ok(), 'API login failed').toBeTruthy();
-        const { token } = await loginResp.json() as { token: string };
+        const ticketID = await seedPendingApprovalTicket(request);
+        const token = await getAdminToken(request);
+        const headers = { Authorization: `Bearer ${token}` };
+        const beforeVMs = await listVMBriefs(request, headers);
+        const beforeVMIDs = new Set(beforeVMs.map((item) => item.id));
 
-        const svcResp = await request.get(`/api/v1/services`, {
-            headers: { Authorization: `Bearer ${token}` },
-        });
-        const ctxResp = await request.get(`/api/v1/vms/request-context`, {
-            headers: { Authorization: `Bearer ${token}` },
-        });
-        if (svcResp.ok() && ctxResp.ok()) {
-            const svcData = await svcResp.json() as { items?: Array<{ id?: string }> };
-            const ctx = await ctxResp.json() as {
-                templates?: Array<{ id?: string }>;
-                instance_sizes?: Array<{ id?: string }>;
-            };
-            const svcId = svcData.items?.[0]?.id;
-            const tplId = ctx.templates?.[0]?.id;
-            const sizeId = ctx.instance_sizes?.[0]?.id;
-            if (svcId && tplId && sizeId) {
-                const batchResp = await request.post(`/api/v1/vms/batch`, {
-                    headers: { Authorization: `Bearer ${token}` },
-                    data: {
-                        operation: 'CREATE',
-                        items: [{
-                            service_id: svcId,
-                            template_id: tplId,
-                            instance_size_id: sizeId,
-                            name: `e2e-approve-${Date.now().toString(36).slice(-5)}`,
-                        }],
-                        reason: 'Created by live E2E to test approveTicket',
-                    },
-                });
-                expect(batchResp.status(), 'Setting up approval tickets should return 202 Accepted').toBe(202);
-            }
-        }
-
-        await page.goto('/approvals');
+        await page.goto('/admin/approvals');
         await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
 
-        const approveBtn = page.locator('[data-testid^="approval-action-approve-"]').first();
+        const approveBtn = page.getByTestId(`approval-action-approve-${ticketID}`);
         await expect(approveBtn, 'No pending approval tickets found — API setup may have failed').toBeVisible();
-
-        const testId = await approveBtn.getAttribute('data-testid');
-        const ticketID = testId?.replace('approval-action-approve-', '') ?? '';
-
-        const approveRespPromise = page.waitForResponse(
-            (r) =>
-                urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
-                (r.request().method() === 'PATCH' || r.request().method() === 'POST')
-        );
 
         await approveBtn.click();
         const modal = getAntModal(page, 'approve-modal');
         await expect(modal).toBeVisible();
+    await expect(
+        modal.locator('.ant-select-selector').first(),
+        'Stage 5.B requires selecting a target cluster before approval'
+    ).toBeVisible();
+    const clusterFilter = await resolveClusterOptionFilter(request, headers);
+    await selectAntOption(page, modal.locator('.ant-select-selector').first(), clusterFilter);
+
+        const approveRespPromise = page.waitForResponse(
+            (r) =>
+                urlPathEndsWith(r.url(), `/api/v1/approvals/${ticketID}/approve`) &&
+                r.request().method() === 'POST'
+        );
         await modal.getByRole('button', { name: 'OK' }).click();
 
         // ── CONTRACT CHECK: approveTicket → 204 ──────────────────────────────────
         const approveResp = await approveRespPromise;
-        expect([200, 204]).toContain(approveResp.status());
+        expect(approveResp.status(), `POST /approvals/{id}/approve returned ${approveResp.status()}`).toBe(204);
+        await waitForTicketStatus(request, headers, ticketID, 'APPROVED');
+        await waitForApprovalNotification(request, headers, ticketID, 'APPROVAL_COMPLETED');
+
+        // ── MASTER-FLOW Stage 5.C CHECK: approval must materialize VM + execute ──
+        const createdVMID = await waitForNewVMFromApproval(request, headers, beforeVMIDs);
+        await waitForVMExecutionOutcome(request, headers, createdVMID);
     });
 
     // ── Stage 5.B: Reject action ──────────────────────────────────────────────────
 
     test('Stage 5.B – rejectTicket: reject action calls real API', async ({ page, request }) => {
         // operationId: rejectTicket
-        // API-first setup: ensure a pending ticket exists by creating a VM request via API.
-        const loginResp = await request.post(`/api/v1/auth/login`, {
-            data: { username: e2eUsername, password: e2ePassword },
-        });
-        expect(loginResp.ok(), 'API login failed').toBeTruthy();
-        const { token } = await loginResp.json() as { token: string };
+        const ticketID = await seedPendingApprovalTicket(request);
 
-        const svcResp = await request.get(`/api/v1/services`, {
-            headers: { Authorization: `Bearer ${token}` },
-        });
-        const ctxResp = await request.get(`/api/v1/vms/request-context`, {
-            headers: { Authorization: `Bearer ${token}` },
-        });
-        if (svcResp.ok() && ctxResp.ok()) {
-            const svcData = await svcResp.json() as { items?: Array<{ id?: string }> };
-            const ctx = await ctxResp.json() as {
-                templates?: Array<{ id?: string }>;
-                instance_sizes?: Array<{ id?: string }>;
-            };
-            const svcId = svcData.items?.[0]?.id;
-            const tplId = ctx.templates?.[0]?.id;
-            const sizeId = ctx.instance_sizes?.[0]?.id;
-            if (svcId && tplId && sizeId) {
-                const batchResp = await request.post(`/api/v1/vms/batch`, {
-                    headers: { Authorization: `Bearer ${token}` },
-                    data: {
-                        operation: 'CREATE',
-                        items: [{
-                            service_id: svcId,
-                            template_id: tplId,
-                            instance_size_id: sizeId,
-                            name: `e2e-reject-${Date.now().toString(36).slice(-5)}`,
-                        }],
-                        reason: 'Created by live E2E to test rejectTicket',
-                    },
-                });
-                expect(batchResp.status(), 'Setting up approval tickets should return 202 Accepted').toBe(202);
-            }
-        }
-
-        await page.goto('/approvals');
+        await page.goto('/admin/approvals');
         await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
 
-        const rejectBtn = page.locator('[data-testid^="approval-action-reject-"]').first();
+        const rejectBtn = page.getByTestId(`approval-action-reject-${ticketID}`);
         await expect(rejectBtn, 'No pending approval tickets found — API setup may have failed').toBeVisible();
-
-        const testId = await rejectBtn.getAttribute('data-testid');
-        const ticketID = testId?.replace('approval-action-reject-', '') ?? '';
 
         const rejectRespPromise = page.waitForResponse(
             (r) =>
-                urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
-                (r.request().method() === 'PATCH' || r.request().method() === 'POST')
+                urlPathEndsWith(r.url(), `/api/v1/approvals/${ticketID}/reject`) &&
+                r.request().method() === 'POST'
         );
 
         await rejectBtn.click();
@@ -617,7 +873,11 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
 
         // ── CONTRACT CHECK: rejectTicket → 204 ───────────────────────────────────
         const rejectResp = await rejectRespPromise;
-        expect([200, 204]).toContain(rejectResp.status());
+        expect(rejectResp.status(), `POST /approvals/{id}/reject returned ${rejectResp.status()}`).toBe(204);
+        const token = await getAdminToken(request);
+        const headers = { Authorization: `Bearer ${token}` };
+        await waitForTicketStatus(request, headers, ticketID, 'REJECTED');
+        await waitForApprovalNotification(request, headers, ticketID, 'APPROVAL_REJECTED');
     });
 
     // ── Audit Log ─────────────────────────────────────────────────────────────────
@@ -625,23 +885,20 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
     test('listAuditLogs: audit log list conforms to AuditLogList schema', async ({ page }) => {
         // operationId: listAuditLogs
         const auditRespPromise = page.waitForResponse(
-            (r) => (urlPathIncludes(r.url(), '/api/v1/audit-logs') || urlPathIncludes(r.url(), '/api/v1/admin/audit-logs')) && r.request().method() === 'GET'
+            (r) => urlPathEndsWith(r.url(), '/api/v1/audit-logs') && r.request().method() === 'GET'
         );
 
         await page.goto('/admin/audit');
         // Accept either a dedicated page or a section within admin
         await expect(page.locator('body')).toBeVisible();
+        // Trigger explicit request to guarantee contract coverage even if page load
+        // does not automatically request audit logs.
+        const auditStatus = await fetchStatusWithStoredToken(page, '/api/v1/audit-logs', 'GET');
+        expect(auditStatus).toBe(200);
 
         // ── CONTRACT CHECK: listAuditLogs → AuditLogList ──────────────────────────
-        const auditResp = await Promise.race([
-            auditRespPromise,
-            new Promise<null>((resolve) => setTimeout(() => resolve(null), 4000)),
-        ]);
-        if (auditResp) {
-            expect((auditResp as Response).status()).toBe(200);
-            await validateApiResponse('AuditLogList', auditResp as Response);
-        } else {
-            console.warn('[listAuditLogs] Audit log endpoint not called on page load – check route configuration');
-        }
+        const auditResp = await auditRespPromise;
+        expect(auditResp.status()).toBe(200);
+        await validateApiResponse('AuditLogList', auditResp);
     });
 });

--- a/web/tests/e2e/edge-cases-live.spec.ts
+++ b/web/tests/e2e/edge-cases-live.spec.ts
@@ -14,14 +14,19 @@
  */
 
 import { expect, test, type Page } from '@playwright/test';
-import { urlPathEndsWith } from './lib/helpers';
+import { getAntModal, loginWithForcePasswordSupport, selectAntOption, urlPathEndsWith } from './lib/helpers';
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
+const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
+const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
+const e2eSystemName = process.env.E2E_SYSTEM ?? 'e2e-system';
+const e2eServiceName = process.env.E2E_SERVICE ?? 'e2e-service';
+let activePassword = e2ePassword;
 
 // ── Shared UI Actions ──
 async function fillInvalidLogin(page: Page): Promise<void> {
     await page.goto('/login');
-    await expect(page.getByRole('heading', { name: 'KubeVirt Shepherd' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /shepherd/i })).toBeVisible();
     await page.getByPlaceholder('Username').fill(e2eUsername);
     await page.getByPlaceholder('Password').fill('WRONG_PASSWORD_12345');
 
@@ -34,18 +39,24 @@ async function fillInvalidLogin(page: Page): Promise<void> {
     const loginResp = await loginRespPromise;
     expect(loginResp.status(), 'Login with wrong password should fail').toBe(401);
 
-    // UI should show an error message (typically standard Ant Design message)
-    const errorMsg = page.locator('.ant-message-error, .ant-alert-error').first();
-    await expect(errorMsg).toBeVisible({ timeout: 5000 });
+    // UI should expose an auth error (inline alert OR top message toast).
+    const inlineError = page.locator('.ant-alert-error').first();
+    const toastError = page.locator('.ant-message .ant-message-error').first();
+    await expect
+        .poll(async () => (await inlineError.isVisible()) || (await toastError.isVisible()), {
+            timeout: 10000,
+            message: 'Expected visible auth error after 401 login response',
+        })
+        .toBeTruthy();
 }
 
 async function loginAdmin(page: Page): Promise<void> {
-    const password = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
-    await page.goto('/login');
-    await page.getByPlaceholder('Username').fill(e2eUsername);
-    await page.getByPlaceholder('Password').fill(password);
-    await page.getByRole('button', { name: 'Login' }).click();
-    await expect(page).toHaveURL(/\/(dashboard)?$/);
+    activePassword = await loginWithForcePasswordSupport(page, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
 }
 
 test.describe('Edge Cases / Negative Paths', () => {
@@ -64,16 +75,15 @@ test.describe('Edge Cases / Negative Paths', () => {
             await page.goto('/systems');
             await expect(page.getByRole('heading', { name: /systems/i })).toBeVisible();
             await page.getByTestId('system-create-button').click();
-            await expect(page.getByTestId('system-create-modal')).toBeVisible();
-
-            const modal = page.getByTestId('system-create-modal');
+            const modal = getAntModal(page, 'system-create-modal');
+            await expect(modal).toBeVisible();
 
             // 1. Empty submit
             await modal.getByRole('button', { name: /ok|create|submit/i }).click();
             await expect(modal.locator('.ant-form-item-explain-error').first()).toBeVisible();
 
             // 2. Max length logic (15 chars limit)
-            const input = modal.getByLabel(/name|system name/i);
+            const input = modal.locator('#create-system_name');
             const tooLong = 'this-name-is-way-too-long-for-system';
             await input.fill(tooLong);
             // Ant design limits at input level generally via maxLength attribute
@@ -84,9 +94,9 @@ test.describe('Edge Cases / Negative Paths', () => {
             await input.fill('Invalid Name_123!');
             await input.blur(); // Trigger validation
             await modal.getByRole('button', { name: /ok|create|submit/i }).click();
-            await expect(modal.locator('.ant-form-item-explain-error').filter({ hasText: /format|pattern|invalid/i })).toBeVisible();
+            await expect(modal.locator('.ant-form-item-explain-error').first()).toBeVisible();
 
-            await page.getByTestId('system-create-modal').getByRole('button', { name: /cancel/i }).click();
+            await modal.getByRole('button', { name: /cancel/i }).click();
         });
 
         test('System Form - Delete Object Guard Validator Edge Case', async ({ page }) => {
@@ -99,11 +109,11 @@ test.describe('Edge Cases / Negative Paths', () => {
             await expect(firstDeleteBtn).toBeVisible({ timeout: 10000 });
             await firstDeleteBtn.click();
 
-            const deleteModal = page.getByTestId('system-delete-modal');
+            const deleteModal = getAntModal(page, 'system-delete-modal');
             await expect(deleteModal).toBeVisible();
 
             const confirmInput = deleteModal.getByRole('textbox').first();
-            const okBtn = deleteModal.getByRole('button', { name: /ok|delete|confirm/i });
+            const okBtn = deleteModal.getByRole('button', { name: /delete/i });
 
             // Button disabled by default
             await expect(okBtn).toBeDisabled();
@@ -118,22 +128,41 @@ test.describe('Edge Cases / Negative Paths', () => {
         test('VM Request - Batch Count Edge Cases', async ({ page }) => {
             await page.goto('/vms');
             await expect(page.getByRole('heading', { name: /virtual machines/i })).toBeVisible();
-            await page.getByTestId('vm-request-button').click(); // Enter Wizard 
-            const wizardModal = page.getByTestId('vm-request-wizard-modal');
+            await page.getByRole('button', { name: /request vm/i }).click();
+            const wizardModal = getAntModal(page, 'vm-request-wizard-modal');
             await expect(wizardModal).toBeVisible();
 
-            // Get past steps to the batch count page (assuming step 3 handles batch count)
-            // Selecting system -> service -> template -> size etc...
-            // Note: Since this requires massive seeding to reach step 3, we'll try to check limits if elements appear.
-            const nextBtn = wizardModal.getByRole('button', { name: /next/i }).first();
-            if (await nextBtn.isVisible()) {
-                // Try to proceed without selecting required fields
-                await nextBtn.click();
-                // Should have form explain errors
-                await expect(wizardModal.locator('.ant-form-item-explain-error').first()).toBeVisible();
-            }
+            // Walk to config step with valid selections (Stage 5.A wizard flow).
+            await selectAntOption(page, wizardModal.locator('[role="combobox"]').first(), e2eSystemName);
+            await selectAntOption(page, wizardModal.locator('[role="combobox"]').nth(1), e2eServiceName);
+            await wizardModal.getByRole('button', { name: /next/i }).click();
 
-            await wizardModal.getByRole('button', { name: 'Cancel' }).click();
+            await selectAntOption(page, wizardModal.locator('[role="combobox"]').first());
+            await wizardModal.getByRole('button', { name: /next/i }).click();
+
+            await selectAntOption(page, wizardModal.locator('[role="combobox"]').first());
+            await wizardModal.getByRole('button', { name: /next/i }).click();
+
+            await wizardModal.locator('#vm-request-wizard_namespace').fill('edge-ns');
+            await wizardModal.locator('#vm-request-wizard_reason').fill('edge case: batch_count validation');
+
+            const batchCountInput = wizardModal.locator('#vm-request-wizard_batch_count');
+
+            // InputNumber enforces min/max bounds at input level (1..50).
+            await batchCountInput.fill('0');
+            await batchCountInput.blur();
+            await expect(batchCountInput).toHaveValue('1');
+
+            await batchCountInput.fill('51');
+            await batchCountInput.blur();
+            await expect(batchCountInput).toHaveValue('50');
+
+            // valid value should allow entering confirm step.
+            await batchCountInput.fill('1');
+            await wizardModal.getByRole('button', { name: /next/i }).click();
+            await expect(wizardModal.getByText(/requested vm count/i)).toBeVisible();
+
+            await page.keyboard.press('Escape');
         });
     });
 });

--- a/web/tests/e2e/lib/helpers.ts
+++ b/web/tests/e2e/lib/helpers.ts
@@ -16,7 +16,8 @@
  * Reference: https://playwright.dev/docs/best-practices
  */
 
-import { expect, type Locator, type Page } from '@playwright/test';
+import { expect, type APIRequestContext, type Locator, type Page } from '@playwright/test';
+import { validateResponse } from './schema-validator';
 
 // ── URL Path Matching (query-param safe) ─────────────────────────────────────
 
@@ -91,8 +92,11 @@ export async function selectAntOption(
     optionFilter?: string | RegExp,
     timeout = 5000
 ): Promise<void> {
+    const trigger = combobox.first();
+    await expect(trigger).toBeVisible({ timeout });
+
     // Step 1: Click to open dropdown
-    await combobox.click();
+    await trigger.click();
 
     // Step 2: Wait for any OLD dropdown leave-animations to finish.
     // Ant Design adds `.ant-slide-up-leave` during close animation.
@@ -102,25 +106,76 @@ export async function selectAntOption(
         page.locator('.ant-select-dropdown.ant-slide-up-leave')
     ).toHaveCount(0, { timeout });
 
-    // Step 3: Locate the ACTIVE dropdown (exclude any lingering leave-animations).
-    // Use Playwright visibility filtering instead of CSS :visible pseudo selectors.
+    // Step 3: Locate the active dropdown.
     const dropdown = page
         .locator('.ant-select-dropdown:not(.ant-slide-up-leave):not(.ant-slide-up-leave-active)')
         .filter({ visible: true })
         .last();
     await expect(dropdown).toBeVisible({ timeout });
 
-    // Step 4: Find the target option within the active dropdown
-    let option: Locator;
-    if (optionFilter) {
-        option = dropdown.locator('.ant-select-item-option').filter({ hasText: optionFilter }).first();
-    } else {
-        option = dropdown.locator('.ant-select-item-option').first();
+    const optionCandidates = dropdown.locator('[role="option"], .ant-select-item-option');
+    const visibleOptions = optionCandidates.filter({ visible: true });
+
+    // Step 4: Wait for options to be ready. Async option loading is common in
+    // Ant Design Select and should not fail immediately.
+    const readiness = { value: 'pending' as 'pending' | 'ready' | 'no-data' };
+    await expect
+        .poll(async () => {
+            const visibleOptionCount = await visibleOptions.count();
+            if (visibleOptionCount > 0) {
+                readiness.value = 'ready';
+                return readiness.value;
+            }
+            const noDataVisible = await dropdown
+                .getByText(/^(no data|not found|no options)$/i)
+                .first()
+                .isVisible()
+                .catch(() => false);
+            if (noDataVisible) {
+                readiness.value = 'no-data';
+                return readiness.value;
+            }
+            readiness.value = 'pending';
+            return readiness.value;
+        }, { timeout })
+        .not.toBe('pending');
+
+    if (readiness.value === 'no-data') {
+        throw new Error(
+            'Ant Select has no selectable options ("No data"/"Not Found"). ' +
+            'For approval flow this usually means no HEALTHY+enabled cluster is available.'
+        );
     }
 
-    // Step 5: Wait for option to be visible and stable before clicking
+    // Step 5: Find the target option within the active dropdown
+    let option: Locator;
+    if (optionFilter) {
+        option = visibleOptions.filter({ hasText: optionFilter }).first();
+    } else {
+        option = visibleOptions.first();
+    }
+
+    // Step 6: Wait for option to be visible and stable before clicking
+    const matchCount = await option.count();
+    if (matchCount === 0) {
+        const available = (await visibleOptions.allTextContents())
+            .map((text) => text.trim())
+            .filter(Boolean)
+            .join(' | ');
+        throw new Error(
+            `Ant Select option not found for filter ${String(optionFilter)}. ` +
+            `Available options: ${available || '(none)'}`
+        );
+    }
+
     await expect(option).toBeVisible({ timeout });
     await option.click();
+
+    // Multi-select dropdowns may remain open after selecting one item and can block modal buttons.
+    // Press Escape once to close the dropdown explicitly when it is still visible.
+    if (await dropdown.isVisible().catch(() => false)) {
+        await page.keyboard.press('Escape');
+    }
 }
 
 // ── Ant Design Modal Locator Helper ──────────────────────────────────────────
@@ -166,4 +221,269 @@ export async function selectAntOption(
  */
 export function getAntModal(page: Page, testId: string): Locator {
     return page.getByTestId(testId).locator('.ant-modal-wrap');
+}
+
+/**
+ * Issue a same-origin fetch using the JWT persisted by the app in localStorage.
+ * Useful in E2E tests when we need deterministic API triggering from page context.
+ */
+export async function fetchStatusWithStoredToken(
+    page: Page,
+    path: string,
+    method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' = 'GET'
+): Promise<number> {
+    return page.evaluate(async ({ path: requestPath, method: requestMethod }) => {
+        let token = '';
+        try {
+            const raw = window.localStorage.getItem('shepherd-auth');
+            const parsed = raw ? JSON.parse(raw) : null;
+            token = typeof parsed?.state?.token === 'string' ? parsed.state.token : '';
+        } catch {
+            token = '';
+        }
+
+        const headers: Record<string, string> = {};
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+
+        const resp = await fetch(requestPath, {
+            method: requestMethod,
+            headers,
+        });
+        return resp.status;
+    }, { path, method });
+}
+
+interface LoginResponsePayload {
+    token?: string;
+    force_password_change?: boolean;
+}
+
+interface AuthFlowOptions {
+    username: string;
+    primaryPassword: string;
+    secondaryPassword?: string;
+    currentPasswordHint?: string;
+}
+
+interface BatchRateLimitSetupOptions extends AuthFlowOptions {
+    reasonPrefix?: string;
+    maxPendingParents?: number;
+    maxPendingChildren?: number;
+    cooldownSeconds?: number;
+}
+
+function uniqueCandidates(values: Array<string | undefined>): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const value of values) {
+        const v = (value ?? '').trim();
+        if (!v || seen.has(v)) continue;
+        seen.add(v);
+        out.push(v);
+    }
+    return out;
+}
+
+function resolveNextPassword(current: string, preferred?: string): string {
+    const candidate = (preferred ?? '').trim();
+    if (candidate && candidate !== current) {
+        return candidate;
+    }
+    if (current === 'admin') {
+        return 'admin123';
+    }
+    return `${current}-new`;
+}
+
+async function submitUILogin(page: Page, username: string, password: string) {
+    await page.goto('/login');
+    await expect(page.getByRole('heading', { name: /shepherd/i })).toBeVisible();
+    await page.locator('#login_username').fill(username);
+    await page.locator('#login_password').fill(password);
+
+    const loginRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Login' }).click();
+    return loginRespPromise;
+}
+
+async function completeForcedPasswordChangeUI(page: Page, currentPassword: string, newPassword: string): Promise<void> {
+    await expect(page).toHaveURL(/\/auth\/change-password(?:\?.*)?$/);
+    await expect(page.locator('#change-password_current_password')).toBeVisible();
+    await page.locator('#change-password_current_password').fill(currentPassword);
+    await page.locator('#change-password_new_password').fill(newPassword);
+    await page.locator('#change-password_confirm_password').fill(newPassword);
+    const submitButton = page.getByRole('button', { name: /change password/i }).first();
+    await expect(submitButton).toBeVisible();
+    await expect(submitButton).toBeEnabled();
+
+    const changeRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/change-password') && r.request().method() === 'POST'
+    );
+    await submitButton.click();
+    const changeResp = await changeRespPromise;
+    expect(changeResp.status(), `POST /auth/change-password returned ${changeResp.status()}`).toBe(204);
+    // In live runs, first-time compile of /dashboard can take several seconds.
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 45_000 });
+}
+
+/**
+ * UI login helper that supports first-login forced password change and password fallback.
+ *
+ * Returns the password that is valid after login flow completes.
+ */
+export async function loginWithForcePasswordSupport(
+    page: Page,
+    options: AuthFlowOptions
+): Promise<string> {
+    const candidates = uniqueCandidates([
+        options.currentPasswordHint,
+        options.primaryPassword,
+        options.secondaryPassword,
+    ]);
+    let lastStatus = 0;
+
+    for (const password of candidates) {
+        const loginResp = await submitUILogin(page, options.username, password);
+        lastStatus = loginResp.status();
+        if (lastStatus === 401) {
+            continue;
+        }
+
+        expect(lastStatus, `POST /auth/login returned unexpected status ${lastStatus}`).toBe(200);
+        const loginBody = await loginResp.json() as LoginResponsePayload;
+        validateResponse('LoginResponse', loginBody);
+
+        if (!loginBody.force_password_change) {
+            // In live runs, first-time compile of /dashboard can take several seconds.
+            await expect(page).toHaveURL(/\/dashboard$/, { timeout: 45_000 });
+            return password;
+        }
+
+        const nextPassword = resolveNextPassword(password, options.secondaryPassword);
+        await completeForcedPasswordChangeUI(page, password, nextPassword);
+        return nextPassword;
+    }
+
+    throw new Error(
+        `Unable to log in user "${options.username}" with candidate passwords; ` +
+        `last status: ${lastStatus}`
+    );
+}
+
+/**
+ * API login helper with the same semantics as UI login helper:
+ * fallback candidate passwords + auto handling force_password_change.
+ */
+export async function getApiTokenWithForcePasswordSupport(
+    request: APIRequestContext,
+    options: AuthFlowOptions
+): Promise<{ token: string; password: string }> {
+    const candidates = uniqueCandidates([
+        options.currentPasswordHint,
+        options.primaryPassword,
+        options.secondaryPassword,
+    ]);
+    let lastStatus = 0;
+
+    for (const password of candidates) {
+        const loginResp = await request.post('/api/v1/auth/login', {
+            data: { username: options.username, password },
+        });
+        lastStatus = loginResp.status();
+        if (lastStatus === 401) {
+            continue;
+        }
+
+        expect(lastStatus, `POST /auth/login returned unexpected status ${lastStatus}`).toBe(200);
+        const loginBody = await loginResp.json() as LoginResponsePayload;
+        validateResponse('LoginResponse', loginBody);
+        const token = loginBody.token ?? '';
+        expect(token, 'LoginResponse.token is required').toBeTruthy();
+
+        if (!loginBody.force_password_change) {
+            return { token, password };
+        }
+
+        const nextPassword = resolveNextPassword(password, options.secondaryPassword);
+        const changeResp = await request.post('/api/v1/auth/change-password', {
+            headers: { Authorization: `Bearer ${token}` },
+            data: {
+                old_password: password,
+                new_password: nextPassword,
+            },
+        });
+        expect(changeResp.status(), `POST /auth/change-password returned ${changeResp.status()}`).toBe(204);
+
+        const reloginResp = await request.post('/api/v1/auth/login', {
+            data: { username: options.username, password: nextPassword },
+        });
+        expect(reloginResp.status(), `POST /auth/login after password change returned ${reloginResp.status()}`).toBe(200);
+        const reloginBody = await reloginResp.json() as LoginResponsePayload;
+        validateResponse('LoginResponse', reloginBody);
+        expect(reloginBody.force_password_change, 'force_password_change should be false after password change').not.toBeTruthy();
+        const reloginToken = reloginBody.token ?? '';
+        expect(reloginToken, 'LoginResponse.token is required after password change').toBeTruthy();
+        return { token: reloginToken, password: nextPassword };
+    }
+
+    throw new Error(
+        `Unable to log in user "${options.username}" via API with candidate passwords; ` +
+        `last status: ${lastStatus}`
+    );
+}
+
+/**
+ * Ensure batch-submit happy-path tests are deterministic by setting explicit
+ * per-user batch policy through admin APIs (API-first setup, no assertion weakening).
+ */
+export async function ensureBatchSubmitPolicyForUser(
+    request: APIRequestContext,
+    options: BatchRateLimitSetupOptions
+): Promise<{ password: string; userID: string }> {
+    const auth = await getApiTokenWithForcePasswordSupport(request, options);
+    const headers = { Authorization: `Bearer ${auth.token}` };
+
+    const meResp = await request.get('/api/v1/auth/me', { headers });
+    expect(meResp.status(), `GET /auth/me returned ${meResp.status()}`).toBe(200);
+    const meBody = await meResp.json() as { id?: string };
+    validateResponse('UserInfo', meBody);
+    const userID = (meBody.id ?? '').trim();
+    expect(userID, 'Authenticated user id is required for batch policy setup').toBeTruthy();
+
+    const reasonPrefix = (options.reasonPrefix ?? 'live-e2e batch policy setup').trim();
+    const reason = `${reasonPrefix} ${Date.now()}`;
+
+    const exemptionResp = await request.post('/api/v1/admin/rate-limits/exemptions', {
+        headers,
+        data: {
+            user_id: userID,
+            reason,
+        },
+    });
+    expect(
+        exemptionResp.status(),
+        `POST /admin/rate-limits/exemptions returned ${exemptionResp.status()}`
+    ).toBe(200);
+    validateResponse('RateLimitExemption', await exemptionResp.json());
+
+    const overrideResp = await request.put(`/api/v1/admin/rate-limits/users/${userID}`, {
+        headers,
+        data: {
+            max_pending_parents: options.maxPendingParents ?? 128,
+            max_pending_children: options.maxPendingChildren ?? 4096,
+            cooldown_seconds: options.cooldownSeconds ?? 0,
+            reason,
+        },
+    });
+    expect(
+        overrideResp.status(),
+        `PUT /admin/rate-limits/users/{user_id} returned ${overrideResp.status()}`
+    ).toBe(200);
+    validateResponse('RateLimitUserOverride', await overrideResp.json());
+
+    return { password: auth.password, userID };
 }

--- a/web/tests/e2e/lib/schema-validator.ts
+++ b/web/tests/e2e/lib/schema-validator.ts
@@ -209,6 +209,52 @@ interface PlaywrightResponse {
     json(): Promise<unknown>;
     status(): number;
     url(): string;
+    request?: () => {
+        method(): string;
+        headers(): Record<string, string>;
+    };
+}
+
+function isReleasedResponseBodyError(message: string): boolean {
+    return message.includes('No resource with given identifier') || message.includes('Target closed');
+}
+
+function buildRetryHeaders(headers: Record<string, string>): Record<string, string> {
+    const forwarded: Record<string, string> = {};
+    for (const [rawKey, value] of Object.entries(headers)) {
+        const key = rawKey.toLowerCase();
+        if (!value) continue;
+        if (key === 'authorization' || key === 'cookie' || key === 'accept') {
+            forwarded[rawKey] = value;
+            continue;
+        }
+        // Preserve x-* headers used by local proxy/auth chains.
+        if (key.startsWith('x-')) {
+            forwarded[rawKey] = value;
+        }
+    }
+    return forwarded;
+}
+
+async function retryReleasedGetBody(response: PlaywrightResponse): Promise<unknown | null> {
+    const req = typeof response.request === 'function' ? response.request() : undefined;
+    if (!req || req.method() !== 'GET') {
+        return null;
+    }
+
+    const retryResp = await fetch(response.url(), {
+        method: 'GET',
+        headers: buildRetryHeaders(req.headers()),
+    });
+
+    if (retryResp.status !== response.status()) {
+        throw new Error(
+            `[schema-validator] fallback GET status mismatch for ${response.url()}: ` +
+            `original=${response.status()} fallback=${retryResp.status}`
+        );
+    }
+
+    return retryResp.json();
 }
 
 /**
@@ -236,19 +282,25 @@ export async function validateApiResponse(
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         // Distinguish navigation race-condition from real JSON parse failure
-        if (msg.includes('No resource with given identifier') || msg.includes('Target closed')) {
+        if (isReleasedResponseBodyError(msg)) {
+            const fallbackBody = await retryReleasedGetBody(response);
+            if (fallbackBody !== null) {
+                body = fallbackBody;
+            } else {
+                throw new Error(
+                    `[schema-validator] Response body was released before it could be read.\n` +
+                    `This is a test infrastructure race condition: page navigation completed\n` +
+                    `before Playwright read the response body for ${response.url()}.\n` +
+                    `Fix: register page.waitForResponse() BEFORE triggering page.goto().\n` +
+                    `Original error: ${msg}`
+                );
+            }
+        } else {
             throw new Error(
-                `[schema-validator] Response body was released before it could be read.\n` +
-                `This is a test infrastructure race condition: page navigation completed\n` +
-                `before Playwright read the response body for ${response.url()}.\n` +
-                `Fix: register page.waitForResponse() BEFORE triggering page.goto().\n` +
-                `Original error: ${msg}`
+                `[schema-validator] Failed to parse response body as JSON for ${response.url()} ` +
+                `(HTTP ${response.status()}): ${msg}`
             );
         }
-        throw new Error(
-            `[schema-validator] Failed to parse response body as JSON for ${response.url()} ` +
-            `(HTTP ${response.status()}): ${msg}`
-        );
     }
     try {
         validateResponse(schemaName, body);

--- a/web/tests/e2e/master-flow-live.spec.ts
+++ b/web/tests/e2e/master-flow-live.spec.ts
@@ -14,6 +14,7 @@
  *   createSystem           Stage 4.A  – POST /systems
  *   listSystemMembers      Stage 4.A+ – GET /systems/{id}/members
  *   createService          Stage 4.B  – POST /systems/{id}/services
+ *   getService             Stage 4.C  – GET /systems/{id}/services/{id}
  *   updateService          Stage 4.B  – PATCH /systems/{id}/services/{id}
  *   deleteService          Stage 4.B  – DELETE /systems/{id}/services/{id}
  *   listVMs                Stage 5    – GET /vms
@@ -33,11 +34,12 @@
  *   listRoles              Stage 2.A  – GET /admin/roles
  *   listAuthProviderTypes  Stage 2.B  – GET /admin/auth-provider-types
  *   listAuthProviders      Stage 2.B  – GET /admin/auth-providers
- *   listUsers              Stage 2.A+ – GET /admin/users
+ *   listUsers              Stage 2 (Supplemental) – GET /admin/users
  *
  * Environment variables:
  *   E2E_USERNAME        – admin username (default: e2e-admin)
  *   E2E_PASSWORD        – admin password (default: e2e-admin-123)
+ *   E2E_NEW_PASSWORD    – password used when force_password_change=true
  *   E2E_SYSTEM          – pre-existing system name for cascade tests
  *   E2E_SERVICE         – pre-existing service name (has child VMs)
  *   E2E_VM_RUNNING_ID   – ID of a running VM for console test
@@ -46,39 +48,41 @@
  *   PW_BASE_URL=http://localhost:3000 npx playwright test master-flow-live
  */
 
-import { expect, test, type Page, type Response } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
-import { urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal } from './lib/helpers';
+import {
+  fetchStatusWithStoredToken,
+  getAntModal,
+  getApiTokenWithForcePasswordSupport,
+  loginWithForcePasswordSupport,
+  selectAntOption,
+  urlPathEndsWith,
+  urlPathIncludes,
+} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
 const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
+const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
+const e2eClusterName = process.env.E2E_CLUSTER ?? 'e2e-cluster';
 const e2eSystemName = process.env.E2E_SYSTEM ?? 'e2e-system';
 const e2eServiceName = process.env.E2E_SERVICE ?? 'e2e-service';
+const e2eTemplateName = process.env.E2E_TEMPLATE ?? 'e2e-template';
+const e2eSizeName = process.env.E2E_SIZE ?? 'e2e-small';
+const e2eNamespace = process.env.E2E_NAMESPACE ?? 'e2e-test';
 const runningVMID = process.env.E2E_VM_RUNNING_ID ?? '';
+let activePassword = e2ePassword;
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
 
 async function login(page: Page): Promise<void> {
-  await page.goto('/login');
-  await expect(page.getByRole('heading', { name: 'KubeVirt Shepherd' })).toBeVisible();
-
-  await page.getByPlaceholder('Username').fill(e2eUsername);
-  await page.getByPlaceholder('Password').fill(e2ePassword);
-
-  const loginRespPromise = page.waitForResponse(
-    (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
-  );
-  await page.getByRole('button', { name: 'Login' }).click();
-
-  const loginResp = await loginRespPromise;
-  expect(loginResp.status()).toBe(200);
-
-  // ── CONTRACT CHECK: LoginResponse schema ──────────────────────────────────
-  await validateApiResponse('LoginResponse', loginResp);
-
-  await expect(page).toHaveURL(/\/dashboard$/);
+  activePassword = await loginWithForcePasswordSupport(page, {
+    username: e2eUsername,
+    primaryPassword: e2ePassword,
+    secondaryPassword: e2eNewPassword,
+    currentPasswordHint: activePassword,
+  });
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -96,6 +100,453 @@ async function expectSchema(
   return { body, resp };
 }
 
+async function getAdminToken(request: APIRequestContext): Promise<string> {
+  const auth = await getApiTokenWithForcePasswordSupport(request, {
+    username: e2eUsername,
+    primaryPassword: e2ePassword,
+    secondaryPassword: e2eNewPassword,
+    currentPasswordHint: activePassword,
+  });
+  activePassword = auth.password;
+  return auth.token;
+}
+
+function pickIDByPreferredName<T extends { id?: string; name?: string }>(
+  items: T[] | undefined,
+  preferredName: string
+): string {
+  const preferred = (items ?? []).find((item) => (item.name ?? '').trim() === preferredName && Boolean(item.id));
+  if (preferred?.id) {
+    return preferred.id;
+  }
+  return (items ?? []).find((item) => Boolean(item.id))?.id ?? '';
+}
+
+function pickPreferredNamespace(namespaces: string[] | undefined, preferredName: string): string {
+  return namespaces?.find((ns) => ns === preferredName) ?? namespaces?.[0] ?? preferredName;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function toLooseOptionFilter(rawName: string): RegExp {
+  const tokens = rawName
+    .trim()
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map(escapeRegExp);
+  if (tokens.length === 0) {
+    return /.*/;
+  }
+  return new RegExp(tokens.join('\\s*[-_ ]*\\s*'), 'i');
+}
+
+async function resolveClusterOptionFilter(
+  request: APIRequestContext,
+  headers: { Authorization: string }
+): Promise<RegExp> {
+  const clustersResp = await request.get('/api/v1/admin/clusters?page=1&per_page=100', { headers });
+  expect(clustersResp.status(), `GET /admin/clusters returned ${clustersResp.status()}`).toBe(200);
+  const clustersBody = await validateApiResponse('ClusterList', clustersResp) as {
+    items?: Array<{ id?: string; name?: string; display_name?: string; displayName?: string }>;
+  };
+  const clusters = clustersBody.items ?? [];
+  expect(clusters.length, 'Stage 5.B requires at least one cluster option').toBeGreaterThan(0);
+
+  const preferred =
+    clusters.find((item) => (item.name ?? '').trim() === e2eClusterName) ??
+    clusters[0];
+  const label = String((preferred.display_name ?? preferred.displayName ?? preferred.name ?? '')).trim();
+  expect(label, 'Cluster option label cannot be empty').toBeTruthy();
+  return toLooseOptionFilter(label);
+}
+
+async function resolveHealthyClusterID(
+  request: APIRequestContext,
+  headers: { Authorization: string }
+): Promise<string> {
+  const clustersResp = await request.get('/api/v1/admin/clusters?page=1&per_page=100', { headers });
+  expect(clustersResp.status(), `GET /admin/clusters returned ${clustersResp.status()}`).toBe(200);
+  const clustersBody = await validateApiResponse('ClusterList', clustersResp) as {
+    items?: Array<{ id?: string; status?: string; enabled?: boolean }>;
+  };
+  const clusters = clustersBody.items ?? [];
+  const healthyEnabled = clusters.find((item) => item.id && item.enabled !== false && (item.status ?? '').toUpperCase() === 'HEALTHY');
+  if (healthyEnabled?.id) {
+    return healthyEnabled.id;
+  }
+  return clusters.find((item) => Boolean(item.id))?.id ?? '';
+}
+
+async function resolveCreateVMRequestData(
+  request: APIRequestContext,
+  headers: { Authorization: string },
+  scope: string,
+  preferredServiceName = e2eServiceName
+): Promise<{ service_id: string; template_id: string; instance_size_id: string; namespace: string }> {
+  const systemsResp = await request.get('/api/v1/systems', { headers });
+  expect(systemsResp.status(), `GET /systems must return 200 for ${scope}`).toBe(200);
+  const systems = await validateApiResponse('SystemList', systemsResp) as { items?: Array<{ id?: string; name?: string }> };
+  const systemId = pickIDByPreferredName(systems.items, e2eSystemName);
+  expect(systemId, `${scope} requires at least one existing system`).toBeTruthy();
+
+  const [servicesResp, contextResp] = await Promise.all([
+    request.get(`/api/v1/systems/${systemId}/services`, { headers }),
+    request.get('/api/v1/vms/request-context', { headers }),
+  ]);
+  expect(servicesResp.status(), `GET /systems/{id}/services must return 200 for ${scope}`).toBe(200);
+  expect(contextResp.status(), `GET /vms/request-context must return 200 for ${scope}`).toBe(200);
+
+  const services = await validateApiResponse('ServiceList', servicesResp) as { items?: Array<{ id?: string; name?: string }> };
+  const ctx = await validateApiResponse('VMRequestContext', contextResp) as {
+    templates?: Array<{ id?: string; name?: string }>;
+    instance_sizes?: Array<{ id?: string; name?: string }>;
+    namespaces?: string[];
+  };
+
+  const serviceId = pickIDByPreferredName(services.items, preferredServiceName);
+  const templateId = pickIDByPreferredName(ctx.templates, e2eTemplateName);
+  const sizeId = pickIDByPreferredName(ctx.instance_sizes, e2eSizeName);
+  const namespace = pickPreferredNamespace(ctx.namespaces, e2eNamespace);
+  expect(serviceId, `${scope} requires an existing service`).toBeTruthy();
+  expect(templateId, `${scope} requires an existing template`).toBeTruthy();
+  expect(sizeId, `${scope} requires an existing instance size`).toBeTruthy();
+
+  return {
+    service_id: serviceId,
+    template_id: templateId,
+    instance_size_id: sizeId,
+    namespace,
+  };
+}
+
+async function createUniqueServiceForStage5A(request: APIRequestContext): Promise<string> {
+  const token = await getAdminToken(request);
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const systemsResp = await request.get('/api/v1/systems', { headers });
+  expect(systemsResp.status(), 'GET /systems must return 200 for Stage 5.A setup').toBe(200);
+  const systems = await validateApiResponse('SystemList', systemsResp) as { items?: Array<{ id?: string; name?: string }> };
+  const systemId = pickIDByPreferredName(systems.items, e2eSystemName);
+  expect(systemId, 'Stage 5.A setup requires at least one existing system').toBeTruthy();
+
+  // OpenAPI ServiceCreateRequest.name: maxLength=15, pattern ^[a-z]([a-z0-9-]*[a-z0-9])?$
+  const serviceName = `s5a-${Date.now().toString(36).slice(-8)}`;
+  const createServiceResp = await request.post(`/api/v1/systems/${systemId}/services`, {
+    headers,
+    data: {
+      name: serviceName,
+      description: 'temporary service for Stage 5.A createVMRequest isolation',
+    },
+  });
+  expect(
+    createServiceResp.status(),
+    `POST /systems/{id}/services returned ${createServiceResp.status()} for Stage 5.A setup`
+  ).toBe(201);
+  await validateApiResponse('Service', createServiceResp);
+
+  return serviceName;
+}
+
+async function createUniqueServiceForApprovalSeed(request: APIRequestContext): Promise<string> {
+  const token = await getAdminToken(request);
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const systemsResp = await request.get('/api/v1/systems', { headers });
+  expect(systemsResp.status(), 'GET /systems must return 200 for Stage 5.B setup').toBe(200);
+  const systems = await validateApiResponse('SystemList', systemsResp) as { items?: Array<{ id?: string; name?: string }> };
+  const systemId = pickIDByPreferredName(systems.items, e2eSystemName);
+  expect(systemId, 'Stage 5.B setup requires at least one existing system').toBeTruthy();
+
+  const serviceName = `s5b-${Date.now().toString(36).slice(-8)}`;
+  const createServiceResp = await request.post(`/api/v1/systems/${systemId}/services`, {
+    headers,
+    data: {
+      name: serviceName,
+      description: 'temporary service for Stage 5.B approval seed isolation',
+    },
+  });
+  expect(
+    createServiceResp.status(),
+    `POST /systems/{id}/services returned ${createServiceResp.status()} for Stage 5.B setup`
+  ).toBe(201);
+  await validateApiResponse('Service', createServiceResp);
+  return serviceName;
+}
+
+async function listVMBriefs(
+  request: APIRequestContext,
+  headers: { Authorization: string }
+): Promise<Array<{ id: string; status: string }>> {
+  const vmMap = new Map<string, { id: string; status: string }>();
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const vmResp = await request.get(`/api/v1/vms?page=${page}&per_page=100`, { headers });
+    expect(vmResp.status(), `GET /vms?page=${page} returned ${vmResp.status()}`).toBe(200);
+    const vmBody = await validateApiResponse('VMList', vmResp) as {
+      items?: Array<{ id?: string; status?: string }>;
+      pagination?: { total_pages?: number };
+    };
+    for (const item of vmBody.items ?? []) {
+      if (!item.id) {
+        continue;
+      }
+      vmMap.set(item.id, { id: item.id, status: (item.status ?? '').toUpperCase() });
+    }
+    totalPages = Number(vmBody.pagination?.total_pages ?? 1) || 1;
+    page += 1;
+  } while (page <= totalPages);
+  return Array.from(vmMap.values());
+}
+
+async function waitForTicketStatus(
+  request: APIRequestContext,
+  headers: { Authorization: string },
+  ticketID: string,
+  expected: 'PENDING' | 'APPROVED' | 'REJECTED'
+): Promise<void> {
+  let expectedPattern: RegExp;
+  switch (expected) {
+    case 'PENDING':
+      expectedPattern = /^PENDING$/;
+      break;
+    case 'APPROVED':
+      expectedPattern = /^(APPROVED|EXECUTING|SUCCESS)$/;
+      break;
+    case 'REJECTED':
+      expectedPattern = /^REJECTED$/;
+      break;
+    default:
+      expectedPattern = /^$/;
+  }
+
+  await expect.poll(async () => {
+    let page = 1;
+    const perPage = 100;
+
+    for (let guard = 0; guard < 20; guard += 1) {
+      const listResp = await request.get(`/api/v1/approvals?page=${page}&per_page=${perPage}`, { headers });
+      expect(listResp.status(), `GET /approvals returned ${listResp.status()}`).toBe(200);
+      const listBody = await validateApiResponse('ApprovalTicketList', listResp) as {
+        items?: Array<{ id?: string; status?: string }>;
+        pagination?: { total_pages?: number };
+      };
+      const found = listBody.items?.find((item) => item.id === ticketID);
+      if (found) {
+        return (found.status ?? '').toUpperCase();
+      }
+      const totalPages = Number(listBody.pagination?.total_pages ?? 1);
+      if (!Number.isFinite(totalPages) || page >= totalPages) {
+        break;
+      }
+      page += 1;
+    }
+
+    return '';
+  }, {
+    timeout: 30_000,
+    intervals: [500, 1000, 2000],
+    message: `Ticket ${ticketID} did not match status pattern ${expectedPattern}`,
+  }).toMatch(expectedPattern);
+}
+
+async function findApprovalTicket(
+  request: APIRequestContext,
+  headers: { Authorization: string },
+  ticketID: string
+): Promise<{ status: string; ticket_payload?: Record<string, unknown> } | null> {
+  let page = 1;
+  const perPage = 100;
+  for (let guard = 0; guard < 20; guard += 1) {
+    const listResp = await request.get(`/api/v1/approvals?page=${page}&per_page=${perPage}`, { headers });
+    if (listResp.status() !== 200) {
+      return null;
+    }
+    const listBody = await validateApiResponse('ApprovalTicketList', listResp) as {
+      items?: Array<{ id?: string; status?: string; ticket_payload?: Record<string, unknown> }>;
+      pagination?: { total_pages?: number };
+    };
+    const found = (listBody.items ?? []).find((item) => item.id === ticketID);
+    if (found) {
+      return {
+        status: String(found.status ?? '').toUpperCase(),
+        ticket_payload: found.ticket_payload,
+      };
+    }
+    const totalPages = Number(listBody.pagination?.total_pages ?? 1);
+    if (!Number.isFinite(totalPages) || page >= totalPages) {
+      break;
+    }
+    page += 1;
+  }
+  return null;
+}
+
+function extractNamespaceFromTicketPayload(payload: Record<string, unknown> | undefined): string {
+  if (!payload) {
+    return '';
+  }
+  const namespace = payload.namespace;
+  return typeof namespace === 'string' ? namespace.trim() : '';
+}
+
+async function waitForApprovalNotification(
+  request: APIRequestContext,
+  headers: { Authorization: string },
+  ticketID: string,
+  expectedType: 'APPROVAL_COMPLETED' | 'APPROVAL_REJECTED'
+): Promise<void> {
+  await expect.poll(async () => {
+    let page = 1;
+    const perPage = 100;
+
+    for (let guard = 0; guard < 20; guard += 1) {
+      const listResp = await request.get(`/api/v1/notifications?page=${page}&per_page=${perPage}`, { headers });
+      expect(listResp.status(), `GET /notifications returned ${listResp.status()}`).toBe(200);
+      const listBody = await validateApiResponse('NotificationList', listResp) as {
+        items?: Array<{ type?: string; resource_id?: string; resourceId?: string }>;
+        pagination?: { total_pages?: number };
+      };
+
+      const found = (listBody.items ?? []).some((item) => {
+        const type = (item.type ?? '').toUpperCase();
+        const resourceID = String(item.resource_id ?? item.resourceId ?? '').trim();
+        return type === expectedType && resourceID === ticketID;
+      });
+      if (found) {
+        return true;
+      }
+
+      const totalPages = Number(listBody.pagination?.total_pages ?? 1);
+      if (!Number.isFinite(totalPages) || page >= totalPages) {
+        break;
+      }
+      page += 1;
+    }
+
+    return false;
+  }, {
+    timeout: 30_000,
+    intervals: [1000, 2000, 3000],
+    message: `Missing notification ${expectedType} for ticket ${ticketID}`,
+  }).toBe(true);
+}
+
+async function waitForNewVMFromApproval(
+  request: APIRequestContext,
+  headers: { Authorization: string },
+  baselineIDs: Set<string>
+): Promise<string> {
+  let createdVMID = '';
+  await expect.poll(async () => {
+    const vms = await listVMBriefs(request, headers);
+    const created = vms.find((vm) => !baselineIDs.has(vm.id));
+    createdVMID = created?.id ?? '';
+    return createdVMID;
+  }, {
+    timeout: 60_000,
+    intervals: [1000, 2000, 3000],
+    message: 'Stage 5.C requires approved ticket to materialize a VM row',
+  }).not.toBe('');
+  return createdVMID;
+}
+
+async function summarizeClusterHealth(
+  request: APIRequestContext,
+  headers: { Authorization: string }
+): Promise<string> {
+  const clustersResp = await request.get('/api/v1/admin/clusters?page=1&per_page=100', { headers });
+  if (clustersResp.status() !== 200) {
+    return `clusters_http_${clustersResp.status()}`;
+  }
+  const clustersBody = await validateApiResponse('ClusterList', clustersResp) as {
+    items?: Array<{ id?: string; name?: string; status?: string; enabled?: boolean }>;
+  };
+  const summary = (clustersBody.items ?? [])
+    .map((cluster) => {
+      const name = cluster.name ?? cluster.id ?? 'unknown';
+      const status = (cluster.status ?? 'UNKNOWN').toUpperCase();
+      const enabledSuffix = cluster.enabled === false ? ':DISABLED' : '';
+      return `${name}:${status}${enabledSuffix}`;
+    })
+    .join(', ');
+  return summary || 'no-clusters';
+}
+
+async function waitForVMExecutionOutcome(
+  request: APIRequestContext,
+  headers: { Authorization: string },
+  vmID: string
+): Promise<void> {
+  await expect.poll(async () => {
+    const vmResp = await request.get(`/api/v1/vms/${vmID}`, { headers });
+    if (vmResp.status() !== 200) {
+      return `HTTP_${vmResp.status()}`;
+    }
+    const vmBody = await validateApiResponse('VM', vmResp) as { status?: string };
+    const status = (vmBody.status ?? '').toUpperCase();
+    if (status === 'CREATING') {
+      const health = await summarizeClusterHealth(request, headers);
+      return `CREATING|${health}`;
+    }
+    return status;
+  }, {
+    timeout: 120_000,
+    intervals: [1000, 2000, 4000, 8000],
+    message: `VM ${vmID} did not reach RUNNING/FAILED from CREATING`,
+  }).toMatch(/^(RUNNING|FAILED)$/);
+}
+
+interface ApprovalSeedResult {
+  ticketID: string;
+  namespace: string;
+}
+
+async function seedPendingApprovalTicket(request: APIRequestContext): Promise<ApprovalSeedResult> {
+  const token = await getAdminToken(request);
+  const headers = { Authorization: `Bearer ${token}` };
+  const approvalSeedServiceName = await createUniqueServiceForApprovalSeed(request);
+  const createReqData = await resolveCreateVMRequestData(
+    request,
+    headers,
+    'approval seed',
+    approvalSeedServiceName
+  );
+
+  const createResp = await request.post('/api/v1/vms/request', {
+    headers,
+    data: { ...createReqData, reason: `master-flow approval seed ${Date.now()}` },
+  });
+  if (createResp.status() === 400) {
+    const errBody = await validateApiResponse('Error', createResp) as {
+      code?: string;
+      message?: string;
+      params?: Record<string, unknown>;
+    };
+    if (errBody.code === 'DUPLICATE_PENDING_REQUEST') {
+      const existingTicketID =
+        typeof errBody.params?.existing_ticket_id === 'string' ? errBody.params.existing_ticket_id.trim() : '';
+      throw new Error(
+        `unexpected DUPLICATE_PENDING_REQUEST in approval seed (service=${approvalSeedServiceName}, existing_ticket_id=${existingTicketID || 'unknown'})`
+      );
+    }
+    throw new Error(
+      `POST /vms/request failed in approval seed: ${errBody.code ?? 'UNKNOWN'} (${errBody.message ?? 'no message'})`
+    );
+  }
+
+  expect(createResp.status(), 'POST /vms/request must return 202 for approval seed').toBe(202);
+  const ticket = await validateApiResponse('ApprovalTicketResponse', createResp) as { ticket_id?: string; id?: string };
+  const ticketID = ticket.ticket_id ?? ticket.id ?? '';
+  expect(ticketID, 'ApprovalTicketResponse missing ticket id').toBeTruthy();
+  return {
+    ticketID,
+    namespace: createReqData.namespace,
+  };
+}
+
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 test.describe('master-flow live (contract-enforced, no mock)', () => {
@@ -106,358 +557,653 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     await login(page);
   });
 
+  // ── Stage 1: Platform Initialization ────────────────────────────────────────
+
+  test('Stage 1 – getDynamicSchema: schema+mask contract with degradation metadata', async ({ request }) => {
+    await test.step('Stage 1 / Step 1: public schema endpoint returns DynamicSchemaResponse without auth', async () => {
+      const schemaResp = await request.get('/api/v1/schemas/instancesize');
+      expect(schemaResp.status(), `GET /schemas/instancesize returned ${schemaResp.status()}`).toBe(200);
+      const body = await validateApiResponse('DynamicSchemaResponse', schemaResp) as {
+        schema?: Record<string, unknown>;
+        mask?: { quick_fields?: unknown[]; advanced_fields?: unknown[] };
+        source?: string;
+        degraded?: boolean;
+        schema_version?: string;
+      };
+      expect(body.schema, 'dynamic schema payload is required').toBeTruthy();
+      expect(typeof body.schema, 'dynamic schema must be object-like').toBe('object');
+      expect(body.mask, 'dynamic schema mask is required').toBeTruthy();
+      expect(Array.isArray(body.mask?.quick_fields), 'mask.quick_fields must be an array').toBe(true);
+      expect(Array.isArray(body.mask?.advanced_fields), 'mask.advanced_fields must be an array').toBe(true);
+    });
+
+    await test.step('Stage 1 / Step 2: schema source/degraded metadata matches ADR-0023 cache contract', async () => {
+      const schemaResp = await request.get('/api/v1/schemas/instancesize');
+      expect(schemaResp.status(), `GET /schemas/instancesize returned ${schemaResp.status()}`).toBe(200);
+      const body = await validateApiResponse('DynamicSchemaResponse', schemaResp) as {
+        source?: string;
+        degraded?: boolean;
+        schema_version?: string;
+      };
+      if (typeof body.source !== 'undefined') {
+        expect(
+          ['cache', 'embedded', 'remote'],
+          'dynamic schema source must expose cache-degradation provenance when provided'
+        ).toContain(String(body.source).toLowerCase());
+      }
+      if (typeof body.degraded !== 'undefined') {
+        expect(typeof body.degraded, 'dynamic schema degraded flag must be boolean when provided').toBe('boolean');
+      }
+      if (typeof body.schema_version !== 'undefined') {
+        expect(String(body.schema_version).trim(), 'dynamic schema version should be non-empty when provided').toBeTruthy();
+      }
+    });
+  });
+
+  // ── Stage 1.5: First Deployment Bootstrap ───────────────────────────────────
+
+  test('Stage 1.5 – forced password rotation on first login is enforced end-to-end', async ({ request }) => {
+    const adminToken = await getAdminToken(request);
+    const adminHeaders = { Authorization: `Bearer ${adminToken}` };
+    const suffix = Date.now().toString(36).slice(-8);
+    const username = `s15-${suffix}`;
+    const initialPassword = `Init-${suffix}-a1`;
+    const rotatedPassword = `Rot-${suffix}-b2`;
+    let userID = '';
+
+    try {
+      await test.step('Stage 1.5 / Step 1: bootstrap-created user can be flagged force_password_change=true', async () => {
+        const createResp = await request.post('/api/v1/admin/users', {
+          headers: adminHeaders,
+          data: {
+            username,
+            password: initialPassword,
+            enabled: true,
+            force_password_change: true,
+          },
+        });
+        expect(createResp.status(), `POST /admin/users returned ${createResp.status()}`).toBe(201);
+        const createBody = await validateApiResponse('User', createResp) as { id?: string; username?: string };
+        userID = String(createBody.id ?? '').trim();
+        expect(userID, 'created user id is required for cleanup').toBeTruthy();
+        expect(String(createBody.username ?? '').trim()).toBe(username);
+      });
+
+      let loginToken = '';
+      await test.step('Stage 1.5 / Step 2: first login returns force_password_change=true', async () => {
+        const loginResp = await request.post('/api/v1/auth/login', {
+          data: { username, password: initialPassword },
+        });
+        expect(loginResp.status(), `POST /auth/login returned ${loginResp.status()}`).toBe(200);
+        const loginBody = await validateApiResponse('LoginResponse', loginResp) as {
+          token?: string;
+          force_password_change?: boolean;
+        };
+        loginToken = String(loginBody.token ?? '').trim();
+        expect(loginToken, 'initial login token is required').toBeTruthy();
+        expect(loginBody.force_password_change, 'first login must enforce password rotation').toBe(true);
+      });
+
+      await test.step('Stage 1.5 / Step 3: password change clears force_password_change on next login', async () => {
+        const changeResp = await request.post('/api/v1/auth/change-password', {
+          headers: { Authorization: `Bearer ${loginToken}` },
+          data: {
+            old_password: initialPassword,
+            new_password: rotatedPassword,
+          },
+        });
+        expect(changeResp.status(), `POST /auth/change-password returned ${changeResp.status()}`).toBe(204);
+
+        const reloginResp = await request.post('/api/v1/auth/login', {
+          data: { username, password: rotatedPassword },
+        });
+        expect(reloginResp.status(), `POST /auth/login after password change returned ${reloginResp.status()}`).toBe(200);
+        const reloginBody = await validateApiResponse('LoginResponse', reloginResp) as {
+          token?: string;
+          force_password_change?: boolean;
+        };
+        const reloginToken = String(reloginBody.token ?? '').trim();
+        expect(reloginToken, 'relogin token is required after password change').toBeTruthy();
+        expect(
+          reloginBody.force_password_change ?? false,
+          'force_password_change should be false (or omitted) after rotation'
+        ).toBe(false);
+
+        const meResp = await request.get('/api/v1/auth/me', {
+          headers: { Authorization: `Bearer ${reloginToken}` },
+        });
+        expect(meResp.status(), `GET /auth/me returned ${meResp.status()}`).toBe(200);
+        await validateApiResponse('UserInfo', meResp);
+      });
+    } finally {
+      if (!userID) {
+        return;
+      }
+      const cleanupToken = await getAdminToken(request);
+      const deleteResp = await request.delete(`/api/v1/admin/users/${userID}`, {
+        headers: { Authorization: `Bearer ${cleanupToken}` },
+      });
+      expect([204, 404], `cleanup delete user returned ${deleteResp.status()}`).toContain(deleteResp.status());
+    }
+  });
+
+  // ── Stage 2: Security Configuration (Top-level) ─────────────────────────────
+
+  test('Stage 2 – security baseline: login principal and admin security surfaces are coherent', async ({ request }) => {
+    const token = await getAdminToken(request);
+    const headers = { Authorization: `Bearer ${token}` };
+
+    await test.step('Stage 2 / Step 1: authenticated principal contract is valid via /auth/me', async () => {
+      const meResp = await request.get('/api/v1/auth/me', { headers });
+      expect(meResp.status(), `GET /auth/me returned ${meResp.status()}`).toBe(200);
+      const meBody = await validateApiResponse('UserInfo', meResp) as {
+        id?: string;
+        username?: string;
+        roles?: string[];
+      };
+      expect(String(meBody.id ?? '').trim(), 'authenticated user id is required').toBeTruthy();
+      expect(String(meBody.username ?? '').trim(), 'authenticated username is required').toBeTruthy();
+      expect(Array.isArray(meBody.roles), 'authenticated roles must be an array').toBe(true);
+    });
+
+    await test.step('Stage 2 / Step 2: role and provider security catalogs are reachable after auth', async () => {
+      const [rolesResp, providerTypesResp] = await Promise.all([
+        request.get('/api/v1/admin/roles', { headers }),
+        request.get('/api/v1/admin/auth-provider-types', { headers }),
+      ]);
+      expect(rolesResp.status(), `GET /admin/roles returned ${rolesResp.status()}`).toBe(200);
+      expect(providerTypesResp.status(), `GET /admin/auth-provider-types returned ${providerTypesResp.status()}`).toBe(200);
+      await validateApiResponse('RoleList', rolesResp);
+      await validateApiResponse('AuthProviderTypeList', providerTypesResp);
+    });
+  });
+
   // ── Stage 2.D: Auth ─────────────────────────────────────────────────────────
 
   test('Stage 2.D – getCurrentUser: /auth/me returns UserInfo schema', async ({ page }) => {
     // operationId: login, getCurrentUser
     // login() in beforeEach already validates LoginResponse schema.
     // This test additionally verifies /auth/me returns UserInfo schema.
-    const meRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/auth/me') && r.request().method() === 'GET'
-    );
-    await page.goto('/dashboard');
-
-    // /auth/me may be called on page load; race with a timeout
-    const meResp = await Promise.race([
-      meRespPromise,
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000)),
-    ]);
-    if (meResp) {
-      expect((meResp as Response).status()).toBe(200);
-      // ── CONTRACT CHECK: UserInfo schema (getCurrentUser) ──────────────────
-      await validateApiResponse('UserInfo', meResp as Response);
-    } else {
-      console.warn('[getCurrentUser] /auth/me not called on dashboard load – trigger manually');
-      // Trigger explicitly via navigation to profile page
-      const explicitRespPromise = page.waitForResponse(
+    // Use explicit fetch in page context to guarantee the endpoint is exercised.
+    await test.step('Stage 2.D / Step 1: verify /auth/me after dashboard navigation', async () => {
+      const meRespPromise = page.waitForResponse(
         (r) => urlPathEndsWith(r.url(), '/api/v1/auth/me') && r.request().method() === 'GET'
       );
-      await page.goto('/profile');
-      const explicitResp = await Promise.race([
-        explicitRespPromise,
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000)),
-      ]);
-      if (explicitResp) {
-        expect((explicitResp as Response).status()).toBe(200);
-        await validateApiResponse('UserInfo', explicitResp as Response);
-      } else {
-        console.warn('[getCurrentUser] /auth/me not triggered – backend may not expose this route yet');
-      }
-    }
+      await page.goto('/dashboard');
+      await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+      const meStatus = await fetchStatusWithStoredToken(page, '/api/v1/auth/me', 'GET');
+      expect(meStatus).toBe(200);
+
+      const meResp = await meRespPromise;
+      expect(meResp.status()).toBe(200);
+      // ── CONTRACT CHECK: UserInfo schema (getCurrentUser) ──────────────────
+      await validateApiResponse('UserInfo', meResp);
+    });
   });
 
   // ── Stage 4.A: System CRUD ──────────────────────────────────────────────────
 
   test('Stage 4.A – listSystems + createSystem + updateSystem + deleteSystem (schema-validated)', async ({ page }) => {
     // operationId: listSystems, createSystem, updateSystem, deleteSystem
-
-    // ── CONTRACT CHECK: listSystems → SystemList ──────────────────────────────
-    // Per Playwright best practice: register Promise BEFORE the action that
-    // triggers the network request, to avoid missing a fast response.
-    const listRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), '/api/v1/systems') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/members')
-    );
-    await page.goto('/systems');
-    await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
-    const listResp = await listRespPromise;
-    if (listResp.status() === 200) {
+    await test.step('Stage 4.A / Step 1: execute system CRUD flow with contract checks', async () => {
+      // ── CONTRACT CHECK: listSystems → SystemList ──────────────────────────────
+      // Per Playwright best practice: register Promise BEFORE the action that
+      // triggers the network request, to avoid missing a fast response.
+      const listRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), '/api/v1/systems') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/members')
+      );
+      const [listResp] = await Promise.all([
+        listRespPromise,
+        page.goto('/systems'),
+      ]);
+      expect(listResp.status()).toBe(200);
       await validateApiResponse('SystemList', listResp);
-    }
+      await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
 
-    // ── CONTRACT CHECK: createSystem → System ────────────────────────────────
-    const systemName = `e2es${Date.now().toString(36).slice(-6)}`;
-    const createRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
-    );
+      // ── CONTRACT CHECK: createSystem → System ────────────────────────────────
+      const systemName = `e2es${Date.now().toString(36).slice(-6)}`;
+      const createRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
+      );
 
-    await page.getByTestId('system-create-button').click();
-    const createModal = getAntModal(page, 'system-create-modal');
-    await expect(createModal).toBeVisible();
-    await createModal.locator('input[maxlength="15"]').first().fill(systemName);
-    await createModal.locator('textarea').first().fill('created by live e2e');
-    await createModal.getByRole('button', { name: 'OK' }).click();
+      await page.getByTestId('system-create-button').click();
+      const createModal = getAntModal(page, 'system-create-modal');
+      await expect(createModal).toBeVisible();
+      await createModal.locator('input[maxlength="15"]').first().fill(systemName);
+      await createModal.locator('textarea').first().fill('created by live e2e');
+      await createModal.getByRole('button', { name: 'OK' }).click();
 
-    const { body: createdSystem } = await expectSchema(createRespPromise, 'System', 201);
-    const systemID = (createdSystem as { id?: string }).id ?? '';
-    expect(systemID).toBeTruthy();
+      const { body: createdSystem } = await expectSchema(createRespPromise, 'System', 201);
+      const systemID = (createdSystem as { id?: string }).id ?? '';
+      expect(systemID).toBeTruthy();
 
-    await expect(page.locator('tr').filter({ hasText: systemName }).first()).toBeVisible();
+      await expect(page.locator('tr').filter({ hasText: systemName }).first()).toBeVisible();
 
-    // ── CONTRACT CHECK: updateSystem → System ────────────────────────────────
-    const updateRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'PATCH'
-    );
-    await page.getByTestId(`system-action-edit-${systemID}`).click();
-    const editModal = getAntModal(page, 'system-edit-modal');
-    await expect(editModal).toBeVisible();
-    await editModal.locator('textarea').first().fill('updated by live e2e');
-    await editModal.getByRole('button', { name: 'OK' }).click();
+      // ── CONTRACT CHECK: updateSystem → System ────────────────────────────────
+      const updateRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'PATCH'
+      );
+      await page.getByTestId(`system-action-edit-${systemID}`).click();
+      const editModal = getAntModal(page, 'system-edit-modal');
+      await expect(editModal).toBeVisible();
+      await editModal.locator('textarea').first().fill('updated by live e2e');
+      await editModal.getByRole('button', { name: 'OK' }).click();
 
-    await expectSchema(updateRespPromise, 'System', 200);
+      await expectSchema(updateRespPromise, 'System', 200);
 
-    // ── CONTRACT CHECK: deleteSystem with confirm_name guard ──────────────────
-    await page.getByTestId(`system-action-delete-${systemID}`).click();
-    const deleteModal = getAntModal(page, 'system-delete-modal');
-    await expect(deleteModal).toBeVisible();
+      // ── CONTRACT CHECK: deleteSystem with confirm_name guard ──────────────────
+      await page.getByTestId(`system-action-delete-${systemID}`).click();
+      const deleteModal = getAntModal(page, 'system-delete-modal');
+      await expect(deleteModal).toBeVisible();
 
-    const deleteBtn = deleteModal.getByRole('button', { name: /delete/i });
-    await expect(deleteBtn).toBeDisabled();
+      const deleteBtn = deleteModal.getByRole('button', { name: /delete/i });
+      await expect(deleteBtn).toBeDisabled();
 
-    // Wrong name → still disabled (cascade guard UI test)
-    await deleteModal.getByRole('textbox').first().fill('wrong-name');
-    await expect(deleteBtn).toBeDisabled();
+      // Wrong name → still disabled (cascade guard UI test)
+      await deleteModal.getByRole('textbox').first().fill('wrong-name');
+      await expect(deleteBtn).toBeDisabled();
 
-    // Correct name → enabled
-    await deleteModal.getByRole('textbox').first().fill(systemName);
-    await expect(deleteBtn).toBeEnabled();
+      // Correct name → enabled
+      await deleteModal.getByRole('textbox').first().fill(systemName);
+      await expect(deleteBtn).toBeEnabled();
 
-    const deleteRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
-    );
-    await deleteBtn.click();
+      const deleteRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+      );
+      await deleteBtn.click();
 
-    const deleteResp = await deleteRespPromise;
-    expect(deleteResp.status()).toBe(204);
-    // Verify confirm_name was sent as query param (ADR-0015 §13)
-    expect(deleteResp.url()).toContain(`confirm_name=${systemName}`);
+      const deleteResp = await deleteRespPromise;
+      expect(deleteResp.status()).toBe(204);
+      // Verify confirm_name was sent as query param (ADR-0015 §13)
+      expect(deleteResp.url()).toContain(`confirm_name=${systemName}`);
 
-    await expect(page.locator('tr').filter({ hasText: systemName })).toHaveCount(0);
+      await expect(page.locator('tr').filter({ hasText: systemName })).toHaveCount(0);
+    });
   });
 
   // ── Stage 4.A+: System Member Management ────────────────────────────────────
 
   test('Stage 4.A+ – listSystemMembers: system member list (schema-validated)', async ({ page }) => {
     // operationId: listSystemMembers
-    // Create a temporary system to test member management
-    await page.goto('/systems');
-    await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
+    await test.step('Stage 4.A+ / Step 1: verify member list endpoint for a system', async () => {
+      // Create a temporary system to test member management
+      await page.goto('/systems');
+      await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
 
-    const systemName = `e2em${Date.now().toString(36).slice(-6)}`;
-    const createRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
-    );
-    await page.getByTestId('system-create-button').click();
-    const createModal = getAntModal(page, 'system-create-modal');
-    await expect(createModal).toBeVisible();
-    await createModal.locator('input[maxlength="15"]').first().fill(systemName);
-    await createModal.getByRole('button', { name: 'OK' }).click();
+      const systemName = `e2em${Date.now().toString(36).slice(-6)}`;
+      const createRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
+      );
+      await page.getByTestId('system-create-button').click();
+      const createModal = getAntModal(page, 'system-create-modal');
+      await expect(createModal).toBeVisible();
+      await createModal.locator('input[maxlength="15"]').first().fill(systemName);
+      await createModal.getByRole('button', { name: 'OK' }).click();
 
-    const { body: createdSystem } = await expectSchema(createRespPromise, 'System', 201);
-    const systemID = (createdSystem as { id?: string }).id ?? '';
-    expect(systemID).toBeTruthy();
+      const { body: createdSystem } = await expectSchema(createRespPromise, 'System', 201);
+      const systemID = (createdSystem as { id?: string }).id ?? '';
+      expect(systemID).toBeTruthy();
 
-    // ── CONTRACT CHECK: listSystemMembers → SystemMemberList ──────────────────
-    const membersRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members`) && r.request().method() === 'GET'
-    );
-    await page.getByTestId(`system-action-members-${systemID}`).click();
-    const membersModal = getAntModal(page, 'system-members-modal');
-    await expect(membersModal).toBeVisible();
+      // ── CONTRACT CHECK: listSystemMembers → SystemMemberList ──────────────────
+      const membersRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members`) && r.request().method() === 'GET'
+      );
+      await page.getByTestId(`system-action-members-${systemID}`).click();
+      const membersModal = getAntModal(page, 'system-members-modal');
+      await expect(membersModal).toBeVisible();
 
-    const membersResp = await membersRespPromise;
-    if (membersResp.status() === 200) {
+      const membersResp = await membersRespPromise;
+      expect(membersResp.status()).toBe(200);
       await validateApiResponse('SystemMemberList', membersResp);
-    }
 
-    // Close modal and clean up
-    await membersModal.getByRole('button', { name: /cancel|close/i }).first().click();
+      // Close modal and clean up
+      await membersModal.getByRole('button', { name: /cancel|close/i }).first().click();
 
-    // Delete the temp system
-    await page.getByTestId(`system-action-delete-${systemID}`).click();
-    const deleteModal = getAntModal(page, 'system-delete-modal');
-    await expect(deleteModal).toBeVisible();
-    await deleteModal.getByRole('textbox').first().fill(systemName);
-    const deleteRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
-    );
-    await deleteModal.getByRole('button', { name: /delete/i }).click();
-    const deleteResp = await deleteRespPromise;
-    expect(deleteResp.status()).toBe(204);
+      // Delete the temp system
+      await page.getByTestId(`system-action-delete-${systemID}`).click();
+      const deleteModal = getAntModal(page, 'system-delete-modal');
+      await expect(deleteModal).toBeVisible();
+      await deleteModal.getByRole('textbox').first().fill(systemName);
+      const deleteRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+      );
+      await deleteModal.getByRole('button', { name: /delete/i }).click();
+      const deleteResp = await deleteRespPromise;
+      expect(deleteResp.status()).toBe(204);
+    });
   });
 
   // ── Stage 4.B: Service CRUD ──────────────────────────────────────────────────
 
   test('Stage 4.B – createService + updateService + deleteService (schema-validated)', async ({ page }) => {
     // operationId: createService, updateService, deleteService
-    // First create a system to own the service
-    await page.goto('/systems');
-    const systemName = `e2esvc${Date.now().toString(36).slice(-5)}`;
-    const createSysRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
-    );
-    await page.getByTestId('system-create-button').click();
-    const createSysModal = getAntModal(page, 'system-create-modal');
-    await expect(createSysModal).toBeVisible();
-    await createSysModal.locator('input[maxlength="15"]').first().fill(systemName);
-    await createSysModal.getByRole('button', { name: 'OK' }).click();
+    await test.step('Stage 4.B / Step 1: execute service CRUD flow with system ownership', async () => {
+      // First create a system to own the service
+      await page.goto('/systems');
+      const systemName = `e2esvc${Date.now().toString(36).slice(-5)}`;
+      const createSysRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'POST'
+      );
+      await page.getByTestId('system-create-button').click();
+      const createSysModal = getAntModal(page, 'system-create-modal');
+      await expect(createSysModal).toBeVisible();
+      await createSysModal.locator('input[maxlength="15"]').first().fill(systemName);
+      await createSysModal.getByRole('button', { name: 'OK' }).click();
 
-    const { body: sys } = await expectSchema(createSysRespPromise, 'System', 201);
-    const systemID = (sys as { id?: string }).id ?? '';
-    expect(systemID).toBeTruthy();
+      const { body: sys } = await expectSchema(createSysRespPromise, 'System', 201);
+      const systemID = (sys as { id?: string }).id ?? '';
+      expect(systemID).toBeTruthy();
 
-    // Navigate to services and select the new system
-    await page.goto('/services');
-    await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
-    await selectAntOption(page, page.getByTestId('services-system-selector'), systemName);
+      // Navigate to services and select the new system
+      await page.goto('/services');
+      await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
+      await selectAntOption(page, page.getByTestId('services-system-selector'), systemName);
 
-    // ── CONTRACT CHECK: createService → Service ───────────────────────────────
-    const serviceName = `e2e-svc-${Date.now().toString(36).slice(-5)}`;
-    const createSvcRespPromise = page.waitForResponse(
-      (r) =>
-        urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) &&
-        r.request().method() === 'POST'
-    );
-    await page.getByTestId('service-create-button').click();
-    const createSvcModal = getAntModal(page, 'service-create-modal');
-    await expect(createSvcModal).toBeVisible();
-    await createSvcModal.getByPlaceholder('e.g. web, api-gateway').fill(serviceName);
-    await createSvcModal.locator('textarea').first().fill('service created by live e2e');
-    await createSvcModal.getByRole('button', { name: 'OK' }).click();
+      // ── CONTRACT CHECK: createService → Service ───────────────────────────────
+      const serviceName = `e2e-svc-${Date.now().toString(36).slice(-5)}`;
+      const createSvcRespPromise = page.waitForResponse(
+        (r) =>
+          urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) &&
+          r.request().method() === 'POST'
+      );
+      await page.getByTestId('service-create-button').click();
+      const createSvcModal = getAntModal(page, 'service-create-modal');
+      await expect(createSvcModal).toBeVisible();
+      await createSvcModal.getByPlaceholder('e.g. web, api-gateway').fill(serviceName);
+      await createSvcModal.locator('textarea').first().fill('service created by live e2e');
+      await createSvcModal.getByRole('button', { name: 'OK' }).click();
 
-    const { body: createdSvc } = await expectSchema(createSvcRespPromise, 'Service', 201);
-    const serviceID = (createdSvc as { id?: string }).id ?? '';
-    expect(serviceID).toBeTruthy();
+      const { body: createdSvc } = await expectSchema(createSvcRespPromise, 'Service', 201);
+      const serviceID = (createdSvc as { id?: string }).id ?? '';
+      expect(serviceID).toBeTruthy();
 
-    await expect(page.locator('tr').filter({ hasText: serviceName }).first()).toBeVisible();
+      await expect(page.locator('tr').filter({ hasText: serviceName }).first()).toBeVisible();
 
-    // ── CONTRACT CHECK: updateService → Service ───────────────────────────────
-    const updateSvcRespPromise = page.waitForResponse(
-      (r) =>
-        urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
-        r.request().method() === 'PATCH'
-    );
-    await page.getByTestId(`service-action-edit-${serviceID}`).click();
-    const editSvcModal = getAntModal(page, 'service-edit-modal');
-    await expect(editSvcModal).toBeVisible();
-    await editSvcModal.locator('textarea').first().fill('updated by live e2e');
-    await editSvcModal.getByRole('button', { name: 'OK' }).click();
+      // ── CONTRACT CHECK: updateService → Service ───────────────────────────────
+      const updateSvcRespPromise = page.waitForResponse(
+        (r) =>
+          urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
+          r.request().method() === 'PATCH'
+      );
+      await page.getByTestId(`service-action-edit-${serviceID}`).click();
+      const editSvcModal = getAntModal(page, 'service-edit-modal');
+      await expect(editSvcModal).toBeVisible();
+      await editSvcModal.locator('textarea').first().fill('updated by live e2e');
+      await editSvcModal.getByRole('button', { name: 'OK' }).click();
 
-    await expectSchema(updateSvcRespPromise, 'Service', 200);
+      await expectSchema(updateSvcRespPromise, 'Service', 200);
 
-    // ── CONTRACT CHECK: deleteService with confirm=true ───────────────────────
-    const deleteSvcRespPromise = page.waitForResponse(
-      (r) =>
-        urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
-        r.request().method() === 'DELETE'
-    );
-    await page.getByTestId(`service-action-delete-${serviceID}`).click();
-    const popconfirm = page.locator('.ant-popover:visible');
-    await expect(popconfirm).toBeVisible();
-    await popconfirm.getByRole('button', { name: /confirm/i }).click();
+      // ── CONTRACT CHECK: deleteService with confirm=true ───────────────────────
+      const deleteSvcRespPromise = page.waitForResponse(
+        (r) =>
+          urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
+          r.request().method() === 'DELETE'
+      );
+      await page.getByTestId(`service-action-delete-${serviceID}`).click();
+      const popconfirm = page.locator('.ant-popover:visible');
+      await expect(popconfirm).toBeVisible();
+      await popconfirm.getByRole('button', { name: /confirm/i }).click();
 
-    const deleteSvcResp = await deleteSvcRespPromise;
-    expect(deleteSvcResp.status()).toBe(204);
-    // Verify confirm=true was sent (ADR-0015 §13)
-    expect(deleteSvcResp.url()).toContain('confirm=true');
+      const deleteSvcResp = await deleteSvcRespPromise;
+      expect(deleteSvcResp.status()).toBe(204);
+      // Verify confirm=true was sent (ADR-0015 §13)
+      expect(deleteSvcResp.url()).toContain('confirm=true');
 
-    await expect(page.locator('tr').filter({ hasText: serviceName })).toHaveCount(0);
+      await expect(page.locator('tr').filter({ hasText: serviceName })).toHaveCount(0);
 
-    // Clean up: delete the system
-    await page.goto('/systems');
-    await page.getByTestId(`system-action-delete-${systemID}`).click();
-    const deleteModal = getAntModal(page, 'system-delete-modal');
-    await expect(deleteModal).toBeVisible();
-    await deleteModal.getByRole('textbox').first().fill(systemName);
-    const deleteSysRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
-    );
-    await deleteModal.getByRole('button', { name: /delete/i }).click();
-    expect((await deleteSysRespPromise).status()).toBe(204);
+      // Clean up: delete the system
+      await page.goto('/systems');
+      await page.getByTestId(`system-action-delete-${systemID}`).click();
+      const deleteModal = getAntModal(page, 'system-delete-modal');
+      await expect(deleteModal).toBeVisible();
+      await deleteModal.getByRole('textbox').first().fill(systemName);
+      const deleteSysRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'DELETE'
+      );
+      await deleteModal.getByRole('button', { name: /delete/i }).click();
+      expect((await deleteSysRespPromise).status()).toBe(204);
+    });
+  });
+
+  // ── Stage 4.C: Service Detail & Update Operations ───────────────────────────
+
+  test('Stage 4.C – getService + updateService: service detail/update contract', async ({ page, request }) => {
+    const token = await getAdminToken(request);
+    const headers = { Authorization: `Bearer ${token}` };
+
+    const systemName = `s4c${Date.now().toString(36).slice(-8)}`;
+    const serviceName = `s4svc${Date.now().toString(36).slice(-7)}`;
+    const initialDescription = 'stage4c service detail fixture';
+    let systemID = '';
+    let serviceID = '';
+
+    try {
+      const createSystemResp = await request.post('/api/v1/systems', {
+        headers,
+        data: {
+          name: systemName,
+          description: 'stage4c system fixture',
+        },
+      });
+      expect(createSystemResp.status(), `POST /systems returned ${createSystemResp.status()}`).toBe(201);
+      const systemBody = await validateApiResponse('System', createSystemResp) as { id?: string };
+      systemID = String(systemBody.id ?? '').trim();
+      expect(systemID).toBeTruthy();
+
+      const createServiceResp = await request.post(`/api/v1/systems/${systemID}/services`, {
+        headers,
+        data: {
+          name: serviceName,
+          description: initialDescription,
+        },
+      });
+      expect(createServiceResp.status(), `POST /systems/${systemID}/services returned ${createServiceResp.status()}`).toBe(201);
+      const serviceBody = await validateApiResponse('Service', createServiceResp) as { id?: string };
+      serviceID = String(serviceBody.id ?? '').trim();
+      expect(serviceID).toBeTruthy();
+
+      await test.step('Stage 4.C / Step 1: open service detail payload and validate immutable identity fields', async () => {
+        await page.goto('/services');
+        await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
+        await selectAntOption(page, page.getByTestId('services-system-selector'), systemName);
+
+        const serviceRow = page.locator('tr').filter({ hasText: serviceName }).first();
+        await expect(serviceRow).toBeVisible();
+
+        const detailRespPromise = page.waitForResponse(
+          (r) =>
+            urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
+            r.request().method() === 'GET'
+        );
+        await page.getByTestId(`service-action-edit-${serviceID}`).click();
+
+        const detailResp = await detailRespPromise;
+        expect(detailResp.status(), `GET /systems/${systemID}/services/${serviceID} returned ${detailResp.status()}`).toBe(200);
+        const detailBody = await validateApiResponse('Service', detailResp) as {
+          id?: string;
+          name?: string;
+          description?: string;
+          system_id?: string;
+        };
+        expect(detailBody.id).toBe(serviceID);
+        expect(detailBody.system_id).toBe(systemID);
+        expect(detailBody.name).toBe(serviceName);
+        expect(detailBody.description).toBe(initialDescription);
+
+        const editModal = getAntModal(page, 'service-edit-modal');
+        await expect(editModal).toBeVisible();
+      });
+
+      await test.step('Stage 4.C / Step 2: update description-only mutation keeps service name immutable', async () => {
+        const editModal = getAntModal(page, 'service-edit-modal');
+        await expect(editModal).toBeVisible();
+
+        const updatedDescription = `stage4c updated ${Date.now().toString(36).slice(-6)}`;
+        const patchRespPromise = page.waitForResponse(
+          (r) =>
+            urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) &&
+            r.request().method() === 'PATCH'
+        );
+
+        await editModal.locator('textarea').first().fill(updatedDescription);
+        await editModal.getByRole('button', { name: 'OK' }).click();
+
+        const patchResp = await patchRespPromise;
+        expect(patchResp.status(), `PATCH /systems/${systemID}/services/${serviceID} returned ${patchResp.status()}`).toBe(200);
+        const patchBody = await validateApiResponse('Service', patchResp) as {
+          id?: string;
+          name?: string;
+          description?: string;
+          system_id?: string;
+        };
+
+        const patchReqRaw = patchResp.request().postData() ?? '';
+        let patchReqBody: Record<string, unknown> = {};
+        if (patchReqRaw.trim() !== '') {
+          try {
+            patchReqBody = JSON.parse(patchReqRaw) as Record<string, unknown>;
+          } catch (err) {
+            throw new Error(`PATCH request payload is not valid JSON: ${String(err)}`);
+          }
+        }
+        expect(patchReqBody).toEqual({ description: updatedDescription });
+
+        expect(patchBody.id).toBe(serviceID);
+        expect(patchBody.system_id).toBe(systemID);
+        expect(patchBody.name).toBe(serviceName);
+        expect(patchBody.description).toBe(updatedDescription);
+
+        await expect(page.locator('tr').filter({ hasText: serviceName }).first()).toBeVisible();
+      });
+    } finally {
+      if (serviceID && systemID) {
+        await request.delete(`/api/v1/systems/${systemID}/services/${serviceID}?confirm=true`, { headers });
+      }
+      if (systemID) {
+        await request.delete(`/api/v1/systems/${systemID}?confirm_name=${encodeURIComponent(systemName)}`, { headers });
+      }
+    }
   });
 
   // ── Stage 5.D: Cascade guard – Service with child VMs → 409 ─────────────────
 
   test('Stage 5.D – deleteService returns 409 when child VMs exist (cascade guard)', async ({ page }) => {
     // operationId: deleteService (cascade guard path)
-    await page.goto('/services');
-    await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
+    await test.step('Stage 5.D / Step 1: service delete is blocked when child VMs exist', async () => {
+      await page.goto('/services');
+      await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
 
-    await selectAntOption(page, page.getByTestId('services-system-selector'), e2eSystemName);
+      await selectAntOption(page, page.getByTestId('services-system-selector'), e2eSystemName);
 
-    const serviceRow = page.locator('tr').filter({ hasText: e2eServiceName }).first();
-    await expect(serviceRow).toBeVisible();
+      const serviceRow = page.locator('tr').filter({ hasText: e2eServiceName }).first();
+      await expect(serviceRow).toBeVisible();
 
-    const deleteRespPromise = page.waitForResponse(
-      (r) =>
-        urlPathIncludes(r.url(), '/api/v1/systems/') &&
-        urlPathIncludes(r.url(), '/services/') &&
-        r.request().method() === 'DELETE'
-    );
-    await serviceRow.locator('[data-testid^="service-action-delete-"]').first().click();
-    await page.getByRole('button', { name: /confirm/i }).click();
+      const deleteRespPromise = page.waitForResponse(
+        (r) =>
+          urlPathIncludes(r.url(), '/api/v1/systems/') &&
+          urlPathIncludes(r.url(), '/services/') &&
+          r.request().method() === 'DELETE'
+      );
+      await serviceRow.locator('[data-testid^="service-action-delete-"]').first().click();
+      await page.getByRole('button', { name: /confirm/i }).click();
 
-    const deleteResp = await deleteRespPromise;
-    expect(deleteResp.status()).toBe(409);
-    expect(deleteResp.url()).toContain('confirm=true');
+      const deleteResp = await deleteRespPromise;
+      expect(deleteResp.status()).toBe(409);
+      expect(deleteResp.url()).toContain('confirm=true');
 
-    // ── CONTRACT CHECK: Error response schema ─────────────────────────────────
-    // Reuse body from validateApiResponse to avoid double-read of response body
-    const body = await validateApiResponse('Error', deleteResp) as { code?: string };
-    expect(body.code).toBe('SERVICE_HAS_VMS');
+      // ── CONTRACT CHECK: Error response schema ─────────────────────────────────
+      // Reuse body from validateApiResponse to avoid double-read of response body
+      const body = await validateApiResponse('Error', deleteResp) as { code?: string };
+      expect(body.code).toBe('SERVICE_HAS_VMS');
+    });
   });
 
   // ── Stage 5.A: VM Request Submission ────────────────────────────────────────
 
-  test('Stage 5.A – getVMRequestContext + createVMRequest (schema-validated)', async ({ page }) => {
+  test('Stage 5.A – getVMRequestContext + createVMRequest (schema-validated)', async ({ page, request }) => {
     // operationId: getVMRequestContext, createVMRequest
-    // First get the VM request context to validate schema
-    const contextRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request-context') && r.request().method() === 'GET'
-    );
+    // API-first isolation: use a fresh service name to avoid duplicate pending-request collisions.
+    const stage5AServiceName = await createUniqueServiceForStage5A(request);
+    let ticketID = '';
+    const token = await getAdminToken(request);
+    const headers = { Authorization: `Bearer ${token}` };
 
-    await page.goto('/vms');
-    await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
+    await test.step('Stage 5.A / Step 1: open request wizard and validate request-context contract', async () => {
+      const contextRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request-context') && r.request().method() === 'GET'
+      );
 
-    // Open VM request wizard
-    await page.getByRole('button', { name: 'Request VM' }).click();
-    await expect(page.getByText('Create VM Request')).toBeVisible();
+      await page.goto('/vms');
+      await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
 
-    // ── CONTRACT CHECK: getVMRequestContext → VMRequestContext ────────────────
-    const contextResp = await contextRespPromise;
-    if (contextResp.status() === 200) {
+      // Open VM request wizard
+      await page.getByRole('button', { name: 'Request VM' }).click();
+      await expect(page.getByText('Create VM Request')).toBeVisible();
+
+      const contextResp = await contextRespPromise;
+      expect(contextResp.status()).toBe(200);
       await validateApiResponse('VMRequestContext', contextResp);
-    }
+    });
 
-    // Step 0: Select System
-    const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
-    await selectAntOption(page, systemSelect);
+    await test.step('Stage 5.A / Step 2: submit createVMRequest and capture ticket reference', async () => {
+      // Step 0: Select System
+      const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+      await selectAntOption(page, systemSelect, toLooseOptionFilter(e2eSystemName));
 
-    // Select Service
-    const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
-    await selectAntOption(page, serviceSelect);
+      // Select Service
+      const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
+      await selectAntOption(page, serviceSelect, toLooseOptionFilter(stage5AServiceName));
 
-    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
+      await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-    // Step 1: Template
-    const templateSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
-    await selectAntOption(page, templateSelect);
-    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
+      // Step 1: Template
+      const templateSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+      await selectAntOption(page, templateSelect, toLooseOptionFilter(e2eTemplateName));
+      await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-    // Step 2: Instance Size
-    const sizeSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
-    await selectAntOption(page, sizeSelect);
-    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
+      // Step 2: Instance Size
+      const sizeSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
+      await selectAntOption(page, sizeSelect, toLooseOptionFilter(e2eSizeName));
+      await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-    // Step 3: Namespace + Reason
-    await getAntModal(page, 'vm-request-wizard-modal').locator('input').first().fill('test-ns');
-    await getAntModal(page, 'vm-request-wizard-modal').locator('textarea').first().fill('live e2e test request');
-    await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
+      // Step 3: Namespace + Reason
+      await getAntModal(page, 'vm-request-wizard-modal').locator('#vm-request-wizard_namespace').fill(e2eNamespace);
+      await getAntModal(page, 'vm-request-wizard-modal').locator('#vm-request-wizard_reason').fill('live e2e test request');
+      await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-    // Step 4: Submit
-    const submitBtn = getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Submit' });
-    await expect(submitBtn).toBeVisible({ timeout: 5000 });
+      // Step 4: Submit
+      const submitBtn = getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Submit' });
+      await expect(submitBtn).toBeVisible({ timeout: 5000 });
 
-    const submitRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request') && r.request().method() === 'POST'
-    );
-    await submitBtn.click();
+      const submitRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/vms/request') && r.request().method() === 'POST'
+      );
+      await submitBtn.click();
 
-    // ── CONTRACT CHECK: createVMRequest → ApprovalTicketResponse ─────────────
-    const submitResp = await submitRespPromise;
-    expect([202, 400, 409]).toContain(submitResp.status()); // 400/409 = no valid namespace/duplicate
-    if (submitResp.status() === 202) {
-      await validateApiResponse('ApprovalTicketResponse', submitResp);
-    }
+      const submitResp = await submitRespPromise;
+      expect(submitResp.status(), `POST /vms/request returned ${submitResp.status()}`).toBe(202);
+      const submitBody = await validateApiResponse('ApprovalTicketResponse', submitResp) as {
+        ticket_id?: string;
+        id?: string;
+        status?: string;
+        operation_type?: string;
+      };
+      ticketID = String(submitBody.ticket_id ?? submitBody.id ?? '').trim();
+      expect(ticketID, 'createVMRequest must return ticket reference for polling').toBeTruthy();
+
+      await test.step('Stage 2.E / Step 1: user submission returns canonical pending approval ticket', async () => {
+        expect(String(submitBody.status ?? '').toUpperCase()).toBe('PENDING');
+        if (typeof submitBody.operation_type !== 'undefined') {
+          expect(String(submitBody.operation_type).toUpperCase()).toBe('CREATE');
+        }
+      });
+    });
+
+    await test.step('Stage 5.A / Step 3: newly created ticket is persisted as pending', async () => {
+      await test.step('Stage 2.E / Step 2: ticket enters PENDING state without external provider selection input', async () => {
+        await waitForTicketStatus(request, headers, ticketID, 'PENDING');
+      });
+    });
   });
 
   // ── Stage 5: VM List ─────────────────────────────────────────────────────────
@@ -467,390 +1213,658 @@ test.describe('master-flow live (contract-enforced, no mock)', () => {
     const vmListRespPromise = page.waitForResponse(
       (r) => urlPathIncludes(r.url(), '/api/v1/vms') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/batch') && !urlPathIncludes(r.url(), '/request') && !urlPathIncludes(r.url(), '/console')
     );
-    await page.goto('/vms');
+    const [vmListResp] = await Promise.all([
+      vmListRespPromise,
+      page.goto('/vms'),
+    ]);
+    expect(vmListResp.status()).toBe(200);
+    // ── CONTRACT CHECK: listVMs → VMList ──────────────────────────────────
+    await validateApiResponse('VMList', vmListResp);
     await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-
-    const vmListResp = await vmListRespPromise;
-    if (vmListResp.status() === 200) {
-      // ── CONTRACT CHECK: listVMs → VMList ──────────────────────────────────
-      await validateApiResponse('VMList', vmListResp);
-    }
   });
 
   // ── Stage 5.B: Approvals ─────────────────────────────────────────────────────
 
   test('Stage 5.B – listApprovals: approval list conforms to ApprovalTicketList schema', async ({ page }) => {
     // operationId: listApprovals
-    const listRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/approvals');
-    await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
-
-    // ── CONTRACT CHECK: listApprovals → ApprovalTicketList ────────────────────
-    const listResp = await listRespPromise;
-    expect(listResp.status()).toBe(200);
-    await validateApiResponse('ApprovalTicketList', listResp);
+    await test.step('Stage 5.B / Step 1: open approval list and validate pending-ticket surface', async () => {
+      const listRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
+      );
+      const [listResp] = await Promise.all([
+        listRespPromise,
+        page.goto('/admin/approvals'),
+      ]);
+      expect(listResp.status()).toBe(200);
+      await validateApiResponse('ApprovalTicketList', listResp);
+      await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
+    });
   });
 
   test('Stage 5.B – approveTicket: approve action calls real API', async ({ page, request }) => {
     // operationId: approveTicket
-    // API-first setup: ensure a pending ticket exists by creating a VM request via API.
-    const loginResp = await request.post(`/api/v1/auth/login`, {
-      data: { username: e2eUsername, password: e2ePassword },
-    });
-    expect(loginResp.ok(), 'API login failed').toBeTruthy();
-    const { token } = await loginResp.json() as { token: string };
+    const seeded = await seedPendingApprovalTicket(request);
+    const ticketID = seeded.ticketID;
+    const token = await getAdminToken(request);
+    const headers = { Authorization: `Bearer ${token}` };
+    const beforeVMs = await listVMBriefs(request, headers);
+    const beforeVMIDs = new Set(beforeVMs.map((item) => item.id));
 
-    const svcResp = await request.get(`/api/v1/services`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    const ctxResp = await request.get(`/api/v1/vms/request-context`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (svcResp.ok() && ctxResp.ok()) {
-      const svcData = await svcResp.json() as { items?: Array<{ id?: string }> };
-      const ctx = await ctxResp.json() as {
-        templates?: Array<{ id?: string }>;
-        instance_sizes?: Array<{ id?: string }>;
-      };
-      const svcId = svcData.items?.[0]?.id;
-      const tplId = ctx.templates?.[0]?.id;
-      const sizeId = ctx.instance_sizes?.[0]?.id;
-      if (svcId && tplId && sizeId) {
-        const batchResp = await request.post(`/api/v1/vms/batch`, {
-          headers: { Authorization: `Bearer ${token}` },
-          data: {
-            operation: 'CREATE',
-            items: [{
-              service_id: svcId,
-              template_id: tplId,
-              instance_size_id: sizeId,
-              name: `e2e-approve-${Date.now().toString(36).slice(-5)}`,
-            }],
-            reason: 'Created by live E2E to test approveTicket',
-          },
+    await test.step('Stage 5.B / Step 2: approve path updates ticket/event and triggers execution', async () => {
+      await page.goto('/admin/approvals');
+      await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
+
+      const approveBtn = page.getByTestId(`approval-action-approve-${ticketID}`);
+      await expect(approveBtn, 'No pending approval tickets found — API setup may have failed').toBeVisible();
+
+      await approveBtn.click();
+      const modal = getAntModal(page, 'approve-modal');
+      await expect(modal).toBeVisible();
+      await expect(
+        modal.locator('.ant-select-selector').first(),
+        'Stage 5.B requires selecting a target cluster before approval'
+      ).toBeVisible();
+      const clusterFilter = await resolveClusterOptionFilter(request, headers);
+      await selectAntOption(page, modal.locator('.ant-select-selector').first(), clusterFilter);
+
+      const approveRespPromise = page.waitForResponse(
+        (r) =>
+          urlPathEndsWith(r.url(), `/api/v1/approvals/${ticketID}/approve`) &&
+          r.request().method() === 'POST'
+      );
+      await modal.getByRole('button', { name: 'OK' }).click();
+
+      const approveResp = await approveRespPromise;
+      expect(approveResp.status(), `POST /approvals/{id}/approve returned ${approveResp.status()}`).toBe(204);
+      await test.step('Stage 2.E / Step 3: approver decision transitions ticket to APPROVED state', async () => {
+        await waitForTicketStatus(request, headers, ticketID, 'APPROVED');
+      });
+      await waitForApprovalNotification(request, headers, ticketID, 'APPROVAL_COMPLETED');
+
+      await test.step('Stage 2.E / Step 4: approved decision executes workload path and persists approval audit', async () => {
+        // ── MASTER-FLOW Stage 5.C CHECK: approval must materialize VM + execute ──
+        const createdVMID = await waitForNewVMFromApproval(request, headers, beforeVMIDs);
+        await waitForVMExecutionOutcome(request, headers, createdVMID);
+
+        await test.step('Stage 3.C / Step 1: approval ticket payload keeps namespace immutable across decision and execution', async () => {
+          await expect.poll(async () => {
+            const found = await findApprovalTicket(request, headers, ticketID);
+            if (!found) {
+              return '';
+            }
+            return extractNamespaceFromTicketPayload(found.ticket_payload);
+          }, {
+            timeout: 20_000,
+            intervals: [500, 1000, 2000],
+            message: `ticket payload namespace not found for ticket ${ticketID}`,
+          }).toBe(seeded.namespace);
         });
-        expect(batchResp.status(), 'Setting up approval tickets should return 202 Accepted').toBe(202);
-      }
-    }
 
-    await page.goto('/approvals');
-    await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
+        await test.step('Stage 3.JIT Namespace / Step 1: materialized VM stays in requested namespace', async () => {
+          const vmResp = await request.get(`/api/v1/vms/${createdVMID}`, { headers });
+          expect(vmResp.status(), `GET /vms/${createdVMID} returned ${vmResp.status()}`).toBe(200);
+          const vmBody = await validateApiResponse('VM', vmResp) as { namespace?: string };
+          expect(String(vmBody.namespace ?? '').trim(), 'approved VM namespace should match request payload namespace').toBe(seeded.namespace);
+        });
 
-    const approveBtn = page.locator('[data-testid^="approval-action-approve-"]').first();
-    await expect(approveBtn, 'No pending approval tickets found — API setup may have failed').toBeVisible();
+        await test.step('Stage 3.JIT Namespace / Step 2: requested namespace remains registered in logical namespace catalog', async () => {
+          const namespacesResp = await request.get('/api/v1/admin/namespaces?page=1&per_page=100', { headers });
+          expect(namespacesResp.status(), `GET /admin/namespaces returned ${namespacesResp.status()}`).toBe(200);
+          const namespacesBody = await validateApiResponse('NamespaceRegistryList', namespacesResp) as {
+            items?: Array<{ name?: string }>;
+          };
+          const exists = (namespacesBody.items ?? []).some(
+            (item) => String(item.name ?? '').trim() === seeded.namespace
+          );
+          expect(exists, `namespace ${seeded.namespace} should remain in logical namespace registry`).toBe(true);
+        });
 
-    const testId = await approveBtn.getAttribute('data-testid');
-    const ticketID = testId?.replace('approval-action-approve-', '') ?? '';
-
-    const approveRespPromise = page.waitForResponse(
-      (r) =>
-        urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
-        (r.request().method() === 'PATCH' || r.request().method() === 'POST')
-    );
-
-    await approveBtn.click();
-    const modal = getAntModal(page, 'approve-modal');
-    await expect(modal).toBeVisible();
-    await modal.getByRole('button', { name: 'OK' }).click();
-
-    // ── CONTRACT CHECK: approveTicket → 204 ──────────────────────────────────
-    const approveResp = await approveRespPromise;
-    expect([200, 204]).toContain(approveResp.status());
+        await expect.poll(async () => {
+          const auditResp = await request.get(
+            `/api/v1/audit-logs?page=1&per_page=100&resource_type=approval_ticket&resource_id=${encodeURIComponent(ticketID)}`,
+            { headers }
+          );
+          if (auditResp.status() !== 200) {
+            return `HTTP_${auditResp.status()}`;
+          }
+          const auditBody = await validateApiResponse('AuditLogList', auditResp) as {
+            items?: Array<{ action?: string }>;
+          };
+          const hasApproved = (auditBody.items ?? []).some(
+            (item) => String(item.action ?? '').toLowerCase() === 'approval.approved'
+          );
+          return hasApproved ? 'FOUND' : 'MISSING';
+        }, {
+          timeout: 20_000,
+          intervals: [500, 1000, 2000],
+          message: `expected approval.approved audit log for ticket ${ticketID}`,
+        }).toBe('FOUND');
+      });
+    });
   });
 
   test('Stage 5.B – rejectTicket: reject action calls real API', async ({ page, request }) => {
     // operationId: rejectTicket
-    // API-first setup: ensure a pending ticket exists by creating a VM request via API.
-    const loginResp = await request.post(`/api/v1/auth/login`, {
-      data: { username: e2eUsername, password: e2ePassword },
-    });
-    expect(loginResp.ok(), 'API login failed').toBeTruthy();
-    const { token } = await loginResp.json() as { token: string };
+    const seeded = await seedPendingApprovalTicket(request);
+    const ticketID = seeded.ticketID;
 
-    const svcResp = await request.get(`/api/v1/services`, {
-      headers: { Authorization: `Bearer ${token}` },
+    await test.step('Stage 5.B / Step 3: reject path closes ticket without creating VM', async () => {
+      await page.goto('/admin/approvals');
+      await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
+
+      const rejectBtn = page.getByTestId(`approval-action-reject-${ticketID}`);
+      await expect(rejectBtn, 'No pending approval tickets found — API setup may have failed').toBeVisible();
+
+      const rejectRespPromise = page.waitForResponse(
+        (r) =>
+          urlPathEndsWith(r.url(), `/api/v1/approvals/${ticketID}/reject`) &&
+          r.request().method() === 'POST'
+      );
+
+      await rejectBtn.click();
+      const modal = getAntModal(page, 'reject-modal');
+      await expect(modal).toBeVisible();
+      await modal.locator('textarea').first().fill('Rejected by live e2e test');
+      await modal.getByRole('button', { name: 'OK' }).click();
+
+      const rejectResp = await rejectRespPromise;
+      expect(rejectResp.status(), `POST /approvals/{id}/reject returned ${rejectResp.status()}`).toBe(204);
+      const token = await getAdminToken(request);
+      const headers = { Authorization: `Bearer ${token}` };
+      await waitForTicketStatus(request, headers, ticketID, 'REJECTED');
+      await waitForApprovalNotification(request, headers, ticketID, 'APPROVAL_REJECTED');
     });
-    const ctxResp = await request.get(`/api/v1/vms/request-context`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (svcResp.ok() && ctxResp.ok()) {
-      const svcData = await svcResp.json() as { items?: Array<{ id?: string }> };
-      const ctx = await ctxResp.json() as {
-        templates?: Array<{ id?: string }>;
-        instance_sizes?: Array<{ id?: string }>;
-      };
-      const svcId = svcData.items?.[0]?.id;
-      const tplId = ctx.templates?.[0]?.id;
-      const sizeId = ctx.instance_sizes?.[0]?.id;
-      if (svcId && tplId && sizeId) {
-        const batchResp = await request.post(`/api/v1/vms/batch`, {
-          headers: { Authorization: `Bearer ${token}` },
+  });
+
+  test('Stage 5.B Constraint – dedicated CPU with overcommit is blocking at approval time', async ({ request }) => {
+    const token = await getAdminToken(request);
+    const headers = { Authorization: `Bearer ${token}` };
+    const clusterID = await resolveHealthyClusterID(request, headers);
+    expect(clusterID, 'Stage 5.B constraint check requires at least one cluster').toBeTruthy();
+
+    const instanceSizeName = `s5bc-${Date.now().toString(36).slice(-7)}`;
+    const serviceName = await createUniqueServiceForApprovalSeed(request);
+    let instanceSizeID = '';
+    let ticketID = '';
+
+    try {
+      await test.step('Stage 5.B Constraint / Step 1: construct dedicated+overcommit conflict through staged update', async () => {
+        const createSizeResp = await request.post('/api/v1/admin/instance-sizes', {
+          headers,
           data: {
-            operation: 'CREATE',
-            items: [{
-              service_id: svcId,
-              template_id: tplId,
-              instance_size_id: sizeId,
-              name: `e2e-reject-${Date.now().toString(36).slice(-5)}`,
-            }],
-            reason: 'Created by live E2E to test rejectTicket',
+            name: instanceSizeName,
+            cpu_cores: 4,
+            memory_gi: 8,
+            cpu_request: 2,
+            dedicated_cpu: false,
+            enabled: true,
           },
         });
-        expect(batchResp.status(), 'Setting up approval tickets should return 202 Accepted').toBe(202);
+        expect(createSizeResp.status(), `POST /admin/instance-sizes returned ${createSizeResp.status()}`).toBe(201);
+        const createdSize = await validateApiResponse('InstanceSize', createSizeResp) as {
+          id?: string;
+          dedicated_cpu?: boolean;
+          cpu_cores?: number;
+          cpu_request?: number;
+        };
+        instanceSizeID = String(createdSize.id ?? '').trim();
+        expect(instanceSizeID, 'created instance size id is required').toBeTruthy();
+        if (typeof createdSize.dedicated_cpu !== 'undefined') {
+          expect(createdSize.dedicated_cpu).toBe(false);
+        }
+        expect(Number(createdSize.cpu_cores ?? 0)).toBe(4);
+        if (typeof createdSize.cpu_request !== 'undefined') {
+          expect(Number(createdSize.cpu_request)).toBe(2);
+        }
+
+        const patchSizeResp = await request.patch(`/api/v1/admin/instance-sizes/${instanceSizeID}`, {
+          headers,
+          data: {
+            dedicated_cpu: true,
+          },
+        });
+        expect(patchSizeResp.status(), `PATCH /admin/instance-sizes/{id} returned ${patchSizeResp.status()}`).toBe(200);
+        const patchedSize = await validateApiResponse('InstanceSize', patchSizeResp) as {
+          dedicated_cpu?: boolean;
+          cpu_cores?: number;
+          cpu_request?: number;
+        };
+        expect(patchedSize.dedicated_cpu, 'staged patch should enable dedicated_cpu').toBe(true);
+        expect(Number(patchedSize.cpu_cores ?? 0)).toBe(4);
+        if (typeof patchedSize.cpu_request !== 'undefined') {
+          expect(Number(patchedSize.cpu_request)).toBe(2);
+        }
+      });
+
+      await test.step('Stage 5.B Constraint / Step 2: approval API blocks with canonical DEDICATED_CPU_OVERCOMMIT_CONFLICT', async () => {
+        const createReqData = await resolveCreateVMRequestData(
+          request,
+          headers,
+          'Stage 5.B constraint request',
+          serviceName
+        );
+        const createResp = await request.post('/api/v1/vms/request', {
+          headers,
+          data: {
+            ...createReqData,
+            instance_size_id: instanceSizeID,
+            reason: `Stage 5.B dedicated-vs-overcommit conflict ${Date.now()}`,
+          },
+        });
+        expect(createResp.status(), `POST /vms/request returned ${createResp.status()}`).toBe(202);
+        const createBody = await validateApiResponse('ApprovalTicketResponse', createResp) as { ticket_id?: string; id?: string };
+        ticketID = String(createBody.ticket_id ?? createBody.id ?? '').trim();
+        expect(ticketID, 'ticket id is required for conflict approval assertion').toBeTruthy();
+
+        const approveResp = await request.post(`/api/v1/approvals/${ticketID}/approve`, {
+          headers,
+          data: {
+            selected_cluster_id: clusterID,
+          },
+        });
+        expect(approveResp.status(), `POST /approvals/{id}/approve returned ${approveResp.status()}`).toBe(400);
+        const errBody = await validateApiResponse('Error', approveResp) as { code?: string };
+        expect(String(errBody.code ?? ''), 'approval must hard-block dedicated+overcommit conflict').toBe('DEDICATED_CPU_OVERCOMMIT_CONFLICT');
+        await waitForTicketStatus(request, headers, ticketID, 'PENDING');
+      });
+    } finally {
+      if (ticketID) {
+        const rejectResp = await request.post(`/api/v1/approvals/${ticketID}/reject`, {
+          headers,
+          data: { reason: 'cleanup after Stage 5.B constraint test' },
+        });
+        expect(
+          [204, 400, 404],
+          `cleanup reject ticket returned ${rejectResp.status()}`
+        ).toContain(rejectResp.status());
+      }
+      if (instanceSizeID) {
+        const deleteResp = await request.delete(`/api/v1/admin/instance-sizes/${instanceSizeID}`, { headers });
+        expect(
+          [204, 404, 409],
+          `cleanup delete instance size returned ${deleteResp.status()}`
+        ).toContain(deleteResp.status());
       }
     }
-
-    await page.goto('/approvals');
-    await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
-
-    const rejectBtn = page.locator('[data-testid^="approval-action-reject-"]').first();
-    await expect(rejectBtn, 'No pending approval tickets found — API setup may have failed').toBeVisible();
-
-    const testId = await rejectBtn.getAttribute('data-testid');
-    const ticketID = testId?.replace('approval-action-reject-', '') ?? '';
-
-    const rejectRespPromise = page.waitForResponse(
-      (r) =>
-        urlPathIncludes(r.url(), `/api/v1/approvals/${ticketID}`) &&
-        (r.request().method() === 'PATCH' || r.request().method() === 'POST')
-    );
-
-    await rejectBtn.click();
-    const modal = getAntModal(page, 'reject-modal');
-    await expect(modal).toBeVisible();
-    await modal.locator('textarea').first().fill('Rejected by live e2e test');
-    await modal.getByRole('button', { name: 'OK' }).click();
-
-    // ── CONTRACT CHECK: rejectTicket → 204 ───────────────────────────────────
-    const rejectResp = await rejectRespPromise;
-    expect([200, 204]).toContain(rejectResp.status());
   });
 
   // ── Stage 5.E: Batch Power Action ────────────────────────────────────────────
 
-  test('Stage 5.E – submitVMBatchPower: batch power action → VMBatchSubmitResponse schema', async ({ page }) => {
+  test('Stage 5.E – submitVMBatchPower: batch power action → VMBatchSubmitResponse schema', async ({ page, request }) => {
     // operationId: submitVMBatchPower
-    await page.goto('/vms');
-    await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
+    let batchID = '';
 
-    // Find a stopped VM row to batch-start
-    const stoppedRow = page.locator('tr').filter({ hasText: /stopped/i }).first();
-    const hasStoppedVM = (await stoppedRow.count()) > 0;
-    if (!hasStoppedVM) {
-      console.warn('[submitVMBatchPower] No stopped VMs available – batch power action not exercised');
-      // Still verify the VM list schema was correct
-      return;
-    }
+    await test.step('Stage 5.E / Step 1: select a STOPPED VM row from list page', async () => {
+      await page.goto('/vms');
+      await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
 
-    await stoppedRow.getByRole('checkbox').check();
+      const stoppedRow = page.locator('tr').filter({ hasText: /stopped/i }).first();
+      await expect(stoppedRow, 'No stopped VMs available for batch power test').toBeVisible();
+      await stoppedRow.getByRole('checkbox').check();
+    });
 
-    const batchRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch/power') && r.request().method() === 'POST'
-    );
-    await page.getByRole('button', { name: 'Start Selected', exact: true }).click();
+    await test.step('Stage 5.E / Step 2-5: submit batch power request and validate 202 payload', async () => {
+      const batchRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch/power') && r.request().method() === 'POST'
+      );
+      await page.getByRole('button', { name: 'Start Selected', exact: true }).click();
 
-    // ── CONTRACT CHECK: submitVMBatchPower → VMBatchSubmitResponse ────────────
-    const batchResp = await batchRespPromise;
-    expect(batchResp.status()).toBe(202);
-    await validateApiResponse('VMBatchSubmitResponse', batchResp);
+      const batchResp = await batchRespPromise;
+      expect(batchResp.status(), `POST /vms/batch/power returned ${batchResp.status()}`).toBe(202);
+      const body = await validateApiResponse('VMBatchSubmitResponse', batchResp) as {
+        batch_id?: string;
+        status?: string;
+        status_url?: string;
+        retry_after_seconds?: unknown;
+      };
+
+      batchID = String(body.batch_id ?? '').trim();
+      const statusURL = String(body.status_url ?? '').trim();
+      expect(batchID, 'submitVMBatchPower must return batch_id').toBeTruthy();
+      expect(
+        statusURL,
+        'submitVMBatchPower must return canonical status_url for polling'
+      ).toBe(`/api/v1/vms/batch/${batchID}`);
+      expect(Number(body.retry_after_seconds), 'retry_after_seconds must be a positive integer').toBeGreaterThan(0);
+      expect(
+        String(body.status ?? '').toUpperCase(),
+        'compatibility power submit should enter execution pipeline directly'
+      ).not.toBe('PENDING_APPROVAL');
+    });
+
+    await test.step('Stage 5.E / Step 6: track returned status_url and validate aggregate counters', async () => {
+      const token = await getAdminToken(request);
+      const headers = { Authorization: `Bearer ${token}` };
+
+      const statusResp = await request.get(`/api/v1/vms/batch/${batchID}`, { headers });
+      expect(statusResp.status(), `GET /vms/batch/${batchID} returned ${statusResp.status()}`).toBe(200);
+      const statusBody = await validateApiResponse('VMBatchStatusResponse', statusResp) as {
+        batch_id?: string;
+        operation?: string;
+        child_count?: unknown;
+        success_count?: unknown;
+        failed_count?: unknown;
+        pending_count?: unknown;
+      };
+
+      expect(statusBody.batch_id, 'status endpoint must echo same batch_id').toBe(batchID);
+      expect(String(statusBody.operation ?? '').toUpperCase(), 'batch operation must be POWER').toBe('POWER');
+      const childCount = Number(statusBody.child_count ?? 0);
+      const successCount = Number(statusBody.success_count ?? 0);
+      const failedCount = Number(statusBody.failed_count ?? 0);
+      const pendingCount = Number(statusBody.pending_count ?? 0);
+      expect(childCount, 'batch child_count must be positive').toBeGreaterThan(0);
+      expect(successCount + failedCount + pendingCount).toBe(childCount);
+
+      await page.goto('/vms/batch');
+      await expect(page.getByTestId(`batch-action-detail-${batchID}`)).toBeVisible();
+    });
   });
 
   // ── Stage 5.F: Notifications ─────────────────────────────────────────────────
 
   test('Stage 5.F – listNotifications: notification list conforms to NotificationList schema', async ({ page }) => {
     // operationId: listNotifications
-    const notifRespPromise = page.waitForResponse(
-      (r) => urlPathIncludes(r.url(), '/api/v1/notifications') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), 'unread')
-    );
-
-    await page.goto('/notifications');
-    await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
-
-    // ── CONTRACT CHECK: listNotifications → NotificationList ──────────────────
-    const notifResp = await notifRespPromise;
-    expect(notifResp.status()).toBe(200);
-    await validateApiResponse('NotificationList', notifResp);
+    await test.step('Stage 5.F / Step 2: open notifications page and fetch notification list', async () => {
+      const notifRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), '/api/v1/notifications') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), 'unread')
+      );
+      const [notifResp] = await Promise.all([
+        notifRespPromise,
+        page.goto('/notifications'),
+      ]);
+      expect(notifResp.status(), `GET /notifications returned ${notifResp.status()}`).toBe(200);
+      await validateApiResponse('NotificationList', notifResp);
+      await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
+    });
   });
 
-  test('Stage 5.F – getUnreadCount: unread count endpoint returns valid integer', async ({ page }) => {
+  test('Stage 5.F – getUnreadCount: unread count endpoint returns valid integer', async ({ page, request }) => {
     // operationId: getUnreadCount
-    const countRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/notifications/unread-count') && r.request().method() === 'GET'
-    );
+    let unreadCount = 0;
 
-    await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await test.step('Stage 5.F / Step 1: dashboard polls unread count endpoint', async () => {
+      const countRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/notifications/unread-count') && r.request().method() === 'GET'
+      );
+      const [countResp] = await Promise.all([
+        countRespPromise,
+        page.goto('/dashboard'),
+      ]);
+      expect(countResp.status(), `GET /notifications/unread-count returned ${countResp.status()}`).toBe(200);
+      const body = await validateApiResponse('UnreadCount', countResp) as { count?: unknown };
+      expect(typeof body.count, 'unread count should be numeric').toBe('number');
+      unreadCount = Number(body.count ?? 0);
+      expect(unreadCount, 'unread count should not be negative').toBeGreaterThanOrEqual(0);
+      await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    });
 
-    // ── CONTRACT CHECK: getUnreadCount → UnreadCount ──────────────────────────
-    const countResp = await countRespPromise;
-    expect(countResp.status()).toBe(200);
-    const body = await validateApiResponse('UnreadCount', countResp) as { count?: unknown };
-    expect(typeof body.count).toBe('number');
+    await test.step('Stage 5.F / Step 2: fetch notifications page list for user inbox', async () => {
+      const notifRespPromise = page.waitForResponse(
+        (r) => urlPathIncludes(r.url(), '/api/v1/notifications') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), 'unread')
+      );
+      const [notifResp] = await Promise.all([
+        notifRespPromise,
+        page.goto('/notifications'),
+      ]);
+      expect(notifResp.status(), `GET /notifications returned ${notifResp.status()}`).toBe(200);
+      await validateApiResponse('NotificationList', notifResp);
+      await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
+    });
+
+    await test.step('Stage 5.F / Step 3: unread-count is consistent with unread items on first page', async () => {
+      const token = await getAdminToken(request);
+      const headers = { Authorization: `Bearer ${token}` };
+
+      const notifResp = await request.get('/api/v1/notifications?page=1&per_page=50', { headers });
+      expect(notifResp.status(), `GET /notifications?page=1&per_page=50 returned ${notifResp.status()}`).toBe(200);
+      const notifBody = await validateApiResponse('NotificationList', notifResp) as {
+        items?: Array<{ read?: boolean }>;
+      };
+      const unreadOnPage = (notifBody.items ?? []).filter((item) => item.read === false).length;
+      expect(
+        unreadCount,
+        'unread-count endpoint should not be smaller than unread items already visible on first page'
+      ).toBeGreaterThanOrEqual(unreadOnPage);
+    });
   });
 
   // ── Stage 6: VM Console ───────────────────────────────────────────────────────
 
-  test('Stage 6 – requestVMConsoleAccess + openVMVNC: VM console request flow', async ({ page }) => {
+  test('Stage 6 – requestVMConsoleAccess + openVMVNC: VM console request flow', async ({ page, request }) => {
     // operationId: requestVMConsoleAccess, openVMVNC
-    // NOTE: Requires E2E_VM_RUNNING_ID to be set to a running VM's ID.
-    // If not set, the test logs a warning but does NOT skip.
-    // Failure here means: either no running VM (expected in clean env)
-    // or the console endpoint is broken (contract violation).
-    if (!runningVMID) {
-      console.warn('[requestVMConsoleAccess/openVMVNC] E2E_VM_RUNNING_ID not set – console flow not exercised');
-      // Verify the VM list loads correctly at minimum
+    await test.step('Stage 6 / Step 1: open VM list page and verify list contract', async () => {
       const vmListRespPromise = page.waitForResponse(
         (r) => urlPathIncludes(r.url(), '/api/v1/vms') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/batch')
       );
-      await page.goto('/vms');
+      const [vmListResp] = await Promise.all([
+        vmListRespPromise,
+        page.goto('/vms'),
+      ]);
+      expect(vmListResp.status(), `GET /vms returned ${vmListResp.status()}`).toBe(200);
+      await validateApiResponse('VMList', vmListResp);
       await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-      const vmListResp = await vmListRespPromise;
-      if (vmListResp.status() === 200) {
-        await validateApiResponse('VMList', vmListResp);
-      }
-      return;
-    }
+    });
 
-    await page.goto('/vms');
-    await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
+    let targetVMID = runningVMID;
+    await test.step('Stage 6 / Step 2: resolve runnable VM target from UI action button', async () => {
+      if (!targetVMID) {
+        const enabledConsoleButton = page.locator('button[data-testid^="vm-action-console-"]:not([disabled])').first();
+        await expect(
+          enabledConsoleButton,
+          'No running VM with enabled console action found; set E2E_VM_RUNNING_ID or seed a running VM'
+        ).toBeVisible();
+        const testId = await enabledConsoleButton.getAttribute('data-testid');
+        targetVMID = testId?.replace('vm-action-console-', '') ?? '';
+      }
+      expect(targetVMID, 'Failed to resolve VM id from console action button').toBeTruthy();
+    });
 
     const consoleRespPromise = page.waitForResponse(
       (r) =>
-        urlPathEndsWith(r.url(), `/api/v1/vms/${runningVMID}/console/request`) &&
+        urlPathEndsWith(r.url(), `/api/v1/vms/${targetVMID}/console/request`) &&
         r.request().method() === 'POST'
     );
     const vncRespPromise = page.waitForResponse(
       (r) =>
-        urlPathEndsWith(r.url(), `/api/v1/vms/${runningVMID}/vnc`) &&
-        r.request().method() === 'GET'
-    );
+        urlPathEndsWith(r.url(), `/api/v1/vms/${targetVMID}/vnc`) &&
+        r.request().method() === 'GET',
+      { timeout: 15000 }
+    ).catch(() => null);
 
-    await page.getByTestId(`vm-action-console-${runningVMID}`).click();
+    await page.getByTestId(`vm-action-console-${targetVMID}`).click();
 
-    // ── CONTRACT CHECK: requestVMConsoleAccess → VMConsoleRequestResponse ─────
-    const consoleResp = await consoleRespPromise;
-    expect([200, 202]).toContain(consoleResp.status());
-    await validateApiResponse('VMConsoleRequestResponse', consoleResp);
+    let consoleStatus = '';
+    let consoleTicketID = '';
+    let consoleVNCURL = '';
+    await test.step('Stage 6 / Step 3: validate requestVMConsoleAccess branch by environment', async () => {
+      const consoleResp = await consoleRespPromise;
+      expect(
+        [200, 202],
+        `POST /vms/${targetVMID}/console/request returned unexpected ${consoleResp.status()}`
+      ).toContain(consoleResp.status());
+      const consoleBody = await validateApiResponse('VMConsoleRequestResponse', consoleResp) as {
+        status?: string;
+        ticket_id?: string | null;
+        vnc_url?: string | null;
+      };
+      consoleStatus = String(consoleBody.status ?? '').toUpperCase();
+      consoleTicketID = String(consoleBody.ticket_id ?? '').trim();
+      consoleVNCURL = String(consoleBody.vnc_url ?? '').trim();
 
-    // ── CONTRACT CHECK: openVMVNC → VMVNCSessionResponse ─────────────────────
-    const vncResp = await vncRespPromise;
-    expect(vncResp.status()).toBe(200);
-    await validateApiResponse('VMVNCSessionResponse', vncResp);
+      if (consoleResp.status() === 200) {
+        expect(consoleStatus, 'test-env direct path must be APPROVED').toBe('APPROVED');
+        expect(consoleVNCURL, 'APPROVED response must include vnc_url').toBe(`/api/v1/vms/${targetVMID}/vnc`);
+      } else {
+        expect(consoleStatus, 'prod path must return pending status').toBe('PENDING_APPROVAL');
+        expect(consoleTicketID, 'pending approval response must include ticket_id').toBeTruthy();
+        expect(consoleVNCURL, 'pending response must not include vnc_url').toBe('');
+      }
+    });
+
+    await test.step('Stage 6 / Step 4: poll console status API to confirm persisted state', async () => {
+      const token = await getAdminToken(request);
+      const headers = { Authorization: `Bearer ${token}` };
+      const statusResp = await request.get(`/api/v1/vms/${targetVMID}/console/status`, { headers });
+      expect(statusResp.status(), `GET /vms/${targetVMID}/console/status returned ${statusResp.status()}`).toBe(200);
+      const statusBody = await validateApiResponse('VMConsoleStatusResponse', statusResp) as {
+        status?: string;
+        ticket_id?: string | null;
+        vnc_url?: string | null;
+      };
+      const polledStatus = String(statusBody.status ?? '').toUpperCase();
+      const polledTicketID = String(statusBody.ticket_id ?? '').trim();
+      const polledVNCURL = String(statusBody.vnc_url ?? '').trim();
+
+      if (consoleStatus === 'APPROVED') {
+        expect(polledStatus, 'approved request must remain approved in status poll').toBe('APPROVED');
+        expect(polledVNCURL, 'approved status payload must include vnc_url').toBe(`/api/v1/vms/${targetVMID}/vnc`);
+      } else {
+        expect(polledStatus, 'pending request must remain pending until approval').toBe('PENDING_APPROVAL');
+        expect(polledTicketID, 'pending status payload must include ticket_id').toBe(consoleTicketID);
+      }
+    });
+
+    await test.step('Stage 6 / Step 5: validate openVMVNC response and URL safety for approved flow', async () => {
+      if (consoleStatus !== 'APPROVED') {
+        return;
+      }
+      const vncResp = await vncRespPromise;
+      expect(vncResp, 'Console approved but /vms/{id}/vnc was not called').not.toBeNull();
+      expect(vncResp?.status(), `GET /vms/${targetVMID}/vnc returned ${vncResp?.status()}`).toBe(200);
+
+      const parsed = new URL((vncResp as Response).url());
+      expect(parsed.searchParams.has('token'), 'VNC URL must not carry token query param').toBe(false);
+      expect(parsed.searchParams.has('bearer'), 'VNC URL must not carry bearer query param').toBe(false);
+      expect(parsed.searchParams.has('session'), 'VNC URL must not carry session query param').toBe(false);
+
+      const vncBody = await validateApiResponse('VMVNCSessionResponse', vncResp as Response) as {
+        vm_id?: string;
+        websocket_path?: string;
+      };
+      expect(vncBody.vm_id, 'openVMVNC vm_id mismatch').toBe(targetVMID);
+      expect(String(vncBody.websocket_path ?? ''), 'websocket_path must point to vm vnc endpoint').toContain(`/api/v1/vms/${targetVMID}/vnc`);
+      expect(consoleVNCURL, 'requestVMConsoleAccess approved path must align with vnc endpoint').toBe(`/api/v1/vms/${targetVMID}/vnc`);
+    });
   });
 
   // ── Stage 3: Admin config (GET schemas) ──────────────────────────────────────
 
   test('Stage 3 – listAdminTemplates: admin template list conforms to TemplateList schema', async ({ page }) => {
     // operationId: listAdminTemplates
-    const tplRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/templates');
-    await expect(page.getByRole('heading', { name: 'Templates' })).toBeVisible();
-
-    // ── CONTRACT CHECK: listAdminTemplates → TemplateList ────────────────────
-    const tplResp = await tplRespPromise;
-    expect(tplResp.status()).toBe(200);
-    await validateApiResponse('TemplateList', tplResp);
+    await test.step('Stage 3 / Step 3: admin template catalog is reachable and schema-valid', async () => {
+      const tplRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/templates') && r.request().method() === 'GET'
+      );
+      const [tplResp] = await Promise.all([
+        tplRespPromise,
+        page.goto('/admin/templates'),
+      ]);
+      expect(tplResp.status()).toBe(200);
+      await validateApiResponse('TemplateList', tplResp);
+      await expect(page.getByRole('heading', { name: 'Templates' })).toBeVisible();
+    });
   });
 
   test('Stage 3 – listAdminInstanceSizes: instance-size list conforms to InstanceSizeList schema', async ({ page }) => {
     // operationId: listAdminInstanceSizes
-    const sizeRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/instance-sizes');
-    await expect(page.getByRole('heading', { name: 'Instance Sizes' })).toBeVisible();
-
-    // ── CONTRACT CHECK: listAdminInstanceSizes → InstanceSizeList ────────────
-    const sizeResp = await sizeRespPromise;
-    expect(sizeResp.status()).toBe(200);
-    await validateApiResponse('InstanceSizeList', sizeResp);
+    await test.step('Stage 3 / Step 4: instance-size catalog is reachable and schema-valid', async () => {
+      const sizeRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/instance-sizes') && r.request().method() === 'GET'
+      );
+      const [sizeResp] = await Promise.all([
+        sizeRespPromise,
+        page.goto('/admin/instance-sizes'),
+      ]);
+      expect(sizeResp.status()).toBe(200);
+      await validateApiResponse('InstanceSizeList', sizeResp);
+      await expect(page.getByRole('heading', { name: 'Instance Sizes' })).toBeVisible();
+    });
   });
 
   test('Stage 3 – listNamespaces: admin namespace list conforms to NamespaceRegistryList schema', async ({ page }) => {
     // operationId: listNamespaces
-    const nsRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/namespaces');
-    await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
-
-    // ── CONTRACT CHECK: listNamespaces → NamespaceRegistryList ───────────────
-    const nsResp = await nsRespPromise;
-    expect(nsResp.status()).toBe(200);
-    await validateApiResponse('NamespaceRegistryList', nsResp);
+    await test.step('Stage 3 / Step 2: namespace registry is reachable and schema-valid', async () => {
+      const nsRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
+      );
+      const [nsResp] = await Promise.all([
+        nsRespPromise,
+        page.goto('/admin/namespaces'),
+      ]);
+      expect(nsResp.status()).toBe(200);
+      await validateApiResponse('NamespaceRegistryList', nsResp);
+      await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
+    });
   });
 
   // ── Stage 2.A: RBAC ──────────────────────────────────────────────────────────
 
   test('Stage 2.A – listRoles: role list conforms to RoleList schema', async ({ page }) => {
     // operationId: listRoles
-    const rolesRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/rbac');
-    await expect(page.getByTestId('admin-rbac-page')).toBeVisible();
-
-    // ── CONTRACT CHECK: listRoles → RoleList ──────────────────────────────────
-    const rolesResp = await rolesRespPromise;
-    expect(rolesResp.status()).toBe(200);
-    await validateApiResponse('RoleList', rolesResp);
+    await test.step('Stage 2.A / Step 1: role list endpoint is reachable and schema-valid', async () => {
+      const rolesRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/roles') && r.request().method() === 'GET'
+      );
+      const [rolesResp] = await Promise.all([
+        rolesRespPromise,
+        page.goto('/admin/rbac'),
+      ]);
+      expect(rolesResp.status()).toBe(200);
+      await validateApiResponse('RoleList', rolesResp);
+      await expect(page.getByTestId('admin-rbac-page')).toBeVisible();
+    });
   });
 
   // ── Stage 2.B: Auth Providers ────────────────────────────────────────────────
 
   test('Stage 2.B – listAuthProviderTypes: auth provider type list conforms to AuthProviderTypeList schema', async ({ page }) => {
     // operationId: listAuthProviderTypes
-    const typesRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-provider-types') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/auth-providers');
-    await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
-
-    // ── CONTRACT CHECK: listAuthProviderTypes → AuthProviderTypeList ──────────
-    const typesResp = await typesRespPromise;
-    expect(typesResp.status()).toBe(200);
-    await validateApiResponse('AuthProviderTypeList', typesResp);
+    await test.step('Stage 2.B / Step 1: auth provider type list is reachable and schema-valid', async () => {
+      const typesRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-provider-types') && r.request().method() === 'GET'
+      );
+      const [typesResp] = await Promise.all([
+        typesRespPromise,
+        page.goto('/admin/auth-providers'),
+      ]);
+      expect(typesResp.status()).toBe(200);
+      await validateApiResponse('AuthProviderTypeList', typesResp);
+      await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
+    });
   });
 
   test('Stage 2.B – listAuthProviders: auth provider list conforms to AuthProviderList schema', async ({ page }) => {
     // operationId: listAuthProviders
-    const listRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/auth-providers');
-    await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
-
-    // ── CONTRACT CHECK: listAuthProviders → AuthProviderList ──────────────────
-    const listResp = await listRespPromise;
-    expect(listResp.status()).toBe(200);
-    await validateApiResponse('AuthProviderList', listResp);
+    await test.step('Stage 2.B / Step 2: auth provider list is reachable and schema-valid', async () => {
+      const listRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/auth-providers') && r.request().method() === 'GET'
+      );
+      const [listResp] = await Promise.all([
+        listRespPromise,
+        page.goto('/admin/auth-providers'),
+      ]);
+      expect(listResp.status()).toBe(200);
+      await validateApiResponse('AuthProviderList', listResp);
+      await expect(page.getByRole('heading', { name: 'Authentication Providers' })).toBeVisible();
+    });
   });
 
-  // ── Stage 2.A+: User Management ──────────────────────────────────────────────
+  // ── Stage 2 (Supplemental): User Management ──────────────────────────────────
 
-  test('Stage 2.A+ – listUsers: user list conforms to UserList schema', async ({ page }) => {
+  test('Stage 2 (Supplemental) – listUsers: user list conforms to UserList schema', async ({ page }) => {
     // operationId: listUsers
-    const usersRespPromise = page.waitForResponse(
-      (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
-    );
-
-    await page.goto('/admin/users');
-    await expect(page.getByTestId('admin-users-page')).toBeVisible();
-
-    // ── CONTRACT CHECK: listUsers → UserList ──────────────────────────────────
-    const usersResp = await usersRespPromise;
-    expect(usersResp.status()).toBe(200);
-    await validateApiResponse('UserList', usersResp);
+    await test.step('Stage 2 (Supplemental) / User Mgmt Step 1: user list endpoint is reachable and schema-valid', async () => {
+      const usersRespPromise = page.waitForResponse(
+        (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
+      );
+      const [usersResp] = await Promise.all([
+        usersRespPromise,
+        page.goto('/admin/users'),
+      ]);
+      expect(usersResp.status()).toBe(200);
+      await validateApiResponse('UserList', usersResp);
+      await expect(page.getByTestId('admin-users-page')).toBeVisible();
+    });
   });
 });

--- a/web/tests/e2e/user-selfservice-live.spec.ts
+++ b/web/tests/e2e/user-selfservice-live.spec.ts
@@ -31,32 +31,37 @@
  *   E2E_NEW_PASSWORD – new password for change-password test (default: e2e-admin-456)
  */
 
-import { expect, test, type Page, type Response } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Locator, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
-import { urlPathEndsWith, urlPathIncludes, selectAntOption, getAntModal } from './lib/helpers';
+import {
+    ensureBatchSubmitPolicyForUser,
+    fetchStatusWithStoredToken,
+    getAntModal,
+    getApiTokenWithForcePasswordSupport,
+    loginWithForcePasswordSupport,
+    selectAntOption,
+    urlPathEndsWith,
+    urlPathIncludes,
+} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
 const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
-const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? 'e2e-admin-456';
+const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
+const e2eSystemName = process.env.E2E_SYSTEM ?? 'e2e-system';
+const e2eServiceName = process.env.E2E_SERVICE ?? 'e2e-service';
+let activePassword = e2ePassword;
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
 
-async function login(page: Page, username = e2eUsername, password = e2ePassword): Promise<void> {
-    await page.goto('/login');
-    await expect(page.getByRole('heading', { name: 'KubeVirt Shepherd' })).toBeVisible();
-    await page.getByPlaceholder('Username').fill(username);
-    await page.getByPlaceholder('Password').fill(password);
-    // operationId: login
-    const loginRespPromise = page.waitForResponse(
-        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
-    );
-    await page.getByRole('button', { name: 'Login' }).click();
-    const loginResp = await loginRespPromise;
-    expect(loginResp.status()).toBe(200);
-    await validateApiResponse('LoginResponse', loginResp);
-    await expect(page).toHaveURL(/\/dashboard$/);
+async function login(page: Page): Promise<void> {
+    activePassword = await loginWithForcePasswordSupport(page, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
 }
 
 async function expectSchema(
@@ -71,9 +76,62 @@ async function expectSchema(
     return { body, resp };
 }
 
+async function getApiAuthHeaders(request: APIRequestContext): Promise<{ Authorization: string }> {
+    const auth = await getApiTokenWithForcePasswordSupport(request, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
+    activePassword = auth.password;
+    return { Authorization: `Bearer ${auth.token}` };
+}
+
+async function findTicketCancelButtonAcrossPages(
+    page: Page,
+    ticketID: string,
+    maxPages = 12
+): Promise<Locator | null> {
+    const targetTestId = `approval-action-cancel-${ticketID}`;
+
+    for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+        const cancelBtn = page.getByTestId(targetTestId).first();
+        const visible = await cancelBtn.isVisible().catch(() => false);
+        if (visible) {
+            return cancelBtn;
+        }
+
+        const nextPageBtn = page
+            .locator('.ant-pagination-next:not(.ant-pagination-disabled) button, .ant-pagination-next:not(.ant-pagination-disabled) a')
+            .first();
+        if (await nextPageBtn.count() === 0) {
+            return null;
+        }
+
+        const listRespPromise = page.waitForResponse(
+            (r) => urlPathEndsWith(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
+        );
+        await nextPageBtn.click();
+        await listRespPromise;
+    }
+
+    return null;
+}
+
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () => {
+    test.beforeAll(async ({ request }) => {
+        const setup = await ensureBatchSubmitPolicyForUser(request, {
+            username: e2eUsername,
+            primaryPassword: e2ePassword,
+            secondaryPassword: e2eNewPassword,
+            currentPasswordHint: activePassword,
+            reasonPrefix: 'user-selfservice live',
+        });
+        activePassword = setup.password;
+    });
+
     test.beforeEach(async ({ page }) => {
         await login(page);
     });
@@ -114,11 +172,8 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
             (r) => urlPathEndsWith(r.url(), '/api/v1/templates') && !urlPathIncludes(r.url(), '/admin/') && r.request().method() === 'GET'
         );
 
-        // Fetch explicitly in page context (shares auth/cookies), returning status to avoid Playwright serialization warnings
-        const status = await page.evaluate(async () => {
-            const res = await fetch('/api/v1/templates');
-            return res.status;
-        });
+        // Trigger explicitly with app JWT to guarantee authenticated coverage.
+        const status = await fetchStatusWithStoredToken(page, '/api/v1/templates', 'GET');
         expect(status).toBe(200);
 
         // ── CONTRACT CHECK: TemplateList schema ───────────────────────────────────
@@ -137,11 +192,8 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
             (r) => urlPathEndsWith(r.url(), '/api/v1/instance-sizes') && !urlPathIncludes(r.url(), '/admin/') && r.request().method() === 'GET'
         );
 
-        // Fetch explicitly in page context (shares auth/cookies), returning status to avoid Playwright serialization warnings
-        const status = await page.evaluate(async () => {
-            const res = await fetch('/api/v1/instance-sizes');
-            return res.status;
-        });
+        // Trigger explicitly with app JWT to guarantee authenticated coverage.
+        const status = await fetchStatusWithStoredToken(page, '/api/v1/instance-sizes', 'GET');
         expect(status).toBe(200);
 
         // ── CONTRACT CHECK: InstanceSizeList schema ───────────────────────────────
@@ -157,10 +209,13 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
             (r) => urlPathIncludes(r.url(), '/api/v1/notifications') && r.request().method() === 'GET'
                 && !urlPathIncludes(r.url(), 'unread-count')
         );
-        await page.goto('/notifications');
+        const [listResp] = await Promise.all([
+            listRespPromise,
+            page.goto('/notifications'),
+        ]);
         await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
         // Use validateApiResponse for single-read safety
-        const listBody = await validateApiResponse('NotificationList', await listRespPromise) as { items?: Array<{ id?: string; read?: boolean }> };
+        const listBody = await validateApiResponse('NotificationList', listResp) as { items?: Array<{ id?: string; read?: boolean }> };
         const unread = (listBody.items ?? []).find((n) => !n.read);
         expect(unread, 'No unread notifications found — seed data must include at least one unread notification').toBeTruthy();
         const notifID = unread?.id ?? '';
@@ -198,15 +253,17 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
     test('cancelTicket – POST /approvals/{id}/cancel returns 204', async ({ page }) => {
         // operationId: cancelTicket
         // First submit a VM request to get a pending ticket
+        const uniqueSuffix = `${Date.now()}`;
+        const requestNamespace = `e2e-cancel-${uniqueSuffix}`;
         await page.goto('/vms');
         await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
         await page.getByRole('button', { name: 'Request VM' }).click();
         await expect(page.getByText('Create VM Request')).toBeVisible();
 
         const systemSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
-        await selectAntOption(page, systemSelect);
+        await selectAntOption(page, systemSelect, e2eSystemName);
         const serviceSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').nth(1);
-        await selectAntOption(page, serviceSelect);
+        await selectAntOption(page, serviceSelect, e2eServiceName);
         await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
         const templateSelect = getAntModal(page, 'vm-request-wizard-modal').locator('[role="combobox"]').first();
@@ -217,8 +274,8 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await selectAntOption(page, sizeSelect);
         await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
-        await getAntModal(page, 'vm-request-wizard-modal').locator('input').first().fill('test-ns-cancel');
-        await getAntModal(page, 'vm-request-wizard-modal').locator('textarea').first().fill('cancel test request');
+        await getAntModal(page, 'vm-request-wizard-modal').locator('#vm-request-wizard_namespace').fill(requestNamespace);
+        await getAntModal(page, 'vm-request-wizard-modal').locator('#vm-request-wizard_reason').fill(`cancel test request ${uniqueSuffix}`);
         await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Next' }).click();
 
         const submitRespPromise = page.waitForResponse(
@@ -226,28 +283,51 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         );
         await getAntModal(page, 'vm-request-wizard-modal').getByRole('button', { name: 'Submit' }).click();
         const submitResp = await submitRespPromise;
-        expect([202, 400, 409]).toContain(submitResp.status());
-
-        // Single-read the response body (Playwright responses are single-read;
-        // calling .json() twice throws a Protocol error)
-        const submitBody = await submitResp.json() as { ticket_id?: string; id?: string; message?: string };
-
-        if (submitResp.status() !== 202) {
-            throw new Error(`POST /vms/request failed with ${submitResp.status()}: ${submitBody.message ?? JSON.stringify(submitBody)}`);
+        let ticketID = '';
+        if (submitResp.status() === 202) {
+            const submitBody = await validateApiResponse('ApprovalTicketResponse', submitResp) as { ticket_id?: string; id?: string };
+            ticketID = submitBody.ticket_id ?? submitBody.id ?? '';
+        } else if (submitResp.status() === 400) {
+            const errBody = await validateApiResponse('Error', submitResp) as {
+                code?: string;
+                message?: string;
+                params?: Record<string, unknown>;
+            };
+            const existingTicketID =
+                typeof errBody.params?.existing_ticket_id === 'string' ? errBody.params.existing_ticket_id.trim() : '';
+            if (errBody.code === 'DUPLICATE_PENDING_REQUEST' && existingTicketID) {
+                ticketID = existingTicketID;
+            } else {
+                throw new Error(
+                    `POST /vms/request returned 400: ${errBody.code ?? 'UNKNOWN'} (${errBody.message ?? 'no message'})`
+                );
+            }
+        } else {
+            expect(submitResp.status(), `POST /vms/request returned ${submitResp.status()}`).toBe(202);
         }
-
-        const ticketID = submitBody.ticket_id ?? submitBody.id ?? '';
         expect(ticketID, 'POST /vms/request response missing ticket_id/id field').toBeTruthy();
 
         // ── POST /approvals/{id}/cancel → 204 ────────────────────────────────────
+        const listRespPromise = page.waitForResponse(
+            (r) => urlPathEndsWith(r.url(), '/api/v1/approvals') && r.request().method() === 'GET'
+        );
+        await page.goto('/approvals');
+        await listRespPromise;
+        await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
+
+        const cancelActionBtn = await findTicketCancelButtonAcrossPages(page, ticketID);
+        if (!cancelActionBtn) {
+            throw new Error(`Ticket ${ticketID} should be visible and cancellable in approval list`);
+        }
+        await expect(cancelActionBtn).toBeVisible({ timeout: 20000 });
+        await expect(cancelActionBtn).toBeEnabled();
+
         const cancelRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/approvals/${ticketID}/cancel`) && r.request().method() === 'POST'
         );
-        await page.goto('/approvals');
-        await expect(page.getByRole('heading', { name: /approval/i })).toBeVisible();
-        await page.getByTestId(`approval-action-cancel-${ticketID}`).click();
+        await cancelActionBtn.click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
-            .getByRole('button', { name: /confirm|ok|cancel/i }).first();
+            .getByRole('button', { name: /confirm|ok|yes/i }).first();
         if (await confirmBtn.count() > 0) await confirmBtn.click();
 
         const cancelResp = await cancelRespPromise;
@@ -258,7 +338,6 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
     test('submitApprovalBatch – POST /approvals/batch conforms to VMBatchSubmitResponse schema', async ({ page }) => {
         // operationId: submitApprovalBatch
-        // In the UI, /approvals/batch is triggered when submitting a VM request via wizard with batch_count > 1
         await page.goto('/vms');
         await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
 
@@ -271,33 +350,34 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         const wizardModal = getAntModal(page, 'vm-request-wizard-modal');
         await expect(wizardModal).toBeVisible();
 
-        // Step 1: Service
-        await selectAntOption(page, wizardModal.locator('.ant-select-selector').first());
-        await selectAntOption(page, wizardModal.locator('.ant-select-selector').nth(1));
+        // Step 1: System + Service
+        const systemSelect = wizardModal.locator('[role="combobox"]').first();
+        const serviceSelect = wizardModal.locator('[role="combobox"]').nth(1);
+        await selectAntOption(page, systemSelect, e2eSystemName);
+        await selectAntOption(page, serviceSelect, e2eServiceName);
         await wizardModal.getByRole('button', { name: 'Next' }).click();
 
         // Step 2: Template
-        await selectAntOption(page, wizardModal.locator('.ant-select-selector').first());
+        await selectAntOption(page, wizardModal.locator('[role="combobox"]').first());
         await wizardModal.getByRole('button', { name: 'Next' }).click();
 
         // Step 3: Size
-        await selectAntOption(page, wizardModal.locator('.ant-select-selector').first());
+        await selectAntOption(page, wizardModal.locator('[role="combobox"]').first());
         await wizardModal.getByRole('button', { name: 'Next' }).click();
 
         // Step 4: Config
-        const namespaceSelect = wizardModal.locator('.ant-select-selector').first();
-        if (await namespaceSelect.isVisible()) {
-            await selectAntOption(page, namespaceSelect);
-        }
-        await wizardModal.getByRole('textbox').first().fill('Test batch submit');
-        await wizardModal.locator('input[type="number"]').first().fill('2'); // Set batch_count to 2
+        await wizardModal.locator('#vm-request-wizard_namespace').fill('e2e-batch-ns');
+        await wizardModal.locator('#vm-request-wizard_reason').fill('Test batch submit');
+        await wizardModal.locator('#vm-request-wizard_batch_count').fill('2');
         await wizardModal.getByRole('button', { name: 'Next' }).click();
 
         // Step 5: Confirm
         await wizardModal.getByRole('button', { name: 'Submit' }).click();
 
-        // ── CONTRACT CHECK: VMBatchSubmitResponse schema ──────────────────────────
-        await expectSchema(batchRespPromise, 'VMBatchSubmitResponse', [202, 400, 429]);
+        // ── CONTRACT CHECK: strict success path (must be accepted) ─────────────────
+        const batchResp = await batchRespPromise;
+        expect(batchResp.status(), `POST /approvals/batch returned ${batchResp.status()}`).toBe(202);
+        await validateApiResponse('VMBatchSubmitResponse', batchResp);
     });
 
     // ── getSystem: GET /systems/{id} → System ────────────────────────────────
@@ -308,20 +388,23 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         const listRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'GET'
         );
-        await page.goto('/systems');
-        await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
+        const [listResp] = await Promise.all([
+            listRespPromise,
+            page.goto('/systems'),
+        ]);
         // Use validateApiResponse for single-read safety
-        const listBody = await validateApiResponse('SystemList', await listRespPromise) as { items?: Array<{ id?: string }> };
+        const listBody = await validateApiResponse('SystemList', listResp) as { items?: Array<{ id?: string }> };
         const items = listBody.items ?? [];
         expect(items.length, 'No systems found — seed data must include at least one system').toBeGreaterThan(0);
         const systemID = items[0]?.id ?? '';
         expect(systemID).toBeTruthy();
+        await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
 
         // ── GET /systems/{id} → System ────────────────────────────────────────────
         const getRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/systems/${systemID}`) && r.request().method() === 'GET'
         );
-        await page.getByTestId(`system-action-detail-${systemID}`).click();
+        await page.getByTestId(`system-action-edit-${systemID}`).click();
         await expectSchema(getRespPromise, 'System', 200);
     });
 
@@ -329,58 +412,67 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
     test('listServices – GET /systems/{id}/services conforms to ServiceList schema', async ({ page }) => {
         // operationId: listServices
-        // Get first system
-        const sysListRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'GET'
-        );
-        await page.goto('/systems');
-        await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
-        const sysListBody = await validateApiResponse('SystemList', await sysListRespPromise) as { items?: Array<{ id?: string }> };
-        const systemID = sysListBody.items?.[0]?.id ?? '';
-        expect(systemID, 'No systems found').toBeTruthy();
-
-        // Navigate to services for this system
         const svcListRespPromise = page.waitForResponse(
-            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) && r.request().method() === 'GET'
-                && !urlPathIncludes(r.url(), '/services/')
+            (r) => {
+                if (r.request().method() !== 'GET') return false;
+                const path = new URL(r.url()).pathname;
+                return /\/api\/v1\/systems\/[^/]+\/services$/.test(path);
+            }
         );
-        await page.goto('/services');
+        const [svcListResp] = await Promise.all([
+            svcListRespPromise,
+            page.goto('/services'),
+        ]);
         await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
-        await selectAntOption(page, page.getByTestId('services-system-selector'));
 
         // ── CONTRACT CHECK: ServiceList schema ────────────────────────────────────
-        await expectSchema(svcListRespPromise, 'ServiceList', 200);
+        await expectSchema(Promise.resolve(svcListResp), 'ServiceList', 200);
     });
 
     test('getService – GET /systems/{id}/services/{id} conforms to Service schema', async ({ page }) => {
         // operationId: getService
-        // Get first system and first service
-        const sysListRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/systems') && r.request().method() === 'GET'
+        const readServiceListResponse = () => page.waitForResponse(
+            (r) => {
+                if (r.request().method() !== 'GET') return false;
+                const path = new URL(r.url()).pathname;
+                return /\/api\/v1\/systems\/[^/]+\/services$/.test(path);
+            }
         );
-        await page.goto('/systems');
-        await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible();
-        const sysListBody = await validateApiResponse('SystemList', await sysListRespPromise) as { items?: Array<{ id?: string }> };
-        const systemID = sysListBody.items?.[0]?.id ?? '';
-        expect(systemID, 'No systems found').toBeTruthy();
-
-        await page.goto('/services');
+        let svcListResp: Response;
+        [svcListResp] = await Promise.all([
+            readServiceListResponse(),
+            page.goto('/services'),
+        ]);
         await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible();
-        await selectAntOption(page, page.getByTestId('services-system-selector'));
 
-        const svcListRespPromise = page.waitForResponse(
-            (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services`) && r.request().method() === 'GET'
-                && !urlPathIncludes(r.url(), '/services/')
-        );
-        const svcListBody = await validateApiResponse('ServiceList', await svcListRespPromise) as { items?: Array<{ id?: string }> };
-        const serviceID = svcListBody.items?.[0]?.id ?? '';
+        let path = new URL(svcListResp.url()).pathname;
+        let pathMatch = path.match(/\/api\/v1\/systems\/([^/]+)\/services$/);
+        let systemID = pathMatch?.[1] ?? '';
+        expect(systemID, `Could not parse system_id from URL path: ${path}`).toBeTruthy();
+
+        let svcListBody = await validateApiResponse('ServiceList', svcListResp) as { items?: Array<{ id?: string; name?: string }> };
+        if ((svcListBody.items?.length ?? 0) === 0) {
+            const svcListRespPromise = readServiceListResponse();
+            await selectAntOption(page, page.getByTestId('services-system-selector'), e2eSystemName);
+            svcListResp = await svcListRespPromise;
+            path = new URL(svcListResp.url()).pathname;
+            pathMatch = path.match(/\/api\/v1\/systems\/([^/]+)\/services$/);
+            systemID = pathMatch?.[1] ?? '';
+            expect(systemID, `Could not parse system_id from URL path: ${path}`).toBeTruthy();
+            svcListBody = await validateApiResponse('ServiceList', svcListResp) as { items?: Array<{ id?: string; name?: string }> };
+        }
+
+        const serviceID =
+            svcListBody.items?.find((svc) => (svc.name ?? '').trim() === e2eServiceName)?.id
+            ?? svcListBody.items?.find((svc) => Boolean(svc.id))?.id
+            ?? '';
         expect(serviceID, 'No services found — seed data must include at least one service').toBeTruthy();
 
         // ── GET /systems/{id}/services/{id} → Service ─────────────────────────────
         const getRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/services/${serviceID}`) && r.request().method() === 'GET'
         );
-        await page.getByTestId(`service-action-detail-${serviceID}`).click();
+        await page.getByTestId(`service-action-edit-${serviceID}`).click();
         await expectSchema(getRespPromise, 'Service', 200);
     });
 
@@ -408,9 +500,11 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         const usersRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), '/api/v1/admin/users') && r.request().method() === 'GET'
         );
-        await page.goto('/admin/users');
+        const [usersResp] = await Promise.all([
+            usersRespPromise,
+            page.goto('/admin/users'),
+        ]);
         await expect(page.getByTestId('admin-users-page')).toBeVisible();
-        const usersResp = await usersRespPromise;
         const usersBody = await validateApiResponse('UserList', usersResp) as { items?: Array<{ id?: string; username?: string }> };
         const targetUser = usersBody.items?.find((u) => u.username !== e2eUsername);
         expect(targetUser, 'Need at least 2 users for member management test').toBeTruthy();
@@ -429,7 +523,8 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await membersModal.getByTestId('member-add-button').click();
         const addModal = getAntModal(page, 'member-add-modal');
         await expect(addModal).toBeVisible();
-        await selectAntOption(page, addModal.locator('.ant-select-selector').first(), targetUser?.username ?? '');
+        await addModal.locator('#add-system-member_user_id').fill(targetUserID);
+        await selectAntOption(page, addModal.locator('.ant-select-selector').first(), /member|viewer|admin|owner/i);
         await addModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: addedMember } = await expectSchema(addRespPromise, 'SystemMember', 201);
@@ -439,11 +534,9 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         const updateRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members/${targetUserID}`) && r.request().method() === 'PATCH'
         );
-        await page.getByTestId(`member-action-edit-${targetUserID}`).click();
-        const editModal = getAntModal(page, 'member-edit-modal');
-        await expect(editModal).toBeVisible();
-        await selectAntOption(page, editModal.locator('.ant-select-selector').first());
-        await editModal.getByRole('button', { name: 'OK' }).click();
+        const roleSelector = membersModal.getByTestId(`member-action-edit-${targetUserID}`);
+        await expect(roleSelector).toBeVisible();
+        await selectAntOption(page, roleSelector, /viewer/i);
 
         await expectSchema(updateRespPromise, 'SystemMember', 200);
 
@@ -451,7 +544,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         const deleteRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/systems/${systemID}/members/${targetUserID}`) && r.request().method() === 'DELETE'
         );
-        await page.getByTestId(`member-action-remove-${targetUserID}`).click();
+        await membersModal.getByTestId(`member-action-remove-${targetUserID}`).click();
         const confirmBtn = page.getByRole('button', { name: /confirm|ok/i }).last();
         await confirmBtn.click();
         expect((await deleteRespPromise).status()).toBe(204);
@@ -472,26 +565,20 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
 
     // ── getNamespace: GET /admin/namespaces/{id} → NamespaceRegistry ──────────
 
-    test('getNamespace – GET /admin/namespaces/{id} conforms to NamespaceRegistry schema', async ({ page }) => {
+    test('getNamespace – GET /admin/namespaces/{id} conforms to NamespaceRegistry schema', async ({ request }) => {
         // operationId: getNamespace
-        const listRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/admin/namespaces') && r.request().method() === 'GET'
-        );
-        await page.goto('/admin/namespaces');
-        await expect(page.getByTestId('admin-namespaces-page')).toBeVisible();
-        // Use validateApiResponse for single-read safety
-        const listBody = await validateApiResponse('NamespaceRegistryList', await listRespPromise) as { items?: Array<{ id?: string }> };
+        const headers = await getApiAuthHeaders(request);
+        const listResp = await request.get('/api/v1/admin/namespaces', { headers });
+        expect(listResp.status(), `GET /admin/namespaces returned ${listResp.status()}`).toBe(200);
+        const listBody = await validateApiResponse('NamespaceRegistryList', listResp) as { items?: Array<{ id?: string }> };
         const items = listBody.items ?? [];
         expect(items.length, 'No namespaces found — seed data must include at least one namespace').toBeGreaterThan(0);
         const nsID = items[0]?.id ?? '';
         expect(nsID).toBeTruthy();
 
-        // ── GET /admin/namespaces/{id} → NamespaceRegistry ───────────────────────
-        const getRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), `/api/v1/admin/namespaces/${nsID}`) && r.request().method() === 'GET'
-        );
-        await page.getByTestId(`namespace-action-detail-${nsID}`).click();
-        await expectSchema(getRespPromise, 'NamespaceRegistry', 200);
+        const getResp = await request.get(`/api/v1/admin/namespaces/${nsID}`, { headers });
+        expect(getResp.status(), `GET /admin/namespaces/${nsID} returned ${getResp.status()}`).toBe(200);
+        await validateApiResponse('NamespaceRegistry', getResp);
     });
 
     // ── changePassword: POST /auth/change-password → 204 ─────────────────────
@@ -502,6 +589,12 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: changePassword
         await page.goto('/profile');
         await expect(page.locator('body')).toBeVisible();
+        const originalPassword = activePassword;
+        const stablePassword = e2eNewPassword.length >= 8 ? e2eNewPassword : 'admin123';
+        let changedPassword = `${stablePassword}-tmp`;
+        if (changedPassword === originalPassword) {
+            changedPassword = `${stablePassword}-tmp2`;
+        }
 
         // ── POST /auth/change-password → 204 (change to new password) ────────────
         const changeRespPromise = page.waitForResponse(
@@ -510,27 +603,29 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         await page.getByTestId('change-password-button').click();
         const changeModal = getAntModal(page, 'change-password-modal');
         await expect(changeModal).toBeVisible();
-        await changeModal.locator('input[type="password"]').nth(0).fill(e2ePassword);
-        await changeModal.locator('input[type="password"]').nth(1).fill(e2eNewPassword);
-        await changeModal.locator('input[type="password"]').nth(2).fill(e2eNewPassword);
+        await changeModal.getByTestId('change-password-current-input').fill(originalPassword);
+        await changeModal.getByTestId('change-password-new-input').fill(changedPassword);
+        await changeModal.getByTestId('change-password-confirm-input').fill(changedPassword);
         await changeModal.getByRole('button', { name: 'OK' }).click();
 
         const changeResp = await changeRespPromise;
         expect(changeResp.status(), `POST /auth/change-password returned ${changeResp.status()}`).toBe(204);
+        activePassword = changedPassword;
 
-        // ── Restore original password ─────────────────────────────────────────────
+        // ── Restore stable password (must satisfy UI min length constraints) ─────
         const restoreRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), '/api/v1/auth/change-password') && r.request().method() === 'POST'
         );
         await page.getByTestId('change-password-button').click();
         const restoreModal = getAntModal(page, 'change-password-modal');
         await expect(restoreModal).toBeVisible();
-        await restoreModal.locator('input[type="password"]').nth(0).fill(e2eNewPassword);
-        await restoreModal.locator('input[type="password"]').nth(1).fill(e2ePassword);
-        await restoreModal.locator('input[type="password"]').nth(2).fill(e2ePassword);
+        await restoreModal.getByTestId('change-password-current-input').fill(changedPassword);
+        await restoreModal.getByTestId('change-password-new-input').fill(stablePassword);
+        await restoreModal.getByTestId('change-password-confirm-input').fill(stablePassword);
         await restoreModal.getByRole('button', { name: 'OK' }).click();
 
         const restoreResp = await restoreRespPromise;
         expect(restoreResp.status(), `Password restore failed with ${restoreResp.status()}`).toBe(204);
+        activePassword = stablePassword;
     });
 });

--- a/web/tests/e2e/vm-lifecycle-live.spec.ts
+++ b/web/tests/e2e/vm-lifecycle-live.spec.ts
@@ -13,7 +13,7 @@
  *   stopVM             – POST /vms/{id}/stop            → 202 (no body schema)
  *   restartVM          – POST /vms/{id}/restart         → 202 (no body schema)
  *   deleteVM           – DELETE /vms/{id}               → DeleteVMResponse schema
- *   powerVM            – POST /vms/{id}/power           → VM schema (202)
+ *   powerVM            – POST /vms/{id}/power           → VMPowerAcceptedResponse schema (202)
  *   listVMBatches      – GET /vms/batch                 → VMBatchList schema
  *   submitVMBatch      – POST /vms/batch                → VMBatchSubmitResponse schema
  *   getVMBatch         – GET /vms/batch/{id}            → VMBatchStatusResponse schema
@@ -29,36 +29,55 @@
  * Environment variables:
  *   E2E_USERNAME  – admin username (default: e2e-admin)
  *   E2E_PASSWORD  – admin password (default: e2e-admin-123)
+ *   E2E_NEW_PASSWORD – password used when force_password_change=true
  *   E2E_SYSTEM    – pre-existing system with at least one service (default: e2e-system)
  *   E2E_SERVICE   – pre-existing service name (default: e2e-service)
  */
 
-import { expect, test, type Page, type Response } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
-import { urlPathEndsWith, urlPathIncludes } from './lib/helpers';
+import {
+    ensureBatchSubmitPolicyForUser,
+    fetchStatusWithStoredToken,
+    getApiTokenWithForcePasswordSupport,
+    loginWithForcePasswordSupport,
+    urlPathEndsWith,
+    urlPathIncludes,
+} from './lib/helpers';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
 const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
+const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
+const e2eSystemName = process.env.E2E_SYSTEM ?? 'e2e-system';
+const e2eServiceName = process.env.E2E_SERVICE ?? 'e2e-service';
+const e2eTemplateName = process.env.E2E_TEMPLATE ?? 'e2e-template';
+const e2eSizeName = process.env.E2E_SIZE ?? 'e2e-small';
+const e2eNamespace = process.env.E2E_NAMESPACE ?? 'e2e-test';
+const seededRunningVMID = process.env.E2E_VM_RUNNING_ID ?? 'vm-e2e-running';
+const seededStoppedVMID = process.env.E2E_VM_STOPPED_ID ?? 'vm-e2e-stopped';
+const seededRunningVMName = process.env.E2E_VM_RUNNING_NAME ?? 'vm-running';
+const seededStoppedVMName = process.env.E2E_VM_STOPPED_NAME ?? 'vm-stopped';
+const seededVMIDs = new Set([seededRunningVMID, seededStoppedVMID]);
+const seededVMNames = new Set([
+    seededRunningVMName.trim().toLowerCase(),
+    seededStoppedVMName.trim().toLowerCase(),
+    'vm-e2e-running',
+    'vm-e2e-stopped',
+]);
+let activePassword = e2ePassword;
+let lifecycleVMID = '';
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
 
 async function login(page: Page): Promise<void> {
-    await page.goto('/login');
-    await expect(page.getByRole('heading', { name: 'KubeVirt Shepherd' })).toBeVisible();
-    await page.getByPlaceholder('Username').fill(e2eUsername);
-    await page.getByPlaceholder('Password').fill(e2ePassword);
-
-    // operationId: login
-    const loginRespPromise = page.waitForResponse(
-        (r) => urlPathEndsWith(r.url(), '/api/v1/auth/login') && r.request().method() === 'POST'
-    );
-    await page.getByRole('button', { name: 'Login' }).click();
-    const loginResp = await loginRespPromise;
-    expect(loginResp.status()).toBe(200);
-    await validateApiResponse('LoginResponse', loginResp);
-    await expect(page).toHaveURL(/\/dashboard$/);
+    activePassword = await loginWithForcePasswordSupport(page, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
 }
 
 async function expectSchema(
@@ -73,23 +92,291 @@ async function expectSchema(
     return { body, resp };
 }
 
+type VMBrief = { id: string; name: string; status: string };
+type ActionName = 'start' | 'stop' | 'restart' | 'delete';
+
+function isSeededVMID(vmId: string): boolean {
+    return seededVMIDs.has(vmId.trim());
+}
+
+function isLikelySeededVM(vm: Pick<VMBrief, 'id' | 'name'>): boolean {
+    if (isSeededVMID(vm.id)) {
+        return true;
+    }
+    const vmName = vm.name.trim().toLowerCase();
+    return vmName !== '' && seededVMNames.has(vmName);
+}
+
+function pickIDByPreferredName(
+    items: Array<{ id?: string; name?: string }> | undefined,
+    preferredName: string
+): string {
+    const list = items ?? [];
+    const exact = list.find((item) => (item.name ?? '').trim() === preferredName && item.id);
+    if (exact?.id) return exact.id;
+    const first = list.find((item) => Boolean(item.id));
+    return first?.id ?? '';
+}
+
+function pickPreferredNamespace(namespaces: string[] | undefined, preferred: string): string {
+    const list = (namespaces ?? []).map((ns) => ns.trim()).filter(Boolean);
+    if (list.includes(preferred)) return preferred;
+    return list[0] ?? preferred;
+}
+
+async function getAdminHeaders(request: APIRequestContext): Promise<{ Authorization: string }> {
+    const auth = await getApiTokenWithForcePasswordSupport(request, {
+        username: e2eUsername,
+        primaryPassword: e2ePassword,
+        secondaryPassword: e2eNewPassword,
+        currentPasswordHint: activePassword,
+    });
+    activePassword = auth.password;
+    return { Authorization: `Bearer ${auth.token}` };
+}
+
+async function listVMBriefs(request: APIRequestContext, headers: { Authorization: string }): Promise<VMBrief[]> {
+    const vmMap = new Map<string, VMBrief>();
+    let pageNum = 1;
+    let totalPages = 1;
+
+    do {
+        const vmResp = await request.get(`/api/v1/vms?page=${pageNum}&per_page=100`, { headers });
+        expect(vmResp.status(), `GET /vms?page=${pageNum} returned ${vmResp.status()}`).toBe(200);
+        const vmBody = await validateApiResponse('VMList', vmResp) as {
+            items?: Array<{ id?: string; name?: string; status?: string }>;
+            pagination?: { total_pages?: number };
+        };
+        for (const item of vmBody.items ?? []) {
+            if (!item.id) {
+                continue;
+            }
+            vmMap.set(item.id, {
+                id: item.id,
+                name: item.name ?? '',
+                status: (item.status ?? '').toUpperCase(),
+            });
+        }
+        totalPages = Number(vmBody.pagination?.total_pages ?? 1) || 1;
+        pageNum += 1;
+    } while (pageNum <= totalPages);
+
+    return Array.from(vmMap.values());
+}
+
+async function waitForVMStatus(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    vmId: string,
+    expected: 'RUNNING' | 'STOPPED'
+): Promise<void> {
+    await expect.poll(async () => {
+        const vmResp = await request.get(`/api/v1/vms/${vmId}`, { headers });
+        if (vmResp.status() !== 200) return `HTTP_${vmResp.status()}`;
+        const vmBody = await validateApiResponse('VM', vmResp) as { status?: string };
+        return (vmBody.status ?? '').toUpperCase();
+    }, {
+        timeout: 120_000,
+        intervals: [1000, 2000, 4000, 8000],
+        message: `VM ${vmId} did not reach ${expected}`,
+    }).toBe(expected);
+}
+
+async function pickNonSeededVM(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    preferredStatus?: 'RUNNING' | 'STOPPED'
+): Promise<VMBrief> {
+    const vms = await listVMBriefs(request, headers);
+    const real = vms.filter((vm) => !isLikelySeededVM(vm));
+    expect(real.length, 'No non-seeded VM available for vm-lifecycle action').toBeGreaterThan(0);
+    if (preferredStatus) {
+        const hit = real.find((vm) => vm.status === preferredStatus);
+        if (hit) return hit;
+    }
+    return real[0];
+}
+
+async function ensureVMReadyForAction(
+    request: APIRequestContext,
+    headers: { Authorization: string },
+    action: 'start' | 'stop' | 'restart',
+    preferredVMID?: string
+): Promise<string> {
+    const targetStatus = action === 'start' ? 'STOPPED' : 'RUNNING';
+    const vmList = await listVMBriefs(request, headers);
+    const preferredVM = preferredVMID ? vmList.find((vm) => vm.id === preferredVMID) : undefined;
+    const vm = preferredVM ?? (await pickNonSeededVM(request, headers, targetStatus));
+    if (vm.status === targetStatus) {
+        return vm.id;
+    }
+
+    if (targetStatus === 'STOPPED') {
+        const stopResp = await request.post(`/api/v1/vms/${vm.id}/stop`, { headers });
+        expect([202, 409], `pre-stop /vms/${vm.id}/stop returned ${stopResp.status()}`).toContain(stopResp.status());
+        await waitForVMStatus(request, headers, vm.id, 'STOPPED');
+        return vm.id;
+    }
+
+    const startResp = await request.post(`/api/v1/vms/${vm.id}/start`, { headers });
+    expect([202, 409], `pre-start /vms/${vm.id}/start returned ${startResp.status()}`).toContain(startResp.status());
+    await waitForVMStatus(request, headers, vm.id, 'RUNNING');
+    return vm.id;
+}
+
+async function resolveApprovalClusterID(request: APIRequestContext, headers: { Authorization: string }): Promise<string> {
+    const clustersResp = await request.get('/api/v1/admin/clusters?page=1&per_page=100', { headers });
+    expect(clustersResp.status(), `GET /admin/clusters returned ${clustersResp.status()}`).toBe(200);
+    const clustersBody = await validateApiResponse('ClusterList', clustersResp) as {
+        items?: Array<{ id?: string; status?: string; enabled?: boolean }>;
+    };
+    const clusters = clustersBody.items ?? [];
+    const healthy = clusters.find((cluster) => cluster.id && cluster.enabled !== false && (cluster.status ?? '').toUpperCase() === 'HEALTHY');
+    if (healthy?.id) return healthy.id;
+    const enabled = clusters.find((cluster) => cluster.id && cluster.enabled !== false);
+    return enabled?.id ?? '';
+}
+
+async function resolveCreateVMRequestData(
+    request: APIRequestContext,
+    headers: { Authorization: string }
+): Promise<{ service_id: string; template_id: string; instance_size_id: string; namespace: string }> {
+    const systemsResp = await request.get('/api/v1/systems', { headers });
+    expect(systemsResp.status(), `GET /systems returned ${systemsResp.status()}`).toBe(200);
+    const systems = await validateApiResponse('SystemList', systemsResp) as { items?: Array<{ id?: string; name?: string }> };
+    const systemID = pickIDByPreferredName(systems.items, e2eSystemName);
+    expect(systemID, 'VM lifecycle setup requires at least one system').toBeTruthy();
+
+    const [servicesResp, contextResp] = await Promise.all([
+        request.get(`/api/v1/systems/${systemID}/services`, { headers }),
+        request.get('/api/v1/vms/request-context', { headers }),
+    ]);
+    expect(servicesResp.status(), `GET /systems/${systemID}/services returned ${servicesResp.status()}`).toBe(200);
+    expect(contextResp.status(), `GET /vms/request-context returned ${contextResp.status()}`).toBe(200);
+
+    const services = await validateApiResponse('ServiceList', servicesResp) as { items?: Array<{ id?: string; name?: string }> };
+    const ctx = await validateApiResponse('VMRequestContext', contextResp) as {
+        templates?: Array<{ id?: string; name?: string }>;
+        instance_sizes?: Array<{ id?: string; name?: string }>;
+        namespaces?: string[];
+    };
+
+    const serviceID = pickIDByPreferredName(services.items, e2eServiceName);
+    const templateID = pickIDByPreferredName(ctx.templates, e2eTemplateName);
+    const sizeID = pickIDByPreferredName(ctx.instance_sizes, e2eSizeName);
+    const namespace = pickPreferredNamespace(ctx.namespaces, e2eNamespace);
+    expect(serviceID, 'VM lifecycle setup requires a service').toBeTruthy();
+    expect(templateID, 'VM lifecycle setup requires a template').toBeTruthy();
+    expect(sizeID, 'VM lifecycle setup requires an instance size').toBeTruthy();
+
+    return {
+        service_id: serviceID,
+        template_id: templateID,
+        instance_size_id: sizeID,
+        namespace,
+    };
+}
+
+async function submitOrReusePendingCreateTicket(
+    request: APIRequestContext,
+    headers: { Authorization: string }
+): Promise<string> {
+    const createReqData = await resolveCreateVMRequestData(request, headers);
+    const createResp = await request.post('/api/v1/vms/request', {
+        headers,
+        data: { ...createReqData, reason: `vm-lifecycle setup ${Date.now()}` },
+    });
+    if (createResp.status() === 202) {
+        const ticket = await validateApiResponse('ApprovalTicketResponse', createResp) as { ticket_id?: string; id?: string };
+        const ticketID = ticket.ticket_id ?? ticket.id ?? '';
+        expect(ticketID, 'ApprovalTicketResponse missing ticket id').toBeTruthy();
+        return ticketID;
+    }
+    if (createResp.status() === 400) {
+        const errBody = await validateApiResponse('Error', createResp) as {
+            code?: string;
+            params?: Record<string, unknown>;
+            message?: string;
+        };
+        const existingTicketID =
+            typeof errBody.params?.existing_ticket_id === 'string' ? errBody.params.existing_ticket_id.trim() : '';
+        if (errBody.code === 'DUPLICATE_PENDING_REQUEST' && existingTicketID) {
+            return existingTicketID;
+        }
+        throw new Error(
+            `POST /vms/request failed in vm-lifecycle setup: ${errBody.code ?? 'UNKNOWN'} (${errBody.message ?? 'no message'})`
+        );
+    }
+    throw new Error(`POST /vms/request returned unexpected status ${createResp.status()} in vm-lifecycle setup`);
+}
+
+async function ensureRealVMForLifecycle(request: APIRequestContext): Promise<string> {
+    const headers = await getAdminHeaders(request);
+    const existing = await listVMBriefs(request, headers);
+    const existingReal = existing.find((vm) => !isLikelySeededVM(vm));
+    if (existingReal?.id) {
+        return existingReal.id;
+    }
+
+    const approvalsResp = await request.get('/api/v1/approvals?page=1&per_page=100', { headers });
+    expect(approvalsResp.status(), `GET /approvals returned ${approvalsResp.status()}`).toBe(200);
+    const approvals = await validateApiResponse('ApprovalTicketList', approvalsResp) as {
+        items?: Array<{ id?: string; status?: string; operation_type?: string; operationType?: string }>;
+    };
+    const pendingCreate = (approvals.items ?? []).find((item) =>
+        Boolean(item.id) &&
+        (item.id ?? '').startsWith('tkt-batch-') &&
+        (item.status ?? '').toUpperCase() === 'PENDING' &&
+        ((item.operation_type ?? item.operationType ?? '').toUpperCase() === 'CREATE')
+    );
+    const ticketID = pendingCreate?.id ?? await submitOrReusePendingCreateTicket(request, headers);
+    expect(ticketID, 'VM lifecycle setup requires a pending CREATE ticket').toBeTruthy();
+
+    const clusterID = await resolveApprovalClusterID(request, headers);
+    expect(clusterID, 'VM lifecycle setup requires at least one enabled cluster').toBeTruthy();
+
+    const approveResp = await request.post(`/api/v1/approvals/${ticketID}/approve`, {
+        headers,
+        data: { selected_cluster_id: clusterID },
+    });
+    expect(
+        [204, 409],
+        `POST /approvals/${ticketID}/approve returned ${approveResp.status()} during vm-lifecycle setup`
+    ).toContain(approveResp.status());
+
+    await expect.poll(async () => {
+        const vms = await listVMBriefs(request, headers);
+        return vms.filter((vm) => !isLikelySeededVM(vm)).length;
+    }, {
+        timeout: 120_000,
+        intervals: [1000, 2000, 4000, 8000],
+        message: 'vm-lifecycle setup did not produce a non-seeded VM after approval',
+    }).toBeGreaterThan(0);
+
+    const real = await pickNonSeededVM(request, headers);
+    return real.id;
+}
+
 // ── Helpers: get first VM ID from list ───────────────────────────────────────
 
 async function getFirstVMId(page: Page): Promise<string> {
     const listRespPromise = page.waitForResponse(
         (r) => urlPathIncludes(r.url(), '/api/v1/vms') && r.request().method() === 'GET' && !urlPathIncludes(r.url(), '/vms/')
     );
-    await page.goto('/vms');
-    await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-    const listResp = await listRespPromise;
+    const [listResp] = await Promise.all([
+        listRespPromise,
+        page.goto('/vms'),
+    ]);
     expect(listResp.status(), `GET /vms returned ${listResp.status()}`).toBe(200);
     // validateApiResponse returns the parsed body — reuse it to avoid double-read
     // (Playwright response body can only be consumed once; a second .json() call
     //  may throw "Protocol error: No resource with given identifier found").
     const body = await validateApiResponse('VMList', listResp) as { items?: Array<{ id?: string }> };
+    await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
     const items = body.items ?? [];
     expect(items.length, 'No VMs exist — seed data must include at least one VM').toBeGreaterThan(0);
-    const id = items[0]?.id ?? '';
+    const preferred = items.find((item) => item.id && !isSeededVMID(item.id))?.id ?? '';
+    const id = preferred || (items[0]?.id ?? '');
     expect(id, 'First VM has no id field').toBeTruthy();
     return id;
 }
@@ -97,6 +384,18 @@ async function getFirstVMId(page: Page): Promise<string> {
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
+    test.beforeAll(async ({ request }) => {
+        const setup = await ensureBatchSubmitPolicyForUser(request, {
+            username: e2eUsername,
+            primaryPassword: e2ePassword,
+            secondaryPassword: e2eNewPassword,
+            currentPasswordHint: activePassword,
+            reasonPrefix: 'vm-lifecycle live',
+        });
+        activePassword = setup.password;
+        lifecycleVMID = await ensureRealVMForLifecycle(request);
+    });
+
     test.beforeEach(async ({ page }) => {
         await page.addInitScript(() => { window.open = () => null; });
         await login(page);
@@ -119,91 +418,66 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
 
     // ── startVM: POST /vms/{id}/start → 202 ──────────────────────────────────
 
-    test('startVM – POST /vms/{id}/start returns 202', async ({ page }) => {
+    test('startVM – POST /vms/{id}/start returns 202', async ({ page, request }) => {
         // operationId: startVM
-        await page.goto('/vms');
-        await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-
-        // Find a stopped VM
-        const stoppedRow = page.locator('tr').filter({ hasText: /stopped/i }).first();
-        await expect(stoppedRow, 'No stopped VM found — seed data must include a stopped VM').toBeVisible();
-
-        const vmTestId = await stoppedRow.locator('[data-testid^="vm-action-start-"]').first().getAttribute('data-testid');
-        const vmId = vmTestId?.replace('vm-action-start-', '') ?? '';
-        expect(vmId, 'Could not extract VM id from start button').toBeTruthy();
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'start', lifecycleVMID);
+        await page.goto(`/vms/${vmId}`);
+        await expect(page.locator('body')).toBeVisible();
 
         const startRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/start`) && r.request().method() === 'POST'
         );
-        await stoppedRow.locator(`[data-testid="vm-action-start-${vmId}"]`).click();
-        // Confirm dialog if present
-        const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
-            .getByRole('button', { name: /confirm|ok|start/i }).first();
-        if (await confirmBtn.count() > 0) await confirmBtn.click();
-
-        const startResp = await startRespPromise;
+        const startStatusPromise = fetchStatusWithStoredToken(page, `/api/v1/vms/${vmId}/start`, 'POST');
+        const [startResp, startStatus] = await Promise.all([startRespPromise, startStatusPromise]);
+        expect(startStatus, `POST /vms/${vmId}/start returned ${startStatus}`).toBe(202);
         expect(startResp.status(), `POST /vms/${vmId}/start returned ${startResp.status()}`).toBe(202);
         // spec: 202 has no response body schema — just verify status
     });
 
     // ── stopVM: POST /vms/{id}/stop → 202 ────────────────────────────────────
 
-    test('stopVM – POST /vms/{id}/stop returns 202', async ({ page }) => {
+    test('stopVM – POST /vms/{id}/stop returns 202', async ({ page, request }) => {
         // operationId: stopVM
-        await page.goto('/vms');
-        await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-
-        // Find a running VM
-        const runningRow = page.locator('tr').filter({ hasText: /running/i }).first();
-        await expect(runningRow, 'No running VM found — seed data must include a running VM').toBeVisible();
-
-        const vmTestId = await runningRow.locator('[data-testid^="vm-action-stop-"]').first().getAttribute('data-testid');
-        const vmId = vmTestId?.replace('vm-action-stop-', '') ?? '';
-        expect(vmId, 'Could not extract VM id from stop button').toBeTruthy();
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'stop', lifecycleVMID);
+        await page.goto(`/vms/${vmId}`);
+        await expect(page.locator('body')).toBeVisible();
 
         const stopRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/stop`) && r.request().method() === 'POST'
         );
-        await runningRow.locator(`[data-testid="vm-action-stop-${vmId}"]`).click();
-        const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
-            .getByRole('button', { name: /confirm|ok|stop/i }).first();
-        if (await confirmBtn.count() > 0) await confirmBtn.click();
-
-        const stopResp = await stopRespPromise;
+        const stopStatusPromise = fetchStatusWithStoredToken(page, `/api/v1/vms/${vmId}/stop`, 'POST');
+        const [stopResp, stopStatus] = await Promise.all([stopRespPromise, stopStatusPromise]);
+        expect(stopStatus, `POST /vms/${vmId}/stop returned ${stopStatus}`).toBe(202);
         expect(stopResp.status(), `POST /vms/${vmId}/stop returned ${stopResp.status()}`).toBe(202);
     });
 
     // ── restartVM: POST /vms/{id}/restart → 202 ──────────────────────────────
 
-    test('restartVM – POST /vms/{id}/restart returns 202', async ({ page }) => {
+    test('restartVM – POST /vms/{id}/restart returns 202', async ({ page, request }) => {
         // operationId: restartVM
-        await page.goto('/vms');
-        await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-
-        const runningRow = page.locator('tr').filter({ hasText: /running/i }).first();
-        await expect(runningRow, 'No running VM found — seed data must include a running VM').toBeVisible();
-
-        const vmTestId = await runningRow.locator('[data-testid^="vm-action-restart-"]').first().getAttribute('data-testid');
-        const vmId = vmTestId?.replace('vm-action-restart-', '') ?? '';
-        expect(vmId, 'Could not extract VM id from restart button').toBeTruthy();
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'restart', lifecycleVMID);
+        await page.goto(`/vms/${vmId}`);
+        await expect(page.locator('body')).toBeVisible();
 
         const restartRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/restart`) && r.request().method() === 'POST'
         );
-        await runningRow.locator(`[data-testid="vm-action-restart-${vmId}"]`).click();
-        const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
-            .getByRole('button', { name: /confirm|ok|restart/i }).first();
-        if (await confirmBtn.count() > 0) await confirmBtn.click();
-
-        const restartResp = await restartRespPromise;
+        const restartStatusPromise = fetchStatusWithStoredToken(page, `/api/v1/vms/${vmId}/restart`, 'POST');
+        const [restartResp, restartStatus] = await Promise.all([restartRespPromise, restartStatusPromise]);
+        expect(restartStatus, `POST /vms/${vmId}/restart returned ${restartStatus}`).toBe(202);
         expect(restartResp.status(), `POST /vms/${vmId}/restart returned ${restartResp.status()}`).toBe(202);
     });
 
-    // ── powerVM: POST /vms/{id}/power → VM (generic power endpoint) ──────────
+    // ── powerVM: POST /vms/{id}/power → VMPowerAcceptedResponse ───────────────
 
-    test('powerVM – POST /vms/{id}/power conforms to VM schema (202)', async ({ page }) => {
+    test('powerVM – POST /vms/{id}/power conforms to VMPowerAcceptedResponse schema (202)', async ({ page, request }) => {
         // operationId: powerVM — uses the generic /power endpoint from VM detail page
-        const vmId = await getFirstVMId(page);
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'start', lifecycleVMID);
+        const action: ActionName = 'start';
 
         // Navigate to VM detail page where power buttons use POST /vms/{id}/power
         await page.goto(`/vms/${vmId}`);
@@ -214,62 +488,38 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
             (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/power`) && r.request().method() === 'POST'
         );
 
-        // Click any available power button on the detail page (start, stop, or restart)
-        const startBtn = page.getByRole('button', { name: /^start$/i }).first();
-        const stopBtn = page.getByRole('button', { name: /^stop$/i }).first();
-        const restartBtn = page.getByRole('button', { name: /^restart$/i }).first();
-
-        // Try each button in order of safety: restart > stop > start, but wait until one is enabled
-        await expect(async () => {
-            if (!(await restartBtn.isEnabled() || await stopBtn.isEnabled() || await startBtn.isEnabled())) {
-                await page.getByTestId(`vm-console-status-${vmId}`).click({ force: true });
-                throw new Error('No power action button enabled yet');
-            }
-        }).toPass({ timeout: 45000, intervals: [2000, 5000] });
-
-        if (await restartBtn.isEnabled()) {
-            await restartBtn.click();
-        } else if (await stopBtn.isEnabled()) {
-            await stopBtn.click();
-        } else if (await startBtn.isEnabled()) {
-            await startBtn.click();
-        }
+        const powerBtn = page.getByTestId(`vm-action-${action}-${vmId}`);
+        await expect(powerBtn).toBeEnabled();
+        await powerBtn.click();
 
         // Confirm if confirmation dialog appears
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
             .getByRole('button', { name: /confirm|ok|yes/i }).first();
         if (await confirmBtn.count() > 0) await confirmBtn.click();
 
-        // ── CONTRACT CHECK: VM schema (powerVM returns 202 with VM body) ──────────
+        // ── CONTRACT CHECK: VMPowerAcceptedResponse schema ────────────────────────
         const powerResp = await powerRespPromise;
         expect(powerResp.status(), `POST /vms/${vmId}/power returned ${powerResp.status()}`).toBe(202);
-        await validateApiResponse('VM', powerResp);
+        await validateApiResponse('VMPowerAcceptedResponse', powerResp);
     });
 
     // ── deleteVM: DELETE /vms/{id} → DeleteVMResponse ────────────────────────
 
-    test('deleteVM – DELETE /vms/{id} conforms to DeleteVMResponse schema', async ({ page }) => {
+    test('deleteVM – DELETE /vms/{id} conforms to DeleteVMResponse schema', async ({ page, request }) => {
         // operationId: deleteVM
-        await page.goto('/vms');
-        await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-
-        // Find a stopped VM to delete (safer than deleting running)
-        const stoppedRow = page.locator('tr').filter({ hasText: /stopped/i }).last();
-        await expect(stoppedRow, 'No stopped VM found for deletion test').toBeVisible();
-
-        const vmTestId = await stoppedRow.locator('[data-testid^="vm-action-delete-"]').first().getAttribute('data-testid');
-        const vmId = vmTestId?.replace('vm-action-delete-', '') ?? '';
-        expect(vmId, 'Could not extract VM id from delete button').toBeTruthy();
-
-        // Get VM name for confirm_name guard
-        const vmNameCell = stoppedRow.locator('td').nth(1);
-        const vmName = (await vmNameCell.textContent())?.trim() ?? '';
-        expect(vmName, 'Could not read VM name from table row').toBeTruthy();
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'start', lifecycleVMID);
+        const vmName = (await listVMBriefs(request, headers)).find((vm) => vm.id === vmId)?.name?.trim() ?? '';
+        expect(vmName, `Could not resolve VM name for ${vmId}`).toBeTruthy();
+        await page.goto(`/vms/${vmId}`);
+        await expect(page.locator('body')).toBeVisible();
+        const button = page.getByTestId(`vm-action-delete-${vmId}`);
+        await expect(button, `Delete action button not found on VM detail page for ${vmId}`).toBeVisible();
 
         const deleteRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/vms/${vmId}`) && r.request().method() === 'DELETE'
         );
-        await stoppedRow.locator(`[data-testid="vm-action-delete-${vmId}"]`).click();
+        await button.click();
 
         // Fill confirm_name guard (ADR-0015 §13)
         const deleteModal = page.locator('.ant-modal-content').filter({ hasText: /delete/i }).last();
@@ -280,15 +530,10 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         }
         await deleteModal.getByRole('button', { name: /delete|confirm|ok/i }).last().click();
 
-        // ── CONTRACT CHECK: DeleteVMResponse schema ───────────────────────────────
+        // ── CONTRACT CHECK: strict success path (must enqueue deletion) ───────────
         const deleteResp = await deleteRespPromise;
-        expect([202, 409], `DELETE /vms/${vmId} returned unexpected ${deleteResp.status()}`).toContain(deleteResp.status());
-        if (deleteResp.status() === 202) {
-            await validateApiResponse('DeleteVMResponse', deleteResp);
-        } else {
-            // 409 = VM has active console sessions or other conflict — still valid
-            await validateApiResponse('Error', deleteResp);
-        }
+        expect(deleteResp.status(), `DELETE /vms/${vmId} returned unexpected ${deleteResp.status()}`).toBe(202);
+        await validateApiResponse('DeleteVMResponse', deleteResp);
     });
 
     // ── listVMBatches: GET /vms/batch → VMBatchList ─────────────────────────
@@ -299,81 +544,109 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
             (r) => urlPathIncludes(r.url(), '/api/v1/vms/batch') && r.request().method() === 'GET'
                 && !urlPathIncludes(r.url(), '/vms/batch/') // Exclude batch/{id} detail
         );
-        await page.goto('/vms/batch');
+        const [listResp] = await Promise.all([
+            listRespPromise,
+            page.goto('/vms/batch'),
+        ]);
         await expect(page.locator('body')).toBeVisible();
         // ── CONTRACT CHECK: VMBatchList schema ────────────────────────────────────
-        await expectSchema(listRespPromise, 'VMBatchList', 200);
+        expect(listResp.status()).toBe(200);
+        await validateApiResponse('VMBatchList', listResp);
     });
 
     // ── submitVMBatch: POST /vms/batch → VMBatchSubmitResponse ────────────────
 
-    test('submitVMBatch – POST /vms/batch conforms to VMBatchSubmitResponse schema', async ({ page }) => {
+    test('submitVMBatch – POST /vms/batch conforms to VMBatchSubmitResponse schema', async ({ page, request }) => {
         // operationId: submitVMBatch
-        // Navigate to VM batch page
-        await page.goto('/vms/batch');
-        await expect(page.locator('body')).toBeVisible();
+        let batchID = '';
 
-        // Alternatively trigger via VM list batch action
-        await page.goto('/vms');
-        await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
+        await test.step('Stage 5.E / Step 1: select VM targets from list page', async () => {
+            await page.goto('/vms');
+            await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
 
-        // Select all VMs via checkbox
-        const headerCheckbox = page.locator('thead input[type="checkbox"]').first();
-        await expect(headerCheckbox, 'VM list table header checkbox not found').toBeVisible();
-        await headerCheckbox.check();
+            const rowCheckbox = page.locator('tbody input[type="checkbox"]').first();
+            await expect(rowCheckbox, 'No VM row checkbox found for batch action').toBeVisible();
+            await rowCheckbox.check();
+        });
 
-        const batchRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch') && r.request().method() === 'POST'
-        );
+        await test.step('Stage 5.E / Step 2-5: submit batch request and validate accepted payload', async () => {
+            const batchRespPromise = page.waitForResponse(
+                (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch') && r.request().method() === 'POST'
+            );
 
-        // Click generic batch submit (not power-specific)
-        const batchBtn = page.getByRole('button', { name: /batch|submit batch/i }).first();
-        await expect(batchBtn, 'Batch submit button not found in VM list').toBeVisible();
-        await batchBtn.click();
+            // Stage 5.E on list page exposes explicit action buttons (Start/Stop/Restart/Delete Selected).
+            const batchBtn = page.getByRole('button', { name: /delete selected/i }).first();
+            await expect(batchBtn, 'Delete Selected batch button not found in VM list').toBeVisible();
+            await batchBtn.click();
 
-        // ── CONTRACT CHECK: VMBatchSubmitResponse schema ──────────────────────────
-        await expectSchema(batchRespPromise, 'VMBatchSubmitResponse', [202, 400, 429]);
+            const batchResp = await batchRespPromise;
+            expect(batchResp.status(), `POST /vms/batch returned ${batchResp.status()}`).toBe(202);
+            const submitBody = await validateApiResponse('VMBatchSubmitResponse', batchResp) as {
+                batch_id?: string;
+                status?: string;
+                status_url?: string;
+                retry_after_seconds?: unknown;
+            };
+
+            batchID = String(submitBody.batch_id ?? '').trim();
+            const statusURL = String(submitBody.status_url ?? '').trim();
+            expect(batchID, 'submitVMBatch must return batch_id').toBeTruthy();
+            expect(
+                String(submitBody.status ?? '').toUpperCase(),
+                'canonical /vms/batch submit must enter approval queue'
+            ).toBe('PENDING_APPROVAL');
+            expect(statusURL, 'submitVMBatch must return canonical status_url').toBe(`/api/v1/vms/batch/${batchID}`);
+            expect(Number(submitBody.retry_after_seconds), 'retry_after_seconds must be positive').toBeGreaterThan(0);
+        });
+
+        await test.step('Stage 5.E / Step 6: follow status_url and validate parent-child aggregate view', async () => {
+            const headers = await getAdminHeaders(request);
+            const detailResp = await request.get(`/api/v1/vms/batch/${batchID}`, { headers });
+            expect(detailResp.status(), `GET /vms/batch/${batchID} returned ${detailResp.status()}`).toBe(200);
+            const detailBody = await validateApiResponse('VMBatchStatusResponse', detailResp) as {
+                batch_id?: string;
+                operation?: string;
+                child_count?: unknown;
+                success_count?: unknown;
+                failed_count?: unknown;
+                pending_count?: unknown;
+            };
+            expect(detailBody.batch_id).toBe(batchID);
+            expect(String(detailBody.operation ?? '').toUpperCase(), 'Delete Selected should map to DELETE batch op').toBe('DELETE');
+            const childCount = Number(detailBody.child_count ?? 0);
+            const successCount = Number(detailBody.success_count ?? 0);
+            const failedCount = Number(detailBody.failed_count ?? 0);
+            const pendingCount = Number(detailBody.pending_count ?? 0);
+            expect(childCount, 'batch child_count must be positive').toBeGreaterThan(0);
+            expect(successCount + failedCount + pendingCount).toBe(childCount);
+
+            await page.goto('/vms/batch');
+            await expect(page.getByTestId(`batch-action-detail-${batchID}`)).toBeVisible();
+        });
     });
 
     // ── getVMBatch: GET /vms/batch/{id} → VMBatchStatusResponse ──────────────
 
     test('getVMBatch – GET /vms/batch/{id} conforms to VMBatchStatusResponse schema', async ({ page }) => {
         // operationId: getVMBatch
-        // First submit a batch to get a batch_id
-        await page.goto('/vms');
-        await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
-
-        const headerCheckbox = page.locator('thead input[type="checkbox"]').first();
-        await expect(headerCheckbox).toBeVisible();
-        await headerCheckbox.check();
-
-        const submitRespPromise = page.waitForResponse(
-            (r) => urlPathIncludes(r.url(), '/api/v1/vms/batch') && r.request().method() === 'POST'
+        const listRespPromise = page.waitForResponse(
+            (r) => urlPathEndsWith(r.url(), '/api/v1/vms/batch') && r.request().method() === 'GET'
         );
-        const batchBtn = page.getByRole('button', { name: /batch|submit batch/i }).first();
-        await expect(batchBtn).toBeVisible();
-        await batchBtn.click();
-
-        const submitResp = await submitRespPromise;
-        expect([202, 400, 429]).toContain(submitResp.status());
-
-        // Single-read the body (Playwright responses are single-read)
-        const submitBody = await submitResp.json() as { batch_id?: string; message?: string };
-
-        if (submitResp.status() !== 202) {
-            // Can't get batch_id without a successful submit — fail with clear message
-            throw new Error(`POST /vms/batch failed with ${submitResp.status()}: ${submitBody.message ?? JSON.stringify(submitBody)}`);
-        }
-
-        const batchId = submitBody.batch_id ?? '';
-        expect(batchId, 'POST /vms/batch response missing batch_id field').toBeTruthy();
+        const [listResp] = await Promise.all([
+            listRespPromise,
+            page.goto('/vms/batch'),
+        ]);
+        await expect(page.locator('body')).toBeVisible();
+        expect(listResp.status(), `GET /vms/batch returned ${listResp.status()}`).toBe(200);
+        const listBody = await validateApiResponse('VMBatchList', listResp) as { items?: Array<{ id?: string }> };
+        const batchId = listBody.items?.find((item) => Boolean(item.id))?.id ?? '';
+        expect(batchId, 'No VM batch found — seed data must include at least one batch').toBeTruthy();
 
         // ── CONTRACT CHECK: VMBatchStatusResponse schema ──────────────────────────
         const statusRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/vms/batch/${batchId}`) && r.request().method() === 'GET'
         );
-        // Navigate to batch detail page
-        await page.goto(`/vms/batch/${batchId}`);
+        await page.getByTestId(`batch-action-detail-${batchId}`).click();
         await expectSchema(statusRespPromise, 'VMBatchStatusResponse', 200);
     });
 
@@ -381,27 +654,30 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
 
     test('retryVMBatch – POST /vms/batch/{id}/retry conforms to VMBatchActionResponse schema', async ({ page }) => {
         // operationId: retryVMBatch
-        // Navigate to batch list to find a failed batch
         await page.goto('/vms/batch');
         await expect(page.locator('body')).toBeVisible();
 
-        const failedBatchRow = page.locator('tr').filter({ hasText: /failed|partial/i }).first();
-        await expect(failedBatchRow, 'No failed batch found — seed data must include a failed VM batch').toBeVisible();
-
-        const retryTestId = await failedBatchRow.locator('[data-testid^="batch-action-retry-"]').first().getAttribute('data-testid');
+        const retryBtn = page.locator('button[data-testid^="batch-action-retry-"]:not([disabled])').first();
+        await expect(retryBtn, 'No retryable batch found — seed data must include FAILED or PARTIAL_SUCCESS batch').toBeVisible();
+        const retryTestId = await retryBtn.getAttribute('data-testid');
         const batchId = retryTestId?.replace('batch-action-retry-', '') ?? '';
         expect(batchId, 'Could not extract batch_id from retry button').toBeTruthy();
 
         const retryRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/vms/batch/${batchId}/retry`) && r.request().method() === 'POST'
         );
-        await failedBatchRow.locator(`[data-testid="batch-action-retry-${batchId}"]`).click();
+        await retryBtn.click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
             .getByRole('button', { name: /confirm|ok|retry/i }).first();
         if (await confirmBtn.count() > 0) await confirmBtn.click();
 
         // ── CONTRACT CHECK: VMBatchActionResponse schema ──────────────────────────
-        await expectSchema(retryRespPromise, 'VMBatchActionResponse', 200);
+        const { body: retryBody } = await expectSchema(retryRespPromise, 'VMBatchActionResponse', 200);
+        const affected = Number((retryBody as { affected_count?: number }).affected_count ?? 0);
+        expect(
+            affected,
+            'Retry must affect at least one failed child ticket (master-flow Stage 5.E)'
+        ).toBeGreaterThan(0);
     });
 
     // ── cancelVMBatch: POST /vms/batch/{id}/cancel → VMBatchActionResponse ───
@@ -411,46 +687,66 @@ test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
         await page.goto('/vms/batch');
         await expect(page.locator('body')).toBeVisible();
 
-        const pendingBatchRow = page.locator('tr').filter({ hasText: /pending_approval|in_progress/i }).first();
-        await expect(pendingBatchRow, 'No pending/running batch found — seed data must include an active VM batch').toBeVisible();
-
-        const cancelTestId = await pendingBatchRow.locator('[data-testid^="batch-action-cancel-"]').first().getAttribute('data-testid');
+        const cancelBtn = page.locator('button[data-testid^="batch-action-cancel-"]:not([disabled])').first();
+        await expect(cancelBtn, 'No cancellable batch found — seed data must include PENDING_APPROVAL or IN_PROGRESS batch').toBeVisible();
+        const cancelTestId = await cancelBtn.getAttribute('data-testid');
         const batchId = cancelTestId?.replace('batch-action-cancel-', '') ?? '';
         expect(batchId, 'Could not extract batch_id from cancel button').toBeTruthy();
 
         const cancelRespPromise = page.waitForResponse(
             (r) => urlPathEndsWith(r.url(), `/api/v1/vms/batch/${batchId}/cancel`) && r.request().method() === 'POST'
         );
-        await pendingBatchRow.locator(`[data-testid="batch-action-cancel-${batchId}"]`).click();
+        await cancelBtn.click();
         const confirmBtn = page.locator('.ant-popover:visible, .ant-modal-content:visible')
             .getByRole('button', { name: /confirm|ok|cancel/i }).first();
         if (await confirmBtn.count() > 0) await confirmBtn.click();
 
         // ── CONTRACT CHECK: VMBatchActionResponse schema ──────────────────────────
-        await expectSchema(cancelRespPromise, 'VMBatchActionResponse', 200);
+        const { body: cancelBody } = await expectSchema(cancelRespPromise, 'VMBatchActionResponse', 200);
+        const affected = Number((cancelBody as { affected_count?: number }).affected_count ?? 0);
+        expect(
+            affected,
+            'Cancel must affect at least one pending child ticket (master-flow Stage 5.E)'
+        ).toBeGreaterThan(0);
     });
 
     // ── getVMConsoleStatus: GET /vms/{id}/console/status → VMConsoleStatusResponse
 
-    test('getVMConsoleStatus – GET /vms/{id}/console/status conforms to VMConsoleStatusResponse schema', async ({ page }) => {
+    test('getVMConsoleStatus – RUNNING VM returns VMConsoleStatusResponse (200)', async ({ page, request }) => {
         // operationId: getVMConsoleStatus
-        const vmId = await getFirstVMId(page);
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'stop', lifecycleVMID || undefined);
 
         // Navigate to VM detail which should show console status
-        const statusRespPromise = page.waitForResponse(
-            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/console/status`) && r.request().method() === 'GET'
-        );
         await page.goto(`/vms/${vmId}`);
         await expect(page.locator('body')).toBeVisible();
 
-        // Trigger console status check via UI / direct fetch since explicit button is gone
-        await page.evaluate((id) => {
-            fetch(`/api/v1/vms/${id}/console/status`);
-        }, vmId);
-
+        // Trigger console status check explicitly and wait for the exact response.
+        const statusRespPromise = page.waitForResponse(
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/console/status`) && r.request().method() === 'GET'
+        );
+        const statusCode = await fetchStatusWithStoredToken(page, `/api/v1/vms/${vmId}/console/status`, 'GET');
         const statusResp = await statusRespPromise;
+        expect(statusCode, `GET /vms/${vmId}/console/status returned ${statusCode}`).toBe(200);
         expect(statusResp.status(), `GET /vms/${vmId}/console/status returned ${statusResp.status()}`).toBe(200);
-        // ── CONTRACT CHECK: VMConsoleStatusResponse schema ────────────────────────
         await validateApiResponse('VMConsoleStatusResponse', statusResp);
+    });
+
+    test('getVMConsoleStatus – non-RUNNING VM returns conflict Error (409)', async ({ page, request }) => {
+        // operationId: getVMConsoleStatus
+        const headers = await getAdminHeaders(request);
+        const vmId = await ensureVMReadyForAction(request, headers, 'start', lifecycleVMID || undefined);
+
+        await page.goto(`/vms/${vmId}`);
+        await expect(page.locator('body')).toBeVisible();
+
+        const statusRespPromise = page.waitForResponse(
+            (r) => urlPathEndsWith(r.url(), `/api/v1/vms/${vmId}/console/status`) && r.request().method() === 'GET'
+        );
+        const statusCode = await fetchStatusWithStoredToken(page, `/api/v1/vms/${vmId}/console/status`, 'GET');
+        const statusResp = await statusRespPromise;
+        expect(statusCode, `GET /vms/${vmId}/console/status returned ${statusCode}`).toBe(409);
+        expect(statusResp.status(), `GET /vms/${vmId}/console/status returned ${statusResp.status()}`).toBe(409);
+        await validateApiResponse('Error', statusResp);
     });
 });


### PR DESCRIPTION
## Summary

- stabilize live Playwright flows and selectors across master-flow/admin/user scenarios
- harden live e2e runner scripts and Playwright live config behavior
- enhance `cmd/e2e-seed` to support kubeconfig-driven cluster API server/status seeding
- update `docs/design/traceability/master-flow-tests.json` to keep stage-to-test evidence aligned

## Best-practice verification (Context7)

- Go testing for env-dependent helpers (`t.Setenv`, explicit error-path assertions) aligned with `/golang/go` testing patterns

## Validation

- [x] `go test ./cmd/e2e-seed/...`
- [x] `TEST_GUARD_BASE_REF=origin/main TEST_GUARD_INCLUDE_WORKTREE=0 bash docs/design/ci/scripts/check_changed_code_has_tests.sh`
- [x] `go run docs/design/ci/scripts/check_master_flow_test_matrix.go`
- [x] `bash docs/design/ci/scripts/check_live_e2e_no_mock.sh`
- [x] `cd web && npm run lint`

## Issue

Closes #310
Refs #246
