### PR TITLE
docs(flow): sync master-flow after accepted ADRs

### DIFF
--- a/docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md
+++ b/docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: 2026-03-06
 deciders: ["@jindyzhao"]
 consulted: []
@@ -9,6 +9,7 @@ informed: []
 # ADR-0040: Catalog Scope for Template and InstanceSize
 
 > **Review Period**: Until 2026-03-08 (48-hour minimum)<br>
+> **Accepted On**: 2026-03-10<br>
 > **Amends**: `ADR-0036-template-instancesize-boundary-enforcement.md`, `ADR-0018-instance-size-abstraction.md`<br>
 > **Relates To**: `ADR-0015-governance-model-v2.md#7-environment-aware-approval-policies`, `ADR-0015-governance-model-v2.md#15-namespace-cluster-binding-and-environment-type-clarification`
 
@@ -49,7 +50,7 @@ The Python production system solved this with a `permission_group` field and lat
 * ✅ Good, because `unclassified` is safe by default and does not leak into user request flows
 * ✅ Good, because cluster compatibility remains a separate validation concern instead of being hidden inside a visibility field
 * 🟡 Neutral, because administrators must classify catalog items before they appear to end users
-* ❌ Bad, because existing experimental data must be backfilled or manually reviewed before exposure; mitigation: backfill to `unclassified` and hide from regular users until reviewed
+* ❌ Bad, because catalog maintainers must still review and classify seeded or experimental entries before exposing them to end users; mitigation: keep `unclassified` hidden from regular request flows until reviewed
 
 ### Confirmation
 
@@ -165,3 +166,4 @@ Revisit if the project later needs per-cluster catalog allowlists or multi-dimen
 |------|--------|--------|
 | 2026-03-06 | @jindyzhao | Initial draft |
 | 2026-03-06 | @jindyzhao | Reworked around `catalog_scope`, zero-trust defaults, and separation from environment type |
+| 2026-03-10 | @jindyzhao | Status promoted to accepted after review period and implementation merge |

--- a/docs/adr/ADR-0041-power-operation-approval-requirement-service.md
+++ b/docs/adr/ADR-0041-power-operation-approval-requirement-service.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: 2026-03-06
 deciders: ["@jindyzhao"]
 consulted: []
@@ -9,6 +9,7 @@ informed: []
 # ADR-0041: Power Operation Approval Requirement Service
 
 > **Review Period**: Until 2026-03-08 (48-hour minimum)<br>
+> **Accepted On**: 2026-03-10<br>
 > **Amends**: `ADR-0005-workflow-extensibility.md`, `ADR-0015-governance-model-v2.md#7-environment-aware-approval-policies`<br>
 > **Relates To**: `ADR-0015-governance-model-v2.md#15-namespace-cluster-binding-and-environment-type-clarification`, `RFC-0004-external-approval.md`
 
@@ -232,3 +233,4 @@ If future policy needs selectors richer than environment type, add explicit type
 |------|--------|--------|
 | 2026-03-06 | @jindyzhao | Initial draft |
 | 2026-03-06 | @jindyzhao | Reworked around `ApprovalRequirementService`, environment-type policy keys, and existing provider-router boundaries |
+| 2026-03-10 | @jindyzhao | Status promoted to accepted after review period and implementation merge |

--- a/docs/adr/ADR-0042-cluster-policy-governance-model.md
+++ b/docs/adr/ADR-0042-cluster-policy-governance-model.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: 2026-03-06
 deciders: ["@jindyzhao"]
 consulted: []
@@ -9,6 +9,7 @@ informed: []
 # ADR-0042: Explicit Cluster Policy Governance Model
 
 > **Review Period**: Until 2026-03-08 (48-hour minimum)<br>
