### PR TITLE
feat(provider): add CDI provisioning query surface

### DIFF
--- a/internal/domain/domain_models_test.go
+++ b/internal/domain/domain_models_test.go
@@ -1,0 +1,38 @@
+package domain
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProvisioningTypesJSON_ExposeVolumeModeAndStorageProfileFields(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(struct {
+		PVC     PersistentVolumeClaim `json:"pvc"`
+		Profile StorageProfile        `json:"profile"`
+	}{
+		PVC: PersistentVolumeClaim{
+			Name:             "golden",
+			Namespace:        "images",
+			VolumeMode:       "Block",
+			StorageClassName: "fast-sc",
+		},
+		Profile: StorageProfile{
+			Name:              "fast-sc",
+			CloneStrategy:     "copy",
+			DefaultVolumeMode: "Filesystem",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal(provisioning models) error = %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, `"volume_mode":"Block"`) {
+		t.Fatalf("Marshal(provisioning models) = %s, want volume_mode", body)
+	}
+	if !strings.Contains(body, `"clone_strategy":"copy"`) {
+		t.Fatalf("Marshal(provisioning models) = %s, want clone_strategy", body)
+	}
+}

--- a/internal/domain/provisioning.go
+++ b/internal/domain/provisioning.go
@@ -1,0 +1,70 @@
+package domain
+
+import "time"
+
+// ObjectReference identifies a Kubernetes object for event correlation.
+type ObjectReference struct {
+	Kind      string
+	Name      string
+	Namespace string
+	UID       string
+}
+
+// ProvisioningCondition is a normalized condition for CDI-backed boot workflows.
+type ProvisioningCondition struct {
+	Type               string    `json:"type"`
+	Status             string    `json:"status"`
+	Reason             string    `json:"reason,omitempty"`
+	Message            string    `json:"message,omitempty"`
+	LastTransitionTime time.Time `json:"last_transition_time,omitempty"`
+}
+
+// ProvisioningEvent summarizes a Kubernetes Event relevant to VM provisioning.
+type ProvisioningEvent struct {
+	Type          string    `json:"type,omitempty"`
+	Reason        string    `json:"reason,omitempty"`
+	Message       string    `json:"message,omitempty"`
+	Count         int32     `json:"count,omitempty"`
+	FirstObserved time.Time `json:"first_observed,omitempty"`
+	LastObserved  time.Time `json:"last_observed,omitempty"`
+}
+
+// DataVolume models the subset of CDI DataVolume state needed by the platform.
+type DataVolume struct {
+	Name         string                  `json:"name"`
+	Namespace    string                  `json:"namespace"`
+	UID          string                  `json:"uid,omitempty"`
+	ClaimName    string                  `json:"claim_name,omitempty"`
+	Phase        string                  `json:"phase,omitempty"`
+	Progress     string                  `json:"progress,omitempty"`
+	RestartCount int32                   `json:"restart_count,omitempty"`
+	Conditions   []ProvisioningCondition `json:"conditions,omitempty"`
+}
+
+// PersistentVolumeClaim models the subset of PVC state needed for observability.
+type PersistentVolumeClaim struct {
+	Name                  string `json:"name"`
+	Namespace             string `json:"namespace"`
+	Phase                 string `json:"phase,omitempty"`
+	StorageClassName      string `json:"storage_class_name,omitempty"`
+	VolumeMode            string `json:"volume_mode,omitempty"`
+	RequestedStorageBytes int64  `json:"requested_storage_bytes,omitempty"`
+	CapacityBytes         int64  `json:"capacity_bytes,omitempty"`
+	CloneType             string `json:"clone_type,omitempty"`
+	ClonePhase            string `json:"clone_phase,omitempty"`
+	CloneFallbackReason   string `json:"clone_fallback_reason,omitempty"`
+}
+
+// StorageClass models the subset of StorageClass state needed for clone-expansion preflight.
+type StorageClass struct {
+	Name                 string `json:"name"`
+	AllowVolumeExpansion bool   `json:"allow_volume_expansion,omitempty"`
+}
+
+// StorageProfile models the subset of CDI StorageProfile state needed for
+// non-blocking clone advisories.
+type StorageProfile struct {
+	Name              string `json:"name"`
+	CloneStrategy     string `json:"clone_strategy,omitempty"`
+	DefaultVolumeMode string `json:"default_volume_mode,omitempty"`
+}

--- a/internal/provider/capability_test.go
+++ b/internal/provider/capability_test.go
@@ -246,10 +246,15 @@ type stubClusterClient struct {
 	kvCR KubeVirtCRClient
 }
 
-func (s *stubClusterClient) VM() VirtualMachineClient          { return nil }
-func (s *stubClusterClient) VMI() VirtualMachineInstanceClient { return nil }
-func (s *stubClusterClient) SSA() DynamicSSAClient             { return nil }
-func (s *stubClusterClient) KubeVirt() KubeVirtCRClient        { return s.kvCR }
+func (s *stubClusterClient) VM() VirtualMachineClient             { return nil }
+func (s *stubClusterClient) VMI() VirtualMachineInstanceClient    { return nil }
+func (s *stubClusterClient) DataVolume() DataVolumeClient         { return nil }
+func (s *stubClusterClient) StorageProfile() StorageProfileClient { return nil }
+func (s *stubClusterClient) PVC() PersistentVolumeClaimClient     { return nil }
+func (s *stubClusterClient) StorageClass() StorageClassClient     { return nil }
+func (s *stubClusterClient) Events() EventClient                  { return nil }
+func (s *stubClusterClient) SSA() DynamicSSAClient                { return nil }
+func (s *stubClusterClient) KubeVirt() KubeVirtCRClient           { return s.kvCR }
 
 func TestCapabilityDetector_Detect_MergesGAAndExplicitGates(t *testing.T) {
 	t.Parallel()

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -3,9 +3,12 @@ package provider
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 // DynamicSSAClient submits unstructured resources via Server-Side Apply.
@@ -47,6 +50,32 @@ type VirtualMachineInstanceClient interface {
 	Unpause(ctx context.Context, namespace, name string, opts *kubevirtv1.UnpauseOptions) error
 }
 
+// DataVolumeClient abstracts CDI DataVolume read operations.
+type DataVolumeClient interface {
+	Get(ctx context.Context, namespace, name string, opts k8smetav1.GetOptions) (*cdiv1beta1.DataVolume, error)
+	List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*cdiv1beta1.DataVolumeList, error)
+}
+
+// StorageProfileClient abstracts CDI StorageProfile reads.
+type StorageProfileClient interface {
+	Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*cdiv1beta1.StorageProfile, error)
+}
+
+// PersistentVolumeClaimClient abstracts PVC read operations.
+type PersistentVolumeClaimClient interface {
+	Get(ctx context.Context, namespace, name string, opts k8smetav1.GetOptions) (*corev1.PersistentVolumeClaim, error)
+}
+
+// StorageClassClient abstracts cluster-scoped StorageClass reads.
+type StorageClassClient interface {
+	Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*storagev1.StorageClass, error)
+}
+
+// EventClient abstracts namespace-scoped Kubernetes Event reads.
+type EventClient interface {
+	List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*corev1.EventList, error)
+}
+
 // KubeVirtCRClient provides access to the cluster-scoped KubeVirt CR.
 // Used by CapabilityDetector to fetch enabled feature gates and running version (ADR-0014).
 //
