### PR TITLE
chore(config-seed): finalize config typing and seed logger cleanup

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -36,10 +36,10 @@ func run() error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	if err := logger.Init(cfg.Log.Level, cfg.Log.Format); err != nil {
-		return fmt.Errorf("init logger: %w", err)
+	if initErr := logger.Init(cfg.Log.Level, cfg.Log.Format); initErr != nil {
+		return fmt.Errorf("init logger: %w", initErr)
 	}
-	defer logger.Sync()
+	defer func() { _ = logger.Sync() }()
 
 	ctx := context.Background()
 

--- a/cmd/seed/main_test.go
+++ b/cmd/seed/main_test.go
@@ -82,3 +82,22 @@ func TestBuiltInRoles_CanonicalPermissionSets(t *testing.T) {
 	assertHasPerm("role-operator", "vm:operate", "vm:create", "vm:read", "vnc:access")
 	assertHasPerm("role-viewer", "vm:read", "system:read", "service:read")
 }
+
+func TestBuiltInRoles_MetadataCompleteness(t *testing.T) {
+	t.Parallel()
+
+	for _, role := range builtInRoles() {
+		if strings.TrimSpace(role.Name) == "" {
+			t.Fatalf("role %s has empty Name", role.ID)
+		}
+		if strings.TrimSpace(role.DisplayName) == "" {
+			t.Fatalf("role %s has empty DisplayName", role.ID)
+		}
+		if strings.TrimSpace(role.Description) == "" {
+			t.Fatalf("role %s has empty Description", role.ID)
+		}
+		if len(role.Permissions) == 0 {
+			t.Fatalf("role %s has no permissions", role.ID)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -52,7 +53,7 @@ type DatabaseConfig struct {
 	Host     string `mapstructure:"host"`
 	Port     int    `mapstructure:"port"`
 	User     string `mapstructure:"user"`
-	Password string `mapstructure:"password"`
+	Password string `mapstructure:"password"` //nolint:gosec // Configuration schema intentionally models a credential field.
 	Database string `mapstructure:"database"`
 	SSLMode  string `mapstructure:"sslmode"`
 
@@ -92,7 +93,7 @@ type SessionConfig struct {
 	IdleTimeout time.Duration `mapstructure:"idle_timeout"`
 	Cookie      string        `mapstructure:"cookie"`
 	Secure      bool          `mapstructure:"secure"`
-	HttpOnly    bool          `mapstructure:"http_only"`
+	HTTPOnly    bool          `mapstructure:"http_only"`
 }
 
 // K8sConfig contains Kubernetes operation settings.
@@ -117,7 +118,7 @@ type RiverConfig struct {
 // ADR-0025: Auto-generate secrets on first boot if missing.
 type SecurityConfig struct {
 	EncryptionKey       string         `mapstructure:"encryption_key"`
-	SessionSecret       string         `mapstructure:"session_secret"`
+	SessionSecret       string         `mapstructure:"session_secret"` //nolint:gosec // Configuration schema intentionally models a secret field.
 	JWTVerificationKeys []string       `mapstructure:"jwt_verification_keys"`
 	PasswordPolicy      PasswordPolicy `mapstructure:"password_policy"`
 }
@@ -163,7 +164,8 @@ func Load() (*Config, error) {
 	setDefaults(v)
 
 	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+		var notFoundErr viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFoundErr) {
 			return nil, fmt.Errorf("read config: %w", err)
 		}
 		// Config file is optional, use defaults and env vars

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,6 +66,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.Security.PasswordPolicy.Mode != "nist" {
 		t.Errorf("PasswordPolicy.Mode = %q, want nist", cfg.Security.PasswordPolicy.Mode)
 	}
+	if !cfg.Session.HTTPOnly {
+		t.Errorf("Session.HTTPOnly = %v, want true", cfg.Session.HTTPOnly)
+	}
 
 	// Worker pool defaults
 	if cfg.Worker.GeneralPoolSize != 100 {
@@ -163,5 +166,17 @@ func TestLoad_ServerCORSFlagsFromEnv(t *testing.T) {
 	}
 	if !cfg.Server.UnsafeAllowAllOrigins {
 		t.Fatalf("Server.UnsafeAllowAllOrigins = %v, want true", cfg.Server.UnsafeAllowAllOrigins)
+	}
+}
+
+func TestLoad_SessionHTTPOnlyFromEnv(t *testing.T) {
+	t.Setenv("SESSION_HTTP_ONLY", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Session.HTTPOnly {
+		t.Fatalf("Session.HTTPOnly = %v, want false", cfg.Session.HTTPOnly)
 	}
 }


### PR DESCRIPTION
## Summary

- switch config optional-file detection to `errors.As` for robust wrapped-error handling
- keep `Session.HTTPOnly` naming consistent with Go style while preserving `session.http_only` mapping
- add explicit security-field lint annotations for config schema fields
- harden `cmd/seed` logger init/sync error handling and add package-level coverage updates

## Best-practice verification (Context7)

- Go wrapped error handling and test patterns reviewed against `/golang/go` references; `errors.As` usage aligns with standard-library style for typed wrapped errors

## Validation

- [x] `go test ./cmd/seed/... ./internal/config/...`
- [x] `TEST_GUARD_BASE_REF=origin/main TEST_GUARD_INCLUDE_WORKTREE=0 bash docs/design/ci/scripts/check_changed_code_has_tests.sh`

## Issue

Closes #312
Refs #246