+> **Accepted On**: 2026-03-10<br>
 > **Discussion**: [Issue #326](https://github.com/kv-shepherd/shepherd/issues/326)<br>
 > **Amends**: `ADR-0014-capability-detection.md` *(clarifies capability vs policy boundary)*<br>
 > **Amends**: `ADR-0018-instance-size-abstraction.md` *(adds policy enforcement after capability matching)*
@@ -62,7 +63,7 @@ expand, and avoids mixing mutable policy with connection metadata on `Cluster`.
   and policy denial explicitly
 * ✅ Good, because policy changes become auditable configuration changes instead
   of hidden conventions
-* 🟡 Neutral, because rollout requires a new entity and migration/backfill work
+* 🟡 Neutral, because rollout requires a new entity and explicit admin policy configuration
 * ❌ Bad, because the platform must now maintain one more admin-managed model;
   mitigation is to keep the first version intentionally small and explicit
 
@@ -176,9 +177,8 @@ Steady-state requirement:
 
 Rollout rule:
 
-* existing clusters are backfilled with explicit rows generated from a
-  `legacy-compatible` preset so the platform does not rely on "missing policy =
-  allow"
+* because the project is pre-launch, clusters are expected to be created with an
+  explicit policy row from the start
 * new clusters are not eligible for selection until a policy row exists
 
 ### Out of Scope
@@ -218,12 +218,12 @@ This ADR does **not** define:
 
 ### Implementation Notes
 
-The first implementation step after acceptance should be a focused issue that:
+Initial implementation landed in the first production slice:
 
-1. adds `ClusterPolicy` schema and migration
-2. introduces a `ClusterPolicyService`
-3. integrates policy checks into `ApprovalValidator`
-4. exposes read-only policy state on admin cluster detail APIs
+1. `ClusterPolicy` schema and service were added
+2. `ApprovalValidator` gained explicit policy checks after capability matching
+3. admin cluster APIs and UI now expose policy state and editing
+4. placement evaluation surfaces now distinguish capability mismatch from policy denial
 
 ---
 
@@ -232,3 +232,4 @@ The first implementation step after acceptance should be a focused issue that:
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-06 | @jindyzhao | Initial draft |
+| 2026-03-10 | @jindyzhao | Status promoted to accepted after review period and implementation merge |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,9 +47,9 @@
 | [ADR-0035](./ADR-0035-auth-provider-plugin-boundary.md) | Auth Provider Plugin Boundary and Type Discovery | **Accepted** | - |
 | [ADR-0036](./ADR-0036-template-instancesize-boundary-enforcement.md) | Template / InstanceSize Boundary Enforcement | **Accepted** | - |
 | [ADR-0037](./ADR-0037-openapi-validation-architecture-and-enforcement-policy.md) | OpenAPI Validation Architecture and Enforcement Policy | **Accepted** | - |
-| [ADR-0040](./ADR-0040-catalog-scope-for-template-and-instancesize.md) | Catalog Scope for Template and InstanceSize | **Proposed** | - |
-| [ADR-0041](./ADR-0041-power-operation-approval-requirement-service.md) | Power Operation Approval Requirement Service | **Proposed** | - |
-| [ADR-0042](./ADR-0042-cluster-policy-governance-model.md) | Explicit Cluster Policy Governance Model | **Proposed** | - |
+| [ADR-0040](./ADR-0040-catalog-scope-for-template-and-instancesize.md) | Catalog Scope for Template and InstanceSize | **Accepted** | - |
+| [ADR-0041](./ADR-0041-power-operation-approval-requirement-service.md) | Power Operation Approval Requirement Service | **Accepted** | - |
+| [ADR-0042](./ADR-0042-cluster-policy-governance-model.md) | Explicit Cluster Policy Governance Model | **Accepted** | - |
 
 > ℹ️ **ADR-0037 Sync Notes**:
 >
@@ -114,6 +114,9 @@ For newcomers, we recommend reading ADRs in this order:
 12. **ADR-0021** (API Contract-First) → Contract-first API lifecycle
 13. **ADR-0029** (OpenAPI Toolchain Governance) → Lint/generate/diff enforcement baseline
 14. **ADR-0037** (OpenAPI Validation Architecture, **Accepted**) → Runtime/business validation architecture and compat bridge governance
+15. **ADR-0040** (Catalog Scope, **Accepted**) → User-facing catalog visibility and zero-trust classification
+16. **ADR-0041** (Power Approval Requirement, **Accepted**) → Environment-aware approval decision path for power and VNC operations
+17. **ADR-0042** (Cluster Policy Governance, **Accepted**) → Explicit post-capability governance controls for cluster selection and approval
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/docs/design/ci/scripts/check_design_doc_governance.sh
+++ b/docs/design/ci/scripts/check_design_doc_governance.sh
@@ -142,20 +142,19 @@ enforce_traceability_manifest_update() {
   local event_path="${GITHUB_EVENT_PATH:-}"
   local event_name="${GITHUB_EVENT_NAME:-}"
 
-  if [[ -z "${event_path}" || ! -f "${event_path}" ]]; then
-    return 0
-  fi
-  if ! command -v python3 >/dev/null 2>&1; then
-    fail "python3 is required for traceability diff enforcement in CI"
-  fi
-  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    fail "git repository is required for traceability diff enforcement in CI"
-  fi
-
   local base_sha=""
   local head_sha=""
-  read -r base_sha head_sha < <(
-    python3 - "$event_name" "$event_path" <<'PY'
+  local diff_mode="ci"
+  if [[ -n "${event_path}" && -f "${event_path}" ]]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+      fail "python3 is required for traceability diff enforcement in CI"
+    fi
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      fail "git repository is required for traceability diff enforcement in CI"
+    fi
+
+    read -r base_sha head_sha < <(
+      python3 - "$event_name" "$event_path" <<'PY'
 import json
 import sys
 
@@ -180,11 +179,34 @@ if not base or not head:
 
 print(base, head)
 PY
-  ) || fail "Cannot determine base/head commit for traceability diff enforcement. Ensure checkout fetch-depth is 0."
+    ) || fail "Cannot determine base/head commit for traceability diff enforcement. Ensure checkout fetch-depth is 0."
+  else
+    diff_mode="local"
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+      fail "Local traceability diff enforcement requires refs/remotes/origin/main. Run 'git fetch origin main' before local ci-checks."
+    fi
+
+    base_sha="$(git merge-base HEAD refs/remotes/origin/main)" \
+      || fail "Cannot determine merge-base against origin/main for local traceability diff enforcement."
+    head_sha="$(git rev-parse HEAD)" \
+      || fail "Cannot determine HEAD for local traceability diff enforcement."
+  fi
 
   local changed_files=""
-  changed_files="$(git diff --name-only "${base_sha}...${head_sha}" 2>/dev/null)" \
-    || fail "git diff failed for ${base_sha}...${head_sha}. Ensure checkout fetch-depth is 0."
+  if [[ "${diff_mode}" == "ci" ]]; then
+    changed_files="$(git diff --name-only "${base_sha}...${head_sha}" 2>/dev/null)" \
+      || fail "git diff failed for ${base_sha}...${head_sha}. Ensure checkout fetch-depth is 0."
+  else
+    local tracked_changes=""
+    local untracked_changes=""
+    tracked_changes="$(git diff --name-only "${base_sha}" 2>/dev/null)" \
+      || fail "git diff failed for local traceability enforcement against ${base_sha}."
+    untracked_changes="$(git ls-files --others --exclude-standard)"
+    changed_files="$(printf '%s\n%s\n' "${tracked_changes}" "${untracked_changes}" | awk 'NF' | sort -u)"
+  fi
 
   if [[ -z "${changed_files}" ]]; then
     return 0

--- a/docs/design/interaction-flows/master-flow.md
+++ b/docs/design/interaction-flows/master-flow.md
@@ -1,9 +1,9 @@
 # Master Interaction Flow
 
 > **Status**: Stable (ADR-0017, ADR-0018 Accepted)  
-> **Version**: 1.2
+> **Version**: 1.3
 > **Created**: 2026-01-28  
-> **Last Updated**: 2026-02-06
+> **Last Updated**: 2026-03-06
 > **Language**: English (Canonical Version)  
 > **Source**: Extracted from ADR-0018 Appendix
 >
@@ -947,12 +947,15 @@ external systems are integrated as provider plugins without changing approval st
 │                                                                                              │
 │  ┌─ Step 3: Configure Template ──────────────────────────────────────────────────────────────┐ │
 │  │                                                                                          │
-│  │  Template defines base VM OS configuration:                                              │
-│  │  - OS image source (DataVolume / PVC reference)                                          │
+│  │  Template defines base VM boot configuration:                                            │
+│  │  - `containerdisk` ephemeral root disk                                                   │
+│  │  - `cdi_image_import` persistent root disk imported by CDI                               │
+│  │  - `cdi_pvc_clone` persistent root disk cloned from source PVC via CDI                   │
 │  │  - cloud-init config (admin customizable)                                                │
 │  │  - field visibility control (quick_fields / advanced_fields)                             │
 │  │                                                                                          │
 │  │  💡 Hardware capability requirements (GPU/SR-IOV/Hugepages) moved to InstanceSize         │
+│  │  💡 Direct existing-PVC boot is not a supported product mode                              │
 │  │  💡 Seed data preloads common templates into PostgreSQL                                  │
 │  │                                                                                          │
 │  │  ┌──────────────────────────────────────────────────────────────────────────────────┐   │
@@ -963,15 +966,20 @@ external systems are integrated as provider plugins without changing approval st
 │  │  │  Status:       [active ▼]                                                           │   │
 │  │  │                                                                                    │   │
 │  │  │  ── Image Source ────────────────────────────────────────────────────────────     │   │
-│  │  │  Type:         (●) containerdisk   ( ) pvc                                          │   │
+│  │  │  Type:         (●) containerdisk   ( ) cdi_image_import   ( ) cdi_pvc_clone        │   │
 │  │  │                                                                                    │   │
 │  │  │  ┌─ containerdisk mode ───────────────────────────────────────────────────────┐    │   │
 │  │  │  │  Image:     [docker.io/kubevirt/centos:7                    ]                │    │   │
 │  │  │  └────────────────────────────────────────────────────────────────────────────┘    │   │
 │  │  │                                                                                    │   │
-│  │  │  ┌─ pvc mode (after toggle) ───────────────────────────────────────────────────┐   │   │
-│  │  │  │  Namespace:  [default           ]                                           │   │   │
-│  │  │  │  PVC Name:   [centos7-base-disk ]                                           │   │   │
+│  │  │  ┌─ cdi_image_import mode ─────────────────────────────────────────────────────┐   │   │
+│  │  │  │  Image:     [quay.io/containerdisks/centos:stream9         ]               │   │   │
+│  │  │  │  Source:    [registry ▼]                                                    │   │   │
+│  │  │  └────────────────────────────────────────────────────────────────────────────┘   │   │
+│  │  │                                                                                    │   │
+│  │  │  ┌─ cdi_pvc_clone mode ────────────────────────────────────────────────────────┐   │   │
+│  │  │  │  Namespace:  [golden-images      ]                                           │   │   │
+│  │  │  │  PVC Name:   [centos9-base-root  ]                                           │   │   │
 │  │  │  └────────────────────────────────────────────────────────────────────────────┘   │   │
 │  │  │                                                                                    │   │
 │  │  │  ── cloud-init config (YAML) ─────────────────────────────────────────────────   │   │
@@ -1049,8 +1057,13 @@ external systems are integrated as provider plugins without changing approval st
 │  │  Store in PostgreSQL (backend does not interpret, stores JSON):                          │
 │  │  {                                                                                       │
 │  │      "name": "gpu-workstation",                                                      │
-│  │      "cpu_overcommit": { "enabled": true, "request": "4", "limit": "8" },      │
-│  │      "mem_overcommit": { "enabled": true, "request": "16Gi", "limit": "32Gi" },│
+│  │      "cpu_cores": 8,                                                                  │
+│  │      "cpu_request": 4,                     👈 overcommit when request < cores         │
+│  │      "memory_gi": 32,                                                                 │
+│  │      "memory_request_gi": 16,            👈 overcommit when request < limit          │
+│  │      "dedicated_cpu": true,                                                        │
+│  │      "requires_hugepages": true,                                                    │
+│  │      "hugepages_size": "2Mi",                                                       │
 │  │      "spec_overrides": {                                                               │
 │  │          "spec.template.spec.domain.cpu.cores": 8,                                     │
 │  │          "spec.template.spec.domain.resources.requests.memory": "32Gi",              │
@@ -1573,6 +1586,9 @@ execution, and runtime outcomes.
 │                                                                                              │
 │  Platform admin:                                                                             │
 │                                                                                              │
+│  Current baseline: cluster selection first matches capability, then enforces explicit        │
+│  cluster-policy constraints before approval/execution continues.                             │
+│                                                                                              │
 │  System extracts resource requirements from InstanceSize.spec_overrides and matches clusters:
 │                                                                                              │
 │  1. Extract requirements:                                                                    │
@@ -1646,7 +1662,12 @@ execution, and runtime outcomes.
 │  1. Generate VM name: prod-shop-shop-redis-01                                                │
 │                                                                                              │
 │  2. Merge final YAML:                                                                        │
-│     Template (base) + InstanceSize.spec_overrides + user params (disk_gb)                    │
+│     Template boot source + InstanceSize.spec_overrides + user params (disk_gb)               │
+│                                                                                              │
+│     Boot-source rendering contract:                                                          │
+│     - `containerdisk`    -> `volumes[].containerDisk`                                        │
+│     - `cdi_image_import` -> `dataVolumeTemplates` + `volumes[].dataVolume`                   │
+│     - `cdi_pvc_clone`    -> `dataVolumeTemplates` + `volumes[].dataVolume`                   │
 │                                                                                              │
 │  3. Render output:                                                                           │
 │     apiVersion: kubevirt.io/v1                                                               │

--- a/docs/design/notes/ADR-0040-catalog-scope-for-template-and-instancesize.md
+++ b/docs/design/notes/ADR-0040-catalog-scope-for-template-and-instancesize.md
@@ -1,17 +1,18 @@
 # Design Note: ADR-0040 — Catalog Scope for Template and InstanceSize
 
-> **Status**: Proposed  
+> **Status**: Active (ADR-0040 accepted 2026-03-10)  
 > **Related ADR**: [ADR-0040](../../adr/ADR-0040-catalog-scope-for-template-and-instancesize.md)  
 > **Owner**: @jindyzhao  
-> **Date**: 2026-03-06
+> **Created**: 2026-03-06  
+> **Last Updated**: 2026-03-10
 
 ## Summary
 
-ADR-0040 proposes a dedicated `catalog_scope` classification on `Template` and
-`InstanceSize` so user-facing request flows can filter catalog entries by the
-selected namespace environment type without overloading the platform meaning of
-`environment`. This note captures the proposed schema, API, validation, and
-migration impacts while the ADR remains under review.
+ADR-0040 establishes a dedicated `catalog_scope` classification on `Template`
+and `InstanceSize` so user-facing request flows can filter catalog entries by
+the selected namespace environment type without overloading the platform meaning
+of `environment`. This note captures the accepted schema, API, validation, and
+pre-launch rollout impacts.
 
 ## Scope
 
@@ -23,7 +24,7 @@ migration impacts while the ADR remains under review.
 - Out of scope: cluster policy governance for overcommit and hardware controls
 - Out of scope: per-cluster catalog allowlists
 
-## Pending Changes (Not Yet Normative)
+## Accepted Scope
 
 - Affected docs:
   - `docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md`
@@ -70,7 +71,7 @@ scheduling, approval, or capability signal.
 ### Request Context
 
 `GetVMRequestContext` should stop returning all enabled templates and instance
-sizes. The proposed filtering rules are:
+sizes. The accepted filtering rules are:
 
 - allowed scopes for `test`: `test`, `all`
 - allowed scopes for `prod`: `prod`, `all`
@@ -87,21 +88,15 @@ requests.
 Admin-facing list and detail APIs should continue to expose all scopes,
 including `unclassified`, so catalog maintainers can review and classify items.
 
-## Migration / Rollout
+## Rollout Notes
 
-- Data migration:
-  - add `catalog_scope` to `templates` and `instance_sizes`
-  - backfill existing rows to `unclassified`
-  - do not use `NULL = all`; zero-trust default is intentional
-- Compatibility notes:
-  - user-facing APIs should treat missing field values from pre-migration data
-    as non-visible until backfill is complete
-  - admin APIs may need a temporary filter or badge for `unclassified` cleanup
-- Rollout order:
-  1. schema migration
-  2. admin API + UI exposure
-  3. request-context filtering
-  4. create-request enforcement
+- This project is still pre-launch, so no historical data migration or runtime
+  compatibility layer is required.
+- Canonical behavior is:
+  1. schema carries explicit `catalog_scope`
+  2. admin API + UI expose and validate it directly
+  3. request-context filters hide `unclassified` from regular users
+  4. create-request validation rejects stale or forged mismatched selections
 
 ## Open Questions
 

--- a/docs/design/notes/ADR-0041-power-operation-approval-requirement-service.md
+++ b/docs/design/notes/ADR-0041-power-operation-approval-requirement-service.md
@@ -1,17 +1,17 @@
 # Design Note: ADR-0041 — Power Operation Approval Requirement Service
 
-> **Status**: Proposed  
+> **Status**: Active (ADR-0041 accepted 2026-03-10)  
 > **Related ADR**: [ADR-0041](../../adr/ADR-0041-power-operation-approval-requirement-service.md)  
 > **Owner**: @jindyzhao  
-> **Date**: 2026-03-06
+> **Created**: 2026-03-06  
+> **Last Updated**: 2026-03-10
 
 ## Summary
 
-ADR-0041 proposes a dedicated `ApprovalRequirementService` so VM
+ADR-0041 establishes a dedicated `ApprovalRequirementService` so VM
 start/stop/restart requests can be evaluated against the accepted `test` / `prod`
 approval matrix before any power job is enqueued. This note captures the
-proposed schema, handler flow, and rollout impacts while the ADR remains under
-review.
+accepted schema, handler flow, and current implementation shape.
 
 ## Scope
 
@@ -24,7 +24,7 @@ review.
 - Out of scope: external approval provider implementation details
 - Out of scope: namespace-name regex routing
 
-## Pending Changes (Not Yet Normative)
+## Accepted Scope
 
 - Affected docs:
   - `docs/adr/ADR-0041-power-operation-approval-requirement-service.md`
@@ -89,23 +89,15 @@ Evaluation contract:
 Specific power actions remain in the event payload or request payload, not in a
 growing approval-ticket enum.
 
-## Migration / Rollout
+## Rollout Notes
 
-- Data migration:
-  - replace or supersede experimental `namespace_pattern` fields with typed
-    `environment_type` and `operation`
-  - seed baseline rules for `test` and `prod`
-  - add `POWER` to `approval_tickets.operation_type`
-- Compatibility notes:
-  - existing VNC policy logic should remain functional during the transition;
-    cut over only after the shared service is in place
-  - direct power execution should remain the fallback path only when the rule
-    explicitly says approval is not required
-- Rollout order:
-  1. schema migration and seed data
-  2. `ApprovalRequirementService`
-  3. power-handler integration
-  4. optional VNC migration onto the same service
+- This project is still pre-launch, so no legacy compatibility layer is
+  retained for older `ApprovalPolicy` shapes.
+- Canonical behavior is:
+  1. `ApprovalPolicy` is keyed by `environment_type + operation`
+  2. `ApprovalTicket.operation_type` includes `POWER`
+  3. single and batch power operations use the shared approval requirement path
+  4. VNC approval decisions reuse the same requirement service
 
 ## Open Questions
 

--- a/docs/design/notes/ADR-0042-cluster-policy-governance-model.md
+++ b/docs/design/notes/ADR-0042-cluster-policy-governance-model.md
@@ -1,17 +1,17 @@
 # Design Note: ADR-0042 — Explicit Cluster Policy Governance Model
 
-> **Status**: Proposed
+> **Status**: Active (ADR-0042 accepted 2026-03-10)
 > **Related ADR**: [ADR-0042](../../adr/ADR-0042-cluster-policy-governance-model.md)
 > **Owner**: @jindyzhao
-> **Date**: 2026-03-06
+> **Created**: 2026-03-06
+> **Last Updated**: 2026-03-10
 
 ## Summary
 
-ADR-0042 proposes a dedicated `ClusterPolicy` model so the platform can decide
+ADR-0042 establishes a dedicated `ClusterPolicy` model so the platform can decide
 not only whether a cluster technically supports a workload, but also whether the
-platform allows that workload on that cluster. This note captures the proposed
-schema, enforcement order, API impact, and migration approach while the ADR
-remains under review.
+platform allows that workload on that cluster. This note captures the accepted
+schema, enforcement order, API impact, and pre-launch rollout approach.
 
 ## Scope
 
@@ -25,7 +25,7 @@ remains under review.
 - Out of scope: per-namespace policy overrides
 - Out of scope: `containerdisk` product policy decisions
 
-## Pending Changes (Not Yet Normative)
+## Accepted Scope
 
 - Affected docs:
   - `docs/adr/ADR-0042-cluster-policy-governance-model.md`
@@ -100,13 +100,14 @@ Admin-facing cluster detail should expose both:
 
 The UI should not merge them into a single undifferentiated feature list.
 
-## Migration / Rollout
+## Rollout Notes
 
 1. Add `cluster_policies` table and one-to-one relation
-2. Backfill existing clusters with explicit `legacy-compatible` policy rows
-3. Update admin APIs so cluster onboarding can create or edit policy
-4. Add validator integration behind the new policy service
-5. Tighten defaults only after admin review/backfill is complete
+2. Update admin APIs so cluster onboarding can create or edit policy
+3. Add validator integration behind the new policy service
+4. Keep capability facts and policy decisions exposed separately
+5. Because the project is pre-launch, no historical backfill or compatibility
+   layer is required
 
 ## Open Questions
 
@@ -114,5 +115,5 @@ The UI should not merge them into a single undifferentiated feature list.
   implicit allow, or must it also be explicitly listed?
 - Should clone-source namespace restrictions live here permanently, or move to a
   future storage-policy entity if the matrix grows?
-- Does the first rollout need a separate `ClusterPolicyPreset` concept, or is a
-  one-time migration/backfill script sufficient?
+- Does the platform ever need a separate `ClusterPolicyPreset` concept, or is a
+  direct one-policy-per-cluster model sufficient?

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -139,7 +139,9 @@
       "adrs": [
         "docs/adr/ADR-0014-capability-detection.md",
         "docs/adr/ADR-0018-instance-size-abstraction.md",
-        "docs/adr/ADR-0031-concurrency-and-worker-pool-standard.md"
+        "docs/adr/ADR-0031-concurrency-and-worker-pool-standard.md",
+        "docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md",
+        "docs/adr/ADR-0042-cluster-policy-governance-model.md"
       ]
     },
     {
@@ -248,7 +250,9 @@
       "adrs": [
         "docs/adr/ADR-0006-unified-async-model.md",
         "docs/adr/ADR-0012-hybrid-transaction.md",
-        "docs/adr/ADR-0017-vm-request-flow-clarification.md"
+        "docs/adr/ADR-0017-vm-request-flow-clarification.md",
+        "docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md",
+        "docs/adr/ADR-0042-cluster-policy-governance-model.md"
       ],
       "examples": [
         "docs/design/examples/usecase/create_vm.go"
@@ -266,7 +270,9 @@
         "docs/adr/ADR-0005-workflow-extensibility.md",
         "docs/adr/ADR-0006-unified-async-model.md",
         "docs/adr/ADR-0009-domain-event-pattern.md",
-        "docs/adr/ADR-0017-vm-request-flow-clarification.md"
+        "docs/adr/ADR-0017-vm-request-flow-clarification.md",
+        "docs/adr/ADR-0041-power-operation-approval-requirement-service.md",
+        "docs/adr/ADR-0042-cluster-policy-governance-model.md"
       ],
       "examples": [
         "docs/design/examples/worker/pool.go"
@@ -341,7 +347,8 @@
       ],
       "adrs": [
         "docs/adr/ADR-0015-governance-model-v2.md",
-        "docs/adr/ADR-0015-governance-model-v2.md#adr-0015-vnc-v1-addendum"
+        "docs/adr/ADR-0015-governance-model-v2.md#adr-0015-vnc-v1-addendum",
+        "docs/adr/ADR-0041-power-operation-approval-requirement-service.md"
       ]
     }
   ]

--- a/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
+++ b/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
@@ -1,9 +1,9 @@
 # 规范交互流程 (Master Flow)
 
 > **Status**: Stable (ADR-0017, ADR-0018 Accepted)  
-> **版本**: 1.2
+> **版本**: 1.3
 > **创建日期**: 2026-01-28  
-> **最后更新**: 2026-02-06
+> **最后更新**: 2026-03-06
 > **语言**: 中文 (翻译版本)  
 > **规范版本**: [English Canonical Version](../../../../design/interaction-flows/master-flow.md)
 >
@@ -942,12 +942,15 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │                                                                                              │
 │  ┌─ 步骤 3: 配置 Template ─────────────────────────────────────────────────────────────────────┐ │
 │  │                                                                                          │ │
-│  │  模板定义 VM 的操作系统基础配置:                                                            │ │
-│  │  - OS 镜像来源 (DataVolume / PVC 引用)                                                    │ │
+│  │  模板定义 VM 的启动盘基础配置:                                                              │ │
+│  │  - `containerdisk` 临时根盘                                                                │ │
+│  │  - `cdi_image_import` 通过 CDI 导入的持久化根盘                                            │ │
+│  │  - `cdi_pvc_clone` 通过 CDI 从源 PVC 克隆的持久化根盘                                      │ │
 │  │  - cloud-init 配置 (管理员可自定义)                                                        │ │
 │  │  - 字段可见性控制 (quick_fields / advanced_fields)                                        │ │
 │  │                                                                                          │ │
 │  │  💡 注意: 硬件能力要求 (GPU/SR-IOV/Hugepages) 已移至 InstanceSize 配置                     │ │
+│  │  💡 直接从已有 PVC 启动 VM 不是受支持的产品模式                                             │ │
 │  │  💡 系统初始化时会预填充常用模板 (从 seed data 导入到 PostgreSQL)                           │ │
 │  │                                                                                          │ │
 │  │  ┌──────────────────────────────────────────────────────────────────────────────────┐   │ │
@@ -958,15 +961,20 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │  │  │  状态:         [active ▼]                                                          │   │ │
 │  │  │                                                                                    │   │ │
 │  │  │  ── 镜像来源 ──────────────────────────────────────────────────────────────────   │   │ │
-│  │  │  类型:         (●) containerdisk   ( ) pvc                                         │   │ │
+│  │  │  类型:         (●) containerdisk   ( ) cdi_image_import   ( ) cdi_pvc_clone      │   │ │
 │  │  │                                                                                    │   │ │
 │  │  │  ┌─ containerdisk 模式 ──────────────────────────────────────────────────────┐    │   │ │
 │  │  │  │  镜像地址:   [docker.io/kubevirt/centos:7                    ]             │    │   │ │
 │  │  │  └────────────────────────────────────────────────────────────────────────────┘    │   │ │
 │  │  │                                                                                    │   │ │
-│  │  │  ┌─ pvc 模式 (切换后显示) ─────────────────────────────────────────────────────┐   │   │ │
-│  │  │  │  Namespace:  [default           ]                                          │   │   │ │
-│  │  │  │  PVC 名称:   [centos7-base-disk ]                                          │   │   │ │
+│  │  │  ┌─ cdi_image_import 模式 ────────────────────────────────────────────────────┐   │   │ │
+│  │  │  │  镜像地址:   [quay.io/containerdisks/centos:stream9         ]              │   │   │ │
+│  │  │  │  来源:       [registry ▼]                                                   │   │   │ │
+│  │  │  └────────────────────────────────────────────────────────────────────────────┘   │   │ │
+│  │  │                                                                                    │   │ │
+│  │  │  ┌─ cdi_pvc_clone 模式 ───────────────────────────────────────────────────────┐   │   │ │
+│  │  │  │  Namespace:  [golden-images      ]                                         │   │   │ │
+│  │  │  │  PVC 名称:   [centos9-base-root  ]                                         │   │   │ │
 │  │  │  └────────────────────────────────────────────────────────────────────────────┘   │   │ │
 │  │  │                                                                                    │   │ │
 │  │  │  ── cloud-init 配置 (YAML) ───────────────────────────────────────────────────   │   │ │
@@ -1044,8 +1052,13 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │  │  存储到 PostgreSQL (后端不理解内容，只存储 JSON):                                          │ │
 │  │  {                                                                                       │ │
 │  │      "name": "gpu-workstation",                                                          │ │
-│  │      "cpu_overcommit": { "enabled": true, "request": "4", "limit": "8" },                │ │
-│  │      "mem_overcommit": { "enabled": true, "request": "16Gi", "limit": "32Gi" },          │ │
+│  │      "cpu_cores": 8,                                                                      │ │
+│  │      "cpu_request": 4,                    👈 request < cores 时表示超卖                   │ │
+│  │      "memory_gi": 32,                                                                     │ │
+│  │      "memory_request_gi": 16,           👈 request < limit 时表示超卖                    │ │
+│  │      "dedicated_cpu": true,                                                               │ │
+│  │      "requires_hugepages": true,                                                          │ │
+│  │      "hugepages_size": "2Mi",                                                             │ │
 │  │      "spec_overrides": {                                                                 │ │
 │  │          "spec.template.spec.domain.cpu.cores": 8,                                       │ │
 │  │          "spec.template.spec.domain.resources.requests.memory": "32Gi",                  │ │
@@ -1446,7 +1459,7 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 ## Part 3: VM 生命周期流程
 
 > **说明**: 本节描述 VM 的完整生命周期：创建请求 → 审批 → 执行 → 运行 → 删除
-
+>
 ### Purpose
 
 描述 VM 从提交申请到审批、执行、运行、删除的端到端交互预期。
@@ -1506,6 +1519,8 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 ├─────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                              │
 │  平台管理员:                                                                                  │
+│                                                                                              │
+│  当前基线: 集群选择先做 capability 匹配，再执行显式 cluster policy 校验，然后才继续审批或执行。 │
 │                                                                                              │
 │  系统根据 InstanceSize.spec_overrides 提取资源需求，匹配集群能力:                              │
 │                                                                                              │
@@ -1579,7 +1594,12 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │  1. 生成 VM 名称: prod-shop-shop-redis-01                                                    │
 │                                                                                              │
 │  2. 合并生成最终 YAML:                                                                        │
-│     Template (基础模板) + InstanceSize.spec_overrides + 用户参数 (disk_gb)                    │
+│     Template 启动盘定义 + InstanceSize.spec_overrides + 用户参数 (disk_gb)                    │
+│                                                                                              │
+│     启动盘渲染约定:                                                                           │
+│     - `containerdisk`    -> `volumes[].containerDisk`                                        │
+│     - `cdi_image_import` -> `dataVolumeTemplates` + `volumes[].dataVolume`                   │
+│     - `cdi_pvc_clone`    -> `dataVolumeTemplates` + `volumes[].dataVolume`                   │
 │                                                                                              │
 │  3. 渲染输出:                                                                                 │
 │     apiVersion: kubevirt.io/v1                                                               │


### PR DESCRIPTION
## Summary
- promote ADR-0040, ADR-0041, and ADR-0042 to accepted status and sync their design notes
- update the ADR index to reflect the accepted decision set and reading order
- align the English and zh-CN master-flow documents with the accepted canonical interaction flow

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`

Closes #331