@@ -71,8 +100,13 @@ type KubeVirtCRClient interface {
 type KubeVirtClusterClient interface {
 	VM() VirtualMachineClient          // Read + lifecycle (type-safe)
 	VMI() VirtualMachineInstanceClient // VMI read + pause/unpause
-	SSA() DynamicSSAClient             // Write: CreateVM/UpdateVM (Unstructured SSA, ADR-0011)
-	KubeVirt() KubeVirtCRClient        // KubeVirt CR access for capability detection (ADR-0014)
+	DataVolume() DataVolumeClient      // CDI DataVolume reads for provisioning observability
+	StorageProfile() StorageProfileClient
+	PVC() PersistentVolumeClaimClient // PVC reads for provisioning observability
+	StorageClass() StorageClassClient // StorageClass reads for clone expansion preflight
+	Events() EventClient              // CoreV1 Events for best-effort failure summaries
+	SSA() DynamicSSAClient            // Write: CreateVM/UpdateVM (Unstructured SSA, ADR-0011)
+	KubeVirt() KubeVirtCRClient       // KubeVirt CR access for capability detection (ADR-0014)
 }
 
 // ClusterClientFactory creates KubeVirtClusterClient for a given cluster name.

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -36,6 +36,15 @@ type InfrastructureProvider interface {
 	ValidateSpec(ctx context.Context, cluster, namespace string, spec *domain.VMSpec) (*domain.ValidationResult, error)
 }
 
+// ProvisioningQueryProvider exposes CDI/PVC/event read paths used for boot-disk observability.
+type ProvisioningQueryProvider interface {
+	GetDataVolume(ctx context.Context, cluster, namespace, name string) (*domain.DataVolume, error)
+	GetPersistentVolumeClaim(ctx context.Context, cluster, namespace, name string) (*domain.PersistentVolumeClaim, error)
+	GetStorageClass(ctx context.Context, cluster, name string) (*domain.StorageClass, error)
+	GetStorageProfile(ctx context.Context, cluster, name string) (*domain.StorageProfile, error)
+	ListEventsForObject(ctx context.Context, cluster string, ref domain.ObjectReference) ([]domain.ProvisioningEvent, error)
+}
+
 // SnapshotProvider provides snapshot capabilities (RFC-0013).
 type SnapshotProvider interface {
 	CreateSnapshot(ctx context.Context, cluster, namespace, vmName, snapshotName string) (*domain.Snapshot, error)

--- a/internal/provider/kubecli_adapter.go
+++ b/internal/provider/kubecli_adapter.go
@@ -6,11 +6,14 @@ import (
 	"strings"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 // KubeconfigLoader resolves cluster kubeconfig bytes by cluster ID/name.
@@ -97,6 +100,26 @@ func (c *kubevirtClusterClient) VMI() VirtualMachineInstanceClient {
 	return &kubevirtVMIClient{client: c.client}
 }
 
+func (c *kubevirtClusterClient) DataVolume() DataVolumeClient {
+	return &kubevirtDataVolumeClient{client: c.client}
+}
+
+func (c *kubevirtClusterClient) StorageProfile() StorageProfileClient {
+	return &kubevirtStorageProfileClient{client: c.client}
+}
+
+func (c *kubevirtClusterClient) PVC() PersistentVolumeClaimClient {
+	return &kubevirtPVCClient{client: c.client}
+}
+
+func (c *kubevirtClusterClient) StorageClass() StorageClassClient {
+	return &kubevirtStorageClassClient{client: c.client}
+}
+
+func (c *kubevirtClusterClient) Events() EventClient {
+	return &kubevirtEventClient{client: c.client}
+}
+
 // SSA returns the DynamicSSAClient for Server-Side Apply operations (ADR-0011).
 func (c *kubevirtClusterClient) SSA() DynamicSSAClient {
 	return c.ssaClient
@@ -151,6 +174,50 @@ func (c *kubevirtVMIClient) Pause(ctx context.Context, namespace, name string, o
 
 func (c *kubevirtVMIClient) Unpause(ctx context.Context, namespace, name string, opts *kubevirtv1.UnpauseOptions) error {
 	return c.client.VirtualMachineInstance(namespace).Unpause(ctx, name, opts)
+}
+
+type kubevirtDataVolumeClient struct {
+	client kubecli.KubevirtClient
+}
+
+func (c *kubevirtDataVolumeClient) Get(ctx context.Context, namespace, name string, opts k8smetav1.GetOptions) (*cdiv1beta1.DataVolume, error) {
+	return c.client.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(ctx, name, opts)
+}
+
+func (c *kubevirtDataVolumeClient) List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*cdiv1beta1.DataVolumeList, error) {
+	return c.client.CdiClient().CdiV1beta1().DataVolumes(namespace).List(ctx, opts)
+}
+
+type kubevirtStorageProfileClient struct {
+	client kubecli.KubevirtClient
+}
+
+func (c *kubevirtStorageProfileClient) Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*cdiv1beta1.StorageProfile, error) {
+	return c.client.CdiClient().CdiV1beta1().StorageProfiles().Get(ctx, name, opts)
+}
+
+type kubevirtPVCClient struct {
+	client kubecli.KubevirtClient
+}
+
+func (c *kubevirtPVCClient) Get(ctx context.Context, namespace, name string, opts k8smetav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
+	return c.client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, opts)
+}
+
+type kubevirtStorageClassClient struct {
+	client kubecli.KubevirtClient
+}
+
+func (c *kubevirtStorageClassClient) Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*storagev1.StorageClass, error) {
+	return c.client.StorageV1().StorageClasses().Get(ctx, name, opts)
+}
+
+type kubevirtEventClient struct {
+	client kubecli.KubevirtClient
+}
+
+func (c *kubevirtEventClient) List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*corev1.EventList, error) {
+	return c.client.CoreV1().Events(namespace).List(ctx, opts)
 }
 
 // KubeVirt returns a KubeVirtCRClient that can read the cluster-level KubeVirt CR.

