### PR TITLE
[Draft] docs: add ADR-0043 bootstrap quality gate proposal

### DIFF
--- a/docs/adr/ADR-0022-modular-provider-pattern.md
+++ b/docs/adr/ADR-0022-modular-provider-pattern.md
@@ -461,3 +461,17 @@ Upon acceptance, perform the following:
 ---
 
 _End of ADR-0022_
+
+---
+
+## Post-Acceptance Note (2026-03-11)
+
+`ADR-0043-bootstrap-orchestration-quality-gate.md` is currently in
+`proposed` status and remains under the repository's standard 48-hour review
+window. Until it is accepted, implementation-facing guidance for this
+clarification lives in
+`docs/design/notes/ADR-0043-bootstrap-orchestration-quality-gate.md`.
+
+This follow-up note does not change the accepted content of `ADR-0022`; it only
+clarifies the current review status of the proposed composition-root quality
+gate adjustment.

--- a/docs/adr/ADR-0043-bootstrap-orchestration-quality-gate.md
+++ b/docs/adr/ADR-0043-bootstrap-orchestration-quality-gate.md
@@ -1,0 +1,141 @@
+---
+status: "proposed"
+date: 2026-03-11
+deciders: ["@jindyzhao"]
+consulted: []
+informed: []
+---
+
+# ADR-0043: Clarify Bootstrap Composition-Root Quality Gate
+
+> **Review Period**: Until 2026-03-13 (48-hour minimum)<br>
+> **Discussion**: [Issue #338](https://github.com/kv-shepherd/shepherd/issues/338)<br>
+> **Amends**: `ADR-0022-modular-provider-pattern.md` *(clarifies composition-root confirmation criteria)*
+
+---
+
+## Context and Problem Statement
+
+`ADR-0022` established the modular-provider pattern and the requirement that
+`internal/app/bootstrap.go` remain a concise composition root. One confirmation
+bullet in the accepted ADR used a file-level heuristic: `bootstrap.go` should
+not exceed 100 lines.
+
+The current implementation shows why that heuristic is too mechanical.
+`Bootstrap()` itself remains short and orchestration-only, while the file can
+exceed 100 total lines because of comments or small local helpers. Treating
+total file length as a hard gate would encourage low-value churn such as comment
+removal or arbitrary file splitting instead of protecting the actual design
+intent.
+
+The question is: how should the project evaluate composition-root quality
+without gaming comments, helpers, or harmless file structure?
+
+## Decision Drivers
+
+* Preserve the architectural intent of `ADR-0022`
+* Keep the composition root reviewable and free of business logic
+* Avoid low-value churn caused by mechanical line-count enforcement
+* Allow comments and small helper functions when they improve clarity
+* Keep ADR-0013 manual DI discipline explicit and auditable
+
+## Considered Options
+
+* **Option 1**: Continue enforcing a hard `<100 file lines` rule on `bootstrap.go`
+* **Option 2**: Evaluate `Bootstrap()` by orchestration-only responsibility and concise function size, not total file lines
+* **Option 3**: Remove size guidance entirely and rely only on subjective review
+
+## Decision Outcome
+
+**Chosen option**: "Option 2", because it preserves the real design intent of
+`ADR-0022` while preventing metric gaming and unnecessary churn.
+
+### Consequences
+
+* ✅ Good, because comments and helper functions no longer count as artificial violations
+* ✅ Good, because reviewers focus on whether `Bootstrap()` contains business logic or excessive dependency wiring complexity
+* ✅ Good, because the project keeps a concrete composition-root quality standard instead of a vague "keep it clean" expectation
+* 🟡 Neutral, because review now depends on function-level judgment rather than a single file-total number
+* ❌ Bad, because there is no longer a one-line mechanical check for total file length; mitigation is to keep explicit checklist guidance and manual DI CI checks
+
+### Confirmation
+
+Implementation conforms to this ADR when all of the following are true:
+
+1. `Bootstrap()` remains orchestration-only: initialize infrastructure, compose
+   modules, register workers, and return assembled application state.
+2. `Bootstrap()` does not contain domain/business rules, persistence logic, or
+   request handling behavior.
+3. Small helper functions in the same file are allowed when they keep
+   orchestration readable.
+4. Review and checklist language refers to `Bootstrap()` responsibility and
+   function size, not total file lines.
+5. ADR-0013 manual DI constraints and constructor-centralization rules remain
+   unchanged.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Continue enforcing a hard `<100 file lines` rule on `bootstrap.go`
+
+Treat total physical lines in the file as the quality gate.
+
+* ✅ Good, because it is easy to measure
+* ✅ Good, because it creates a visible ceiling
+* ❌ Bad, because comments and helper functions trigger false violations
+* ❌ Bad, because it encourages low-value rewrites that improve the metric but not the design
+
+### Option 2: Evaluate `Bootstrap()` by orchestration-only responsibility and concise function size
+
+Keep the architectural rule, but apply it to the composition-root function and
+its responsibilities rather than the full file.
+
+* ✅ Good, because it aligns with the actual design goal
+* ✅ Good, because it allows explanatory comments and local helpers
+* ✅ Good, because it keeps the composition root readable without forcing arbitrary splitting
+* ❌ Bad, because code review still requires judgment rather than a single numeric threshold
+
+### Option 3: Remove size guidance entirely and rely only on subjective review
+
+Drop any explicit size/shape expectation.
+
+* ✅ Good, because it avoids metric debates
+* ❌ Bad, because drift becomes harder to detect early
+* ❌ Bad, because reviewers lose a shared expectation for composition-root shape
+
+---
+
+## More Information
+
+### Related Decisions
+
+* `ADR-0013-manual-di.md` - strict manual dependency injection remains unchanged
+* `ADR-0022-modular-provider-pattern.md` - original modular-provider pattern decision
+
+### References
+
+* `docs/adr/TEMPLATE.md`
+* `ADR-0022-modular-provider-pattern.md`
+* `docs/adr/README.md`
+
+### Implementation Notes
+
+While this ADR remains proposed, implementation-facing guidance should live in
+`docs/design/notes/ADR-0043-bootstrap-orchestration-quality-gate.md`. Normative
+design specs should only absorb this clarification after the ADR is accepted.
+
+Revisit this ADR if:
+
+* `Bootstrap()` starts accumulating domain logic again
+* CI gains a reliable function-level complexity gate that makes the manual
+  review language obsolete
+* the project adopts a different composition-root structure entirely
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-11 | @jindyzhao | Reworked into template-compliant proposed ADR with explicit 48-hour review window |

--- a/docs/design/notes/ADR-0043-bootstrap-orchestration-quality-gate.md
+++ b/docs/design/notes/ADR-0043-bootstrap-orchestration-quality-gate.md
@@ -1,0 +1,53 @@
+# Design Note: ADR-0043 — Bootstrap Composition-Root Quality Gate
+
+> **Status**: Proposed (ADR-0043 under review until 2026-03-13)  
+> **Related ADR**: [ADR-0043](../../adr/ADR-0043-bootstrap-orchestration-quality-gate.md)  
+> **Owner**: @jindyzhao  
+> **Created**: 2026-03-11  
+> **Last Updated**: 2026-03-11
+
+## Summary
+
+ADR-0043 proposes a clarification to the `bootstrap.go` quality gate inherited
+from ADR-0022: the meaningful constraint is that `Bootstrap()` stays
+orchestration-only and concise, not that the entire file must remain under a
+mechanical total-line threshold.
+
+This note captures the pending implementation-facing interpretation while the
+ADR is still in review.
+
+## Scope
+
+- In scope: composition-root review criteria for `internal/app/bootstrap.go`
+- In scope: checklist language for orchestration-only validation
+- In scope: allowing comments and small helper functions in the same file
+- Out of scope: changing ADR-0013 manual DI rules
+- Out of scope: changing module boundaries introduced by ADR-0022
+- Out of scope: introducing new automated complexity tooling
+
+## Pending Clarification
+
+Until ADR-0043 is accepted, reviewers should interpret the `bootstrap.go`
+quality gate as follows:
+
+1. `Bootstrap()` should only assemble infrastructure, modules, handlers, and
+   workers.
+2. `Bootstrap()` should not contain domain rules, persistence logic, or request
+   behavior.
+3. Small local helpers and explanatory comments are allowed when they improve
+   readability.
+4. Total file line count is a weak signal, not a pass/fail rule by itself.
+
+## Affected Documentation
+
+- `docs/design/CHECKLIST.md`
+- `docs/design/checklist/phase-0-checklist.md`
+- `docs/design/checklist/phase-5-checklist.md`
+- `docs/design/phases/05-auth-api-frontend.md`
+
+## Revisit Conditions
+
+- ADR-0043 is accepted, rejected, or superseded
+- the project introduces an automated function-level complexity/shape gate
+- `bootstrap.go` begins to accumulate service logic again
+


### PR DESCRIPTION
## Summary
- add proposed ADR-0043 for bootstrap composition-root quality gate clarification
- add the paired design note required while the ADR is still in proposed status
- append an ADR-0022 status note so the accepted ADR stays immutable while pointing to the pending clarification

## Issue
Refs #338

## Review Window
- ADR-0043 public comment window runs until 2026-03-13
- this PR is intentionally opened as Draft during the review window

## Validation
- docs-only change
- no tests run