--- a/internal/provider/kubevirt.go
+++ b/internal/provider/kubevirt.go
@@ -7,10 +7,13 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kv-shepherd.io/shepherd/internal/domain"
 )
@@ -328,6 +331,211 @@ func (p *KubeVirtProviderImpl) ValidateSpec(ctx context.Context, cluster, namesp
 	return &domain.ValidationResult{Valid: true}, nil
 }
 
+// GetDataVolume retrieves a CDI DataVolume for provisioning observability.
+func (p *KubeVirtProviderImpl) GetDataVolume(ctx context.Context, cluster, namespace, name string) (*domain.DataVolume, error) {
+	client, err := p.clientFactory(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get client for cluster %s: %w", cluster, err)
+	}
+
+	opCtx, cancel := p.withTimeout(ctx)
+	defer cancel()
+
+	dv, err := client.DataVolume().Get(opCtx, namespace, name, k8smetav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get datavolume %s/%s: %w", namespace, name, err)
+	}
+
+	conditions := make([]domain.ProvisioningCondition, 0, len(dv.Status.Conditions))
+	for _, cond := range dv.Status.Conditions {
+		conditions = append(conditions, domain.ProvisioningCondition{
+			Type:               string(cond.Type),
+			Status:             string(cond.Status),
+			Reason:             cond.Reason,
+			Message:            cond.Message,
+			LastTransitionTime: cond.LastTransitionTime.Time,
+		})
+	}
+
+	return &domain.DataVolume{
+		Name:         dv.Name,
+		Namespace:    dv.Namespace,
+		UID:          string(dv.UID),
+		ClaimName:    dv.Status.ClaimName,
+		Phase:        string(dv.Status.Phase),
+		Progress:     string(dv.Status.Progress),
+		RestartCount: dv.Status.RestartCount,
+		Conditions:   conditions,
+	}, nil
+}
+
+// GetPersistentVolumeClaim retrieves a PVC backing a CDI DataVolume.
+func (p *KubeVirtProviderImpl) GetPersistentVolumeClaim(ctx context.Context, cluster, namespace, name string) (*domain.PersistentVolumeClaim, error) {
+	client, err := p.clientFactory(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get client for cluster %s: %w", cluster, err)
+	}
+
+	opCtx, cancel := p.withTimeout(ctx)
+	defer cancel()
+
+	pvc, err := client.PVC().Get(opCtx, namespace, name, k8smetav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get pvc %s/%s: %w", namespace, name, err)
+	}
+
+	return &domain.PersistentVolumeClaim{
+		Name:                  pvc.Name,
+		Namespace:             pvc.Namespace,
+		Phase:                 string(pvc.Status.Phase),
+		StorageClassName:      stringValue(pvc.Spec.StorageClassName),
+		VolumeMode:            pvcVolumeMode(pvc.Spec.VolumeMode),
+		RequestedStorageBytes: quantityValueBytes(pvc.Spec.Resources.Requests.Storage()),
+		CapacityBytes:         quantityValueBytes(pvc.Status.Capacity.Storage()),
+		CloneType:             strings.TrimSpace(pvc.Annotations["cdi.kubevirt.io/cloneType"]),
+		ClonePhase:            strings.TrimSpace(pvc.Annotations["cdi.kubevirt.io/clonePhase"]),
+		CloneFallbackReason:   strings.TrimSpace(pvc.Annotations["cdi.kubevirt.io/cloneFallbackReason"]),
+	}, nil
+}
+
+// GetStorageClass retrieves a cluster-scoped StorageClass for clone-expansion preflight.
+func (p *KubeVirtProviderImpl) GetStorageClass(ctx context.Context, cluster, name string) (*domain.StorageClass, error) {
+	client, err := p.clientFactory(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get client for cluster %s: %w", cluster, err)
+	}
+
+	opCtx, cancel := p.withTimeout(ctx)
+	defer cancel()
+
+	storageClass, err := client.StorageClass().Get(opCtx, name, k8smetav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get storageclass %s: %w", name, err)
+	}
+
+	allowExpansion := false
+	if storageClass.AllowVolumeExpansion != nil {
+		allowExpansion = *storageClass.AllowVolumeExpansion
+	}
+
+	return &domain.StorageClass{
+		Name:                 storageClass.Name,
+		AllowVolumeExpansion: allowExpansion,
+	}, nil
+}
+
+// GetStorageProfile retrieves the CDI StorageProfile for a target storage class.
+func (p *KubeVirtProviderImpl) GetStorageProfile(ctx context.Context, cluster, name string) (*domain.StorageProfile, error) {
+	client, err := p.clientFactory(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get client for cluster %s: %w", cluster, err)
+	}
+
+	opCtx, cancel := p.withTimeout(ctx)
+	defer cancel()
+
+	storageProfile, err := client.StorageProfile().Get(opCtx, name, k8smetav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get storageprofile %s: %w", name, err)
+	}
+
+	return mapStorageProfile(storageProfile), nil
+}
+
+// ListEventsForObject lists best-effort Kubernetes Events for the referenced object.
+func (p *KubeVirtProviderImpl) ListEventsForObject(ctx context.Context, cluster string, ref domain.ObjectReference) ([]domain.ProvisioningEvent, error) {
+	client, err := p.clientFactory(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get client for cluster %s: %w", cluster, err)
+	}
+	if strings.TrimSpace(ref.Namespace) == "" {
+		return nil, fmt.Errorf("event lookup requires namespace")
+	}
+	if strings.TrimSpace(ref.Kind) == "" || strings.TrimSpace(ref.Name) == "" {
+		return nil, fmt.Errorf("event lookup requires kind and name")
+	}
+
+	opCtx, cancel := p.withTimeout(ctx)
+	defer cancel()
+
+	selectors := []string{
+		"involvedObject.kind=" + ref.Kind,
+		"involvedObject.name=" + ref.Name,
+	}
+	if ref.UID != "" {
+		selectors = append(selectors, "involvedObject.uid="+ref.UID)
+	}
+
+	list, err := client.Events().List(opCtx, ref.Namespace, k8smetav1.ListOptions{
+		FieldSelector: strings.Join(selectors, ","),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list events for %s/%s %s: %w", ref.Namespace, ref.Kind, ref.Name, err)
+	}
+
+	items := make([]domain.ProvisioningEvent, 0, len(list.Items))
+	for i := range list.Items {
+		ev := &list.Items[i]
+		items = append(items, domain.ProvisioningEvent{
+			Type:          ev.Type,
+			Reason:        ev.Reason,
+			Message:       ev.Message,
+			Count:         ev.Count,
+			FirstObserved: firstObservedTime(*ev),
+			LastObserved:  lastObservedTime(*ev),
+		})
+	}
+	return items, nil
+}
+
+func pvcVolumeMode(mode *corev1.PersistentVolumeMode) string {
+	if mode == nil {
+		return ""
+	}
+	return string(*mode)
+}
+
+func mapStorageProfile(storageProfile *cdiv1beta1.StorageProfile) *domain.StorageProfile {
+	if storageProfile == nil {
+		return &domain.StorageProfile{}
+	}
+
+	return &domain.StorageProfile{
+		Name:              storageProfile.Name,
+		CloneStrategy:     storageProfileCloneStrategy(storageProfile),
+		DefaultVolumeMode: storageProfileDefaultVolumeMode(storageProfile),
+	}
+}
+
+func storageProfileCloneStrategy(storageProfile *cdiv1beta1.StorageProfile) string {
+	if storageProfile == nil {
+		return ""
+	}
+	if storageProfile.Status.CloneStrategy != nil {
+		return string(*storageProfile.Status.CloneStrategy)
+	}
+	if storageProfile.Spec.CloneStrategy != nil {
+		return string(*storageProfile.Spec.CloneStrategy)
+	}
+	return ""
+}
+
+func storageProfileDefaultVolumeMode(storageProfile *cdiv1beta1.StorageProfile) string {
+	if storageProfile == nil {
+		return ""
+	}
+
+	claimPropertySets := storageProfile.Status.ClaimPropertySets
+	if len(claimPropertySets) == 0 {
+		claimPropertySets = storageProfile.Spec.ClaimPropertySets
+	}
+	if len(claimPropertySets) == 0 || claimPropertySets[0].VolumeMode == nil {
+		return ""
+	}
+
+	return string(*claimPropertySets[0].VolumeMode)
+}
+
 // extractNameFromYAML extracts metadata.name from YAML bytes for safety validation.
 // Used by UpdateVM to ensure the YAML target matches the function parameter.
 func extractNameFromYAML(yamlData []byte) (string, error) {
@@ -378,4 +586,38 @@ func validateNestedPathHalfStep(
 		return nil
 	}
 	return validateFn(path, value)
+}
+
+func firstObservedTime(ev corev1.Event) time.Time {
+	if !ev.FirstTimestamp.IsZero() {
+		return ev.FirstTimestamp.Time
+	}
+	if !ev.EventTime.IsZero() {
+		return ev.EventTime.Time
+	}
+	return ev.CreationTimestamp.Time
+}
+
+func lastObservedTime(ev corev1.Event) time.Time {
+	if !ev.LastTimestamp.IsZero() {
+		return ev.LastTimestamp.Time
+	}
+	if !ev.EventTime.IsZero() {
+		return ev.EventTime.Time
+	}
+	return ev.CreationTimestamp.Time
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func quantityValueBytes(q *resource.Quantity) int64 {
+	if q == nil {
+		return 0
+	}
+	return q.Value()
 }

--- a/internal/provider/kubevirt_test.go
+++ b/internal/provider/kubevirt_test.go
@@ -7,13 +7,21 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kv-shepherd.io/shepherd/internal/domain"
 )
 
 // validVMYAML is a minimal valid VirtualMachine YAML for testing.
@@ -268,6 +276,225 @@ func TestValidateYAMLResourceHalfSteps_RejectsNonStandardCPU(t *testing.T) {
 	}
 }
 
+func TestMapStorageProfile_PrefersStatusOverSpec(t *testing.T) {
+	filesystem := corev1.PersistentVolumeFilesystem
+	block := corev1.PersistentVolumeBlock
+	copyStrategy := cdiv1beta1.CDICloneStrategy("copy")
+	snapshotStrategy := cdiv1beta1.CDICloneStrategy("snapshot")
+
+	storageProfile := &cdiv1beta1.StorageProfile{}
+	storageProfile.Name = "gold"
+	storageProfile.Spec.CloneStrategy = &copyStrategy
+	storageProfile.Spec.ClaimPropertySets = []cdiv1beta1.ClaimPropertySet{
+		{VolumeMode: &filesystem},
+	}
+	storageProfile.Status.CloneStrategy = &snapshotStrategy
+	storageProfile.Status.ClaimPropertySets = []cdiv1beta1.ClaimPropertySet{
+		{VolumeMode: &block},
+	}
+
+	got := mapStorageProfile(storageProfile)
+	if got.Name != "gold" {
+		t.Fatalf("Name = %q, want %q", got.Name, "gold")
+	}
+	if got.CloneStrategy != "snapshot" {
+		t.Fatalf("CloneStrategy = %q, want %q", got.CloneStrategy, "snapshot")
+	}
+	if got.DefaultVolumeMode != "Block" {
+		t.Fatalf("DefaultVolumeMode = %q, want %q", got.DefaultVolumeMode, "Block")
+	}
+}
+
+func TestMapStorageProfile_FallsBackToSpecWhenStatusEmpty(t *testing.T) {
+	filesystem := corev1.PersistentVolumeFilesystem
+	copyStrategy := cdiv1beta1.CDICloneStrategy("copy")
+
+	storageProfile := &cdiv1beta1.StorageProfile{}
+	storageProfile.Name = "slow"
+	storageProfile.Spec.CloneStrategy = &copyStrategy
+	storageProfile.Spec.ClaimPropertySets = []cdiv1beta1.ClaimPropertySet{
+		{VolumeMode: &filesystem},
+	}
+
+	got := mapStorageProfile(storageProfile)
+	if got.CloneStrategy != "copy" {
+		t.Fatalf("CloneStrategy = %q, want %q", got.CloneStrategy, "copy")
+	}
+	if got.DefaultVolumeMode != "Filesystem" {
+		t.Fatalf("DefaultVolumeMode = %q, want %q", got.DefaultVolumeMode, "Filesystem")
+	}
+}
+
+func TestGetDataVolume_MapsStatusFields(t *testing.T) {
+	t.Parallel()
+
+	provider := NewKubeVirtProvider(func(cluster string) (KubeVirtClusterClient, error) {
+		if cluster != "cluster-a" {
+			t.Fatalf("cluster = %q, want %q", cluster, "cluster-a")
+		}
+		return providerTestClusterClient{
+			dataVolumeClient: providerTestDataVolumeClient{
+				dataVolume: &cdiv1beta1.DataVolume{
+					ObjectMeta: k8smetav1.ObjectMeta{
+						Name:      "root-dv",
+						Namespace: "team-a",
+						UID:       "dv-uid",
+					},
+					Status: cdiv1beta1.DataVolumeStatus{
+						ClaimName:    "root-pvc",
+						Phase:        cdiv1beta1.Succeeded,
+						Progress:     "100.0%",
+						RestartCount: 2,
+						Conditions: []cdiv1beta1.DataVolumeCondition{
+							{
+								Type:               cdiv1beta1.DataVolumeReady,
+								Status:             corev1.ConditionTrue,
+								Reason:             "ImportSucceeded",
+								Message:            "ready",
+								LastTransitionTime: k8smetav1.NewTime(time.Unix(1700000000, 0)),
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	}, time.Minute)
+
+	got, err := provider.GetDataVolume(context.Background(), "cluster-a", "team-a", "root-dv")
+	if err != nil {
+		t.Fatalf("GetDataVolume() error = %v", err)
+	}
+	if got.Name != "root-dv" || got.Namespace != "team-a" || got.UID != "dv-uid" {
+		t.Fatalf("GetDataVolume() identity = %+v", got)
+	}
+	if got.ClaimName != "root-pvc" || got.Phase != "Succeeded" || got.Progress != "100.0%" || got.RestartCount != 2 {
+		t.Fatalf("GetDataVolume() status = %+v", got)
+	}
+	if len(got.Conditions) != 1 || got.Conditions[0].Type != "Ready" || got.Conditions[0].Status != "True" {
+		t.Fatalf("GetDataVolume() conditions = %+v", got.Conditions)
+	}
+}
+
+func TestGetPersistentVolumeClaim_MapsCloneMetadata(t *testing.T) {
+	t.Parallel()
+
+	filesystem := corev1.PersistentVolumeFilesystem
+	storageClass := "fast-sc"
+	requested := resourceMustParse("20Gi")
+	capacity := resourceMustParse("24Gi")
+
+	provider := NewKubeVirtProvider(func(string) (KubeVirtClusterClient, error) {
+		return providerTestClusterClient{
+			pvcClient: providerTestPVCClient{
+				pvc: &corev1.PersistentVolumeClaim{
+					ObjectMeta: k8smetav1.ObjectMeta{
+						Name:      "root-pvc",
+						Namespace: "team-a",
+						Annotations: map[string]string{
+							"cdi.kubevirt.io/cloneType":           "copy",
+							"cdi.kubevirt.io/clonePhase":          "Succeeded",
+							"cdi.kubevirt.io/cloneFallbackReason": "storageClassMismatch",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						VolumeMode:       &filesystem,
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: requested},
+						},
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase:    corev1.ClaimBound,
+						Capacity: corev1.ResourceList{corev1.ResourceStorage: capacity},
+					},
+				},
+			},
+		}, nil
+	}, time.Minute)
+
+	got, err := provider.GetPersistentVolumeClaim(context.Background(), "cluster-a", "team-a", "root-pvc")
+	if err != nil {
+		t.Fatalf("GetPersistentVolumeClaim() error = %v", err)
+	}
+	if got.StorageClassName != "fast-sc" || got.VolumeMode != "Filesystem" || got.Phase != "Bound" {
+		t.Fatalf("GetPersistentVolumeClaim() core mapping = %+v", got)
+	}
+	if got.RequestedStorageBytes <= 0 || got.CapacityBytes <= 0 {
+		t.Fatalf("GetPersistentVolumeClaim() storage bytes = %+v", got)
+	}
+	if got.CloneType != "copy" || got.ClonePhase != "Succeeded" || got.CloneFallbackReason != "storageClassMismatch" {
+		t.Fatalf("GetPersistentVolumeClaim() clone metadata = %+v", got)
+	}
+}
+
+func TestListEventsForObject_MapsEventTimestamps(t *testing.T) {
+	t.Parallel()
+
+	first := k8smetav1.NewTime(time.Unix(1700000100, 0))
+	last := k8smetav1.NewTime(time.Unix(1700000200, 0))
+
+	provider := NewKubeVirtProvider(func(string) (KubeVirtClusterClient, error) {
+		return providerTestClusterClient{
+			eventClient: providerTestEventClient{
+				list: &corev1.EventList{
+					Items: []corev1.Event{
+						{
+							Type:           "Warning",
+							Reason:         "CloneFailed",
+							Message:        "quota denied",
+							Count:          3,
+							FirstTimestamp: first,
+							LastTimestamp:  last,
+						},
+					},
+				},
+			},
+		}, nil
+	}, time.Minute)
+
+	got, err := provider.ListEventsForObject(context.Background(), "cluster-a", domain.ObjectReference{
+		Kind:      "DataVolume",
+		Name:      "root-dv",
+		Namespace: "team-a",
+	})
+	if err != nil {
+		t.Fatalf("ListEventsForObject() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListEventsForObject() len = %d, want 1", len(got))
+	}
+	if got[0].Type != "Warning" || got[0].Reason != "CloneFailed" || got[0].Message != "quota denied" || got[0].Count != 3 {
+		t.Fatalf("ListEventsForObject() event = %+v", got[0])
+	}
+	if !got[0].FirstObserved.Equal(first.Time) || !got[0].LastObserved.Equal(last.Time) {
+		t.Fatalf("ListEventsForObject() timestamps = %+v", got[0])
+	}
+}
+
+func TestGetStorageClass_MapsAllowVolumeExpansion(t *testing.T) {
+	t.Parallel()
+
+	allowExpansion := true
+	provider := NewKubeVirtProvider(func(string) (KubeVirtClusterClient, error) {
+		return providerTestClusterClient{
+			storageClassClient: providerTestStorageClassClient{
+				storageClass: &storagev1.StorageClass{
+					ObjectMeta:           k8smetav1.ObjectMeta{Name: "fast-sc"},
+					AllowVolumeExpansion: &allowExpansion,
+				},
+			},
+		}, nil
+	}, time.Minute)
+
+	got, err := provider.GetStorageClass(context.Background(), "cluster-a", "fast-sc")
+	if err != nil {
+		t.Fatalf("GetStorageClass() error = %v", err)
+	}
+	if got.Name != "fast-sc" || !got.AllowVolumeExpansion {
+		t.Fatalf("GetStorageClass() = %+v", got)
+	}
+}
+
 func TestValidateYAMLResourceHalfSteps_RejectsNonStandardMemory(t *testing.T) {
 	invalid := strings.Replace(validVMYAML, `memory: "8Gi"`, `memory: "1300Mi"`, 1)
 	err := validateYAMLResourceHalfSteps([]byte(invalid))
@@ -277,4 +504,63 @@ func TestValidateYAMLResourceHalfSteps_RejectsNonStandardMemory(t *testing.T) {
 	if !strings.Contains(err.Error(), "512Mi increments") {
 		t.Fatalf("expected memory half-step error, got: %v", err)
 	}
+}
+
+type providerTestClusterClient struct {
+	vmClient             VirtualMachineClient
+	vmiClient            VirtualMachineInstanceClient
+	dataVolumeClient     DataVolumeClient
+	storageProfileClient StorageProfileClient
+	pvcClient            PersistentVolumeClaimClient
+	storageClassClient   StorageClassClient
+	eventClient          EventClient
+	ssaClient            DynamicSSAClient
+	kvCRClient           KubeVirtCRClient
+}
+
+func (c providerTestClusterClient) VM() VirtualMachineClient          { return c.vmClient }
+func (c providerTestClusterClient) VMI() VirtualMachineInstanceClient { return c.vmiClient }
+func (c providerTestClusterClient) DataVolume() DataVolumeClient      { return c.dataVolumeClient }
+func (c providerTestClusterClient) StorageProfile() StorageProfileClient {
+	return c.storageProfileClient
+}
+func (c providerTestClusterClient) PVC() PersistentVolumeClaimClient { return c.pvcClient }
+func (c providerTestClusterClient) StorageClass() StorageClassClient { return c.storageClassClient }
+func (c providerTestClusterClient) Events() EventClient              { return c.eventClient }
+func (c providerTestClusterClient) SSA() DynamicSSAClient            { return c.ssaClient }
+func (c providerTestClusterClient) KubeVirt() KubeVirtCRClient       { return c.kvCRClient }
+
+type providerTestDataVolumeClient struct{ dataVolume *cdiv1beta1.DataVolume }
+
+func (c providerTestDataVolumeClient) Get(_ context.Context, _, _ string, _ k8smetav1.GetOptions) (*cdiv1beta1.DataVolume, error) {
+	return c.dataVolume, nil
+}
+func (c providerTestDataVolumeClient) List(_ context.Context, _ string, _ k8smetav1.ListOptions) (*cdiv1beta1.DataVolumeList, error) {
+	return &cdiv1beta1.DataVolumeList{}, nil
+}
+
+type providerTestPVCClient struct{ pvc *corev1.PersistentVolumeClaim }
+
+func (c providerTestPVCClient) Get(_ context.Context, _, _ string, _ k8smetav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
+	return c.pvc, nil
+}
+
+type providerTestStorageClassClient struct{ storageClass *storagev1.StorageClass }
+
+func (c providerTestStorageClassClient) Get(_ context.Context, _ string, _ k8smetav1.GetOptions) (*storagev1.StorageClass, error) {
+	return c.storageClass, nil
+}
+
+type providerTestEventClient struct{ list *corev1.EventList }
+
+func (c providerTestEventClient) List(_ context.Context, _ string, _ k8smetav1.ListOptions) (*corev1.EventList, error) {
+	return c.list, nil
+}
+
+func resourceMustParse(value string) resource.Quantity {
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		panic(err)
+	}
+	return q
 }

--- a/internal/provider/mock.go
+++ b/internal/provider/mock.go
@@ -5,19 +5,32 @@ import (
 	"fmt"
 	"sync"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"kv-shepherd.io/shepherd/internal/domain"
 )
 
 // MockProvider implements InfrastructureProvider for testing without a K8s cluster.
 type MockProvider struct {
-	vms map[string]*domain.VM // key: namespace/name
-	mu  sync.RWMutex
+	vms             map[string]*domain.VM                    // key: namespace/name
+	dataVolumes     map[string]*domain.DataVolume            // key: namespace/name
+	pvcs            map[string]*domain.PersistentVolumeClaim // key: namespace/name
+	storageClasses  map[string]*domain.StorageClass          // key: name
+	storageProfiles map[string]*domain.StorageProfile        // key: name
+	events          map[string][]domain.ProvisioningEvent    // key: namespace/kind/name
+	mu              sync.RWMutex
 }
 
 // NewMockProvider creates a new MockProvider.
 func NewMockProvider() *MockProvider {
 	return &MockProvider{
-		vms: make(map[string]*domain.VM),
+		vms:             make(map[string]*domain.VM),
+		dataVolumes:     make(map[string]*domain.DataVolume),
+		pvcs:            make(map[string]*domain.PersistentVolumeClaim),
+		storageClasses:  make(map[string]*domain.StorageClass),
+		storageProfiles: make(map[string]*domain.StorageProfile),
+		events:          make(map[string][]domain.ProvisioningEvent),
 	}
 }
 
@@ -36,6 +49,11 @@ func (p *MockProvider) Reset() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.vms = make(map[string]*domain.VM)
+	p.dataVolumes = make(map[string]*domain.DataVolume)
+	p.pvcs = make(map[string]*domain.PersistentVolumeClaim)
+	p.storageClasses = make(map[string]*domain.StorageClass)
+	p.storageProfiles = make(map[string]*domain.StorageProfile)
+	p.events = make(map[string][]domain.ProvisioningEvent)
 }
 
 func (p *MockProvider) Name() string { return "mock" }
@@ -133,6 +151,105 @@ func (p *MockProvider) ValidateSpec(_ context.Context, _, _ string, _ *domain.VM
 	return &domain.ValidationResult{Valid: true}, nil
 }
 
+func (p *MockProvider) SeedDataVolumes(items []*domain.DataVolume) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		p.dataVolumes[item.Namespace+"/"+item.Name] = item
+	}
+}
+
+func (p *MockProvider) SeedPVCs(items []*domain.PersistentVolumeClaim) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		p.pvcs[item.Namespace+"/"+item.Name] = item
+	}
+}
+
+func (p *MockProvider) SeedStorageClasses(items []*domain.StorageClass) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		p.storageClasses[item.Name] = item
+	}
+}
+
+func (p *MockProvider) SeedStorageProfiles(items []*domain.StorageProfile) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		p.storageProfiles[item.Name] = item
+	}
+}
+
+func (p *MockProvider) SeedEvents(ref domain.ObjectReference, items []domain.ProvisioningEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events[eventKey(ref)] = append([]domain.ProvisioningEvent(nil), items...)
+}
+
+func (p *MockProvider) GetDataVolume(_ context.Context, _, namespace, name string) (*domain.DataVolume, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	item, ok := p.dataVolumes[namespace+"/"+name]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "cdi.kubevirt.io", Resource: "datavolumes"}, name)
+	}
+	return item, nil
+}
+
+func (p *MockProvider) GetPersistentVolumeClaim(_ context.Context, _, namespace, name string) (*domain.PersistentVolumeClaim, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	item, ok := p.pvcs[namespace+"/"+name]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}, name)
+	}
+	return item, nil
+}
+
+func (p *MockProvider) GetStorageClass(_ context.Context, _, name string) (*domain.StorageClass, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	item, ok := p.storageClasses[name]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, name)
+	}
+	return item, nil
+}
+
+func (p *MockProvider) GetStorageProfile(_ context.Context, _, name string) (*domain.StorageProfile, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	item, ok := p.storageProfiles[name]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "cdi.kubevirt.io", Resource: "storageprofiles"}, name)
+	}
+	return item, nil
+}
+
+func (p *MockProvider) ListEventsForObject(_ context.Context, _ string, ref domain.ObjectReference) ([]domain.ProvisioningEvent, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	items := p.events[eventKey(ref)]
+	out := make([]domain.ProvisioningEvent, len(items))
+	copy(out, items)
+	return out, nil
+}
+
 func (p *MockProvider) setStatus(namespace, name string, status domain.VMStatus) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -143,4 +260,8 @@ func (p *MockProvider) setStatus(namespace, name string, status domain.VMStatus)
 	}
 	vm.Status = status
 	return nil
+}
+
+func eventKey(ref domain.ObjectReference) string {
+	return ref.Namespace + "/" + ref.Kind + "/" + ref.Name
 }


### PR DESCRIPTION
## Summary
- add provider-side reads for CDI DataVolume, PVC, Events, StorageClass, and StorageProfile
- add internal provisioning domain models for these read paths
- add provider tests for CDI object mapping and keep the provider boundary intact

## Validation
- make lint
- make ci-checks
- go test ./internal/provider ./internal/domain ./internal/testutil -count=1

Refs #323