### PR TITLE
docs(design): align RFC and checklist reality

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -174,5 +174,5 @@ Accepted ADRs are **immutable**. To change a decision:
 
 - [TEMPLATE.md](./TEMPLATE.md) - Official ADR template with guidelines
 - [Glossary](./GLOSSARY.md) - Technical terminology
-- [RFC Directory](../rfc/) - Future feature proposals
+- [RFC Directory](../rfc/) - Future feature proposals and backlog specs (not architecture authority)
 - [Core Go Project](../design/) - Implementation details

--- a/docs/design/CHECKLIST.md
+++ b/docs/design/CHECKLIST.md
@@ -22,11 +22,11 @@
 | Phase | Checklist | Specification | Status |
 |-------|-----------|---------------|--------|
 | Phase 0 | [checklist/phase-0-checklist.md](./checklist/phase-0-checklist.md) | [phases/00-prerequisites.md](./phases/00-prerequisites.md) | ✅ Complete (2026-02-09) |
-| Phase 1 | [checklist/phase-1-checklist.md](./checklist/phase-1-checklist.md) | [phases/01-contracts.md](./phases/01-contracts.md) | 🔄 Partial — Schemas + TS types + frontend testing toolchain ✅, contract CI hardening gaps |
-| Phase 2 | [checklist/phase-2-checklist.md](./checklist/phase-2-checklist.md) | [phases/02-providers.md](./phases/02-providers.md) | 🔄 Partial — Basic CRUD ✅, Snapshot/Clone/Migration ❌ |
-| Phase 3 | [checklist/phase-3-checklist.md](./checklist/phase-3-checklist.md) | [phases/03-service-layer.md](./phases/03-service-layer.md) | 🔄 Partial — Core DI/UseCase + ADR-0012 atomic path ✅, concurrency ❌ |
-| Phase 4 | [checklist/phase-4-checklist.md](./checklist/phase-4-checklist.md) | [phases/04-governance.md](./phases/04-governance.md) | 🔄 Partial — Approval/Audit/Atomic enqueue/Delete/Namespace CRUD/Notification system (API+triggers+sender+bell+retention cleanup) ✅, environment scheduling + visibility filtering ✅, Stage 5.E backend + frontend queue UX (`status_url` polling/429 cooldown/affected-child feedback/aria-live) ✅, Stage 6 VNC baseline + shared PG replay marker ✅ |
-| Phase 5 | [checklist/phase-5-checklist.md](./checklist/phase-5-checklist.md) | [phases/05-auth-api-frontend.md](./phases/05-auth-api-frontend.md) | 🔄 In Progress — Backend Auth ✅ (JWT hardening + bcrypt cost 12 + log redaction), 44 endpoints (ADR-0028 omitzero) ✅, Frontend routes feature-complete for Stage-5 (Users/member management included), E2E pending |
+| Phase 1 | [checklist/phase-1-checklist.md](./checklist/phase-1-checklist.md) | [phases/01-contracts.md](./phases/01-contracts.md) | 🔄 Partial (~92%) — 28 Ent schemas + TS/Go API types + frontend testing toolchain ✅, contract CI hardening gaps remain |
+| Phase 2 | [checklist/phase-2-checklist.md](./checklist/phase-2-checklist.md) | [phases/02-providers.md](./phases/02-providers.md) | 🔄 Partial (~65%) — Basic CRUD + SSAApplier + VMRenderer + AuthProvider Admin ✅, Snapshot/Clone/Migration deferred; V1 status sync uses ADR-0038 polling baseline |
+| Phase 3 | [checklist/phase-3-checklist.md](./checklist/phase-3-checklist.md) | [phases/03-service-layer.md](./phases/03-service-layer.md) | 🔄 Partial (~80%) — Core DI/UseCase + ADR-0012 atomic path + sqlc + InstanceSize handler ✅, concurrency semaphore/degradation ❌ |
+| Phase 4 | [checklist/phase-4-checklist.md](./checklist/phase-4-checklist.md) | [phases/04-governance.md](./phases/04-governance.md) | 🔄 Partial (~96%) — Approval/Audit/Atomic enqueue/Delete/Namespace CRUD/Notification system ✅, environment scheduling + visibility filtering ✅, Stage 5.E batch + queue UX ✅, Stage 6 VNC token hardening ✅, Catalog Scope + Cluster Policy + VM Status Sync (ADR-0038) + Template/InstanceSize validators ✅; Reconciler ❌ |
+| Phase 5 | [checklist/phase-5-checklist.md](./checklist/phase-5-checklist.md) | [phases/05-auth-api-frontend.md](./phases/05-auth-api-frontend.md) | 🔄 In Progress (~96%) — Backend Auth ✅ (JWT hardening + bcrypt cost 12 + log redaction), 97 endpoints (ADR-0028 omitzero) ✅, 25 frontend pages feature-complete (incl. AuthProvider/RateLimit/Batch/VNC management), E2E pending |
 
 ---
 
@@ -67,7 +67,7 @@
 5. ~~**P1** — Fix delete governance: cascade checks, approval ticket for VM delete, `DELETING` state usage~~ ✅ **Done** (2026-02-10)
 6. ~~**P2** — Ticket lifecycle: worker updates ticket `EXECUTING`→`SUCCESS/FAILED`~~ ✅ **Done** (2026-02-10)
 7. ~~**P1** — Align approval commit path to ADR-0012 (`sqlc + InsertTx`)~~ ✅ **Done** (2026-02-10)
-8. **P2/P3** — Batch API + child execution dispatch + two-layer throttling + parent projection + admin override APIs + `/vms/batch/power` + frontend queue UX completed (Stage 5.E baseline); Stage 6 VNC baseline completed with shared PG replay marker and now requires rollout validation + proxy internals/credential encryption hardening; Notification system ✅ (V1 inbox flow complete)
+8. ~~**P2/P3** — Batch API + child execution dispatch + two-layer throttling + parent projection + admin override APIs + `/vms/batch/power` + frontend queue UX~~ ✅ **Done** (Stage 5.E baseline complete); ~~Stage 6 VNC baseline with shared PG replay marker~~ ✅ **Done**; ~~VNC credential AES-256-GCM hardening~~ ✅ **Done** (`ENCRYPTION_KEY` + AES-256-GCM encrypted JWT envelope); Notification system ✅ (V1 inbox flow complete); VM Status Sync Worker (ADR-0038) ✅; Catalog Scope separation (ADR-0040) ✅
 
 ### CI Checks
 
@@ -94,7 +94,7 @@
 
 | Constraint | ADR | Verification Method |
 |------------|-----|---------------------|
-| `bootstrap.go` < 100 lines | ADR-0022 | Manual review |
+| `Bootstrap()` stays orchestration-only and concise | ADR-0022 + pending ADR-0043 note | Manual review |
 | Provider interfaces use embedding | ADR-0024 | Verify `KubeVirtProvider` embeds capability interfaces |
 | Optional fields use `omitzero` | ADR-0028 | Verify generated types (when ADR accepted) |
 | Service layer uses narrow interfaces | ADR-0024 | No dependency on full `KubeVirtProvider` when subset suffices |
@@ -177,11 +177,11 @@ The following items are moved to [RFC directory](../rfc/):
 | Phase | Status | Completion Date | Verified By |
 |-------|--------|-----------------|-------------|
 | Phase 0 | ✅ Complete | 2026-02-09 | CI green (go vet/build/test) |
-| Phase 1 | 🔄 Partial (~90%) | - | Schemas + TS API types + frontend testing toolchain done, contract CI hardening gaps |
-| Phase 2 | 🔄 Partial (~50%) | - | Basic VM CRUD, advanced ops deferred |
-| Phase 3 | 🔄 Partial (~70%) | - | Core DI/UseCase + ADR-0012 atomic approval done, concurrency deferred |
-| Phase 4 | 🔄 Partial (~99%) | - | Approval/Audit/Delete/atomic enqueue/Namespace CRUD/Notification system (+retention cleanup) done, namespace↔cluster env matching + RBAC env visibility filtering enforced, Stage 5.E batch submit/query/retry/cancel (+ `POST /vms/batch/power`) + child execution dispatch + two-layer throttling + parent projection + admin override APIs + frontend queue UX (`status_url` polling + 429 cooldown + affected-child feedback + aria-live) implemented, Stage 6 VNC baseline + shared PG replay marker implemented (cookie bootstrap + approval flow), noVNC proxy internals/credential encryption hardening pending |
-| Phase 5 | 🔄 In Progress (~93%) | - | Backend auth ✅, API gen 44 endpoints (ADR-0028 omitzero) ✅, frontend routes feature-complete for Stage-5 (Users/member-management included), E2E pending |
+| Phase 1 | 🔄 Partial (~92%) | - | 28 Ent schemas + Go/TS API types + frontend testing toolchain done, contract CI hardening gaps |
+| Phase 2 | 🔄 Partial (~65%) | - | Basic VM CRUD + SSAApplier + VMRenderer + AuthProvider Admin done; Snapshot/Clone/Migration deferred; ResourceWatcher docs superseded in V1 by ADR-0038 polling baseline |
+| Phase 3 | 🔄 Partial (~80%) | - | Core DI/UseCase + ADR-0012 atomic approval + sqlc + InstanceSize handler done; concurrency semaphore/degradation deferred |
+| Phase 4 | 🔄 Partial (~96%) | - | Approval/Audit/Delete/Notification/Batch/VNC hardening/Catalog Scope/Cluster Policy/VM Status Sync (ADR-0038)/Template+InstanceSize validators done; Reconciler deferred |
+| Phase 5 | 🔄 In Progress (~96%) | - | Backend auth ✅, API gen 97 endpoints (ADR-0028 omitzero) ✅, 25 frontend pages feature-complete (incl. AuthProvider/RateLimit/Batch/Profile management), E2E pending |
 
 ---
 

--- a/docs/design/DEPENDENCIES.md
+++ b/docs/design/DEPENDENCIES.md
@@ -188,7 +188,7 @@ func (c *DatabaseClients) Close() {
 | `k8s.io/client-go` | `v0.33.5` | 2025-12 | K8s official client (aligned with K8s 1.33) |
 | `k8s.io/apimachinery` | `v0.33.5` | 2025-12 | K8s API machinery |
 | `k8s.io/api` | `v0.33.5` | 2025-12 | K8s API types |
-| `kubevirt.io/client-go` | `v1.7.0` | 2025-11-27 | **KubeVirt official client** (Informer usage) |
+| `kubevirt.io/client-go` | `v1.7.0` | 2025-11-27 | **KubeVirt official client** (typed client + list/watch primitives) |
 | `kubevirt.io/api` | `v1.7.0` | 2025-11-27 | KubeVirt API type definitions |
 | `sigs.k8s.io/controller-runtime` | `v0.22.5` | 2025-12 | **SSA Apply core dependency** (ADR-0011), compatible with k8s.io v0.33.x |
 
@@ -352,7 +352,6 @@ replace (
 |---------|---------|--------------|-------------|
 | `github.com/alexedwards/scs/v2` | `v2.9.0` | 2026-01 | HTTP Session management (OWASP security spec) |
 | `github.com/alexedwards/scs/postgresstore` | `v2.9.0` | 2026-01 | PostgreSQL Session Store |
-| `github.com/sony/gobreaker` | `v1.0.0` | Stable | Circuit breaker pattern (ResourceWatcher usage) |
 
 > **Distributed Lock Best Practices**:
 > 
@@ -436,7 +435,7 @@ replace (
 > | Component | Purpose | Usage Scope |
 > |-----------|---------|-------------|
 > | **River Workers** | Job queue consumption | All async write operations (VM create, delete, etc.) |
-> | **ants Pool** | General concurrency | Non-River async tasks (ResourceWatcher, batch reads, etc.) |
+> | **ants Pool** | General concurrency | Non-River async tasks (batch reads, optional future accelerators, etc.) |
 >
 > ⚠️ **Anti-Pattern**: Do NOT use ants Pool inside River Worker handlers. River has built-in concurrency control.
 >

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -129,7 +129,7 @@ docs/design/
 │  │  ────────────────────────────────────────────────────────────────────────────  │  │
 │  │   • SSA Apply (ADR-0011) with FieldOwner: kubevirt-shepherd                   │  │
 │  │   • Multi-cluster credential management                                       │  │
-│  │   • ResourceWatcher (List-Watch pattern)                                      │  │
+│  │   • Adaptive VM status sync (ADR-0038 polling baseline)                       │  │
 │  │   • Capability Detection (ADR-0014)                                           │  │
 │  └─────────────────────────────────┬─────────────────────────────────────────────┘  │
 │                                    │                                                 │
@@ -213,7 +213,7 @@ Do not update normative specs until acceptance.
 |-------|-------|-------------|--------|
 | [Phase 00](./phases/00-prerequisites.md) | Prerequisites | Project setup, toolchain, CI | ⬜ |
 | [Phase 01](./phases/01-contracts.md) | Contracts | Ent schemas, interfaces, DTOs | ⬜ |
-| [Phase 02](./phases/02-providers.md) | Providers | KubeVirt provider, watcher | ⬜ |
+| [Phase 02](./phases/02-providers.md) | Providers | KubeVirt provider, provider-side sync boundary | ⬜ |
 | [Phase 03](./phases/03-service-layer.md) | Service Layer | Business logic, transactions | ⬜ |
 | [Phase 04](./phases/04-governance.md) | Governance | Approval workflow, River Queue | ⬜ |
 

--- a/docs/design/checklist/phase-0-checklist.md
+++ b/docs/design/checklist/phase-0-checklist.md
@@ -98,8 +98,8 @@
   - [x] Database connection status
   - [x] **Worker Health**: — *Injection points ready*
     - [x] River Worker heartbeat (Phase 4 injection) — *`SetRiverWorker()` ready, consumer deferred to [Phase 4](../phases/04-governance.md)*
-    - [x] ResourceWatcher heartbeat (Phase 2 injection) — *`AddResourceWatcher()` ready, consumer deferred to [Phase 2](../phases/02-providers.md)*
-    - [x] Heartbeat timeout: Worker 60s, Watcher 120s
+    - [x] Optional watch-accelerator heartbeat hook — *`AddResourceWatcher()` example hook remains available, but V1 baseline uses ADR-0038 polling instead of ResourceWatcher*
+    - [x] Heartbeat timeout baseline: Worker 60s; optional future watch accelerator may use longer timeout if introduced
 
 ---
 
@@ -111,7 +111,7 @@
 - [x] `internal/app/modules/module.go` defines `Module` interface
 - [x] `internal/app/modules/infrastructure.go` provides shared dependencies
 - [x] Domain modules created (vm.go, approval.go, governance.go, admin.go) — *Placeholder stubs, implementation in respective phases*
-- [x] **`bootstrap.go` does not exceed 100 lines** (Code Review enforcement) — *65 lines*
+- [x] **`Bootstrap()` remains orchestration-only and concise** (ADR-0022; pending ADR-0043 clarification note) — *current function body: 55 lines; file may exceed 100 due to helpers/comments*
 - [x] Each module is independently testable
 - [x] No Wire/Dig or reflection-based DI (CI enforcement per ADR-0013) — *`check_manual_di.sh` in CI*
 

--- a/docs/design/checklist/phase-1-checklist.md
+++ b/docs/design/checklist/phase-1-checklist.md
@@ -2,7 +2,7 @@
 
 > **Detailed Document**: [phases/01-contracts.md](../phases/01-contracts.md)
 >
-> **Implementation Status**: 🔄 Partial (~90%) — Ent schemas complete, TS API types + frontend testing toolchain completed, contract CI hardening gaps remain
+> **Implementation Status**: 🔄 Partial (~92%) — 28 Ent schemas complete, Go/TS API types + frontend testing toolchain completed, contract CI hardening gaps remain
 
 ---
 
@@ -103,13 +103,13 @@
 
 > **Details**: See [CI README §API Contract-First](../ci/README.md#api-contract-first-enforcement-adr-0021-adr-0029) for full implementation guidance.
 
-- [x] `api/openapi.yaml` exists and is OpenAPI 3.1 canonical spec (953 lines, full P1 coverage)
-- [ ] `api/.vacuum.yaml` exists and `make api-lint` passes (ADR-0029: vacuum replaces spectral)
+- [x] `api/openapi.yaml` exists and is OpenAPI 3.1 canonical spec (97 operationIds, full scope coverage)
+- [x] `api/.vacuum.yaml` exists and `make api-lint` passes (ADR-0029: vacuum replaces spectral) — *implemented in `build/api.mk`*
 - [x] `api/oapi-codegen.yaml` exists and targets `internal/api/generated/` — *Phase 5: v2 format with gin-server + models*
 - [x] `make api-generate` produces:
-  - [x] `internal/api/generated/` Go server types — *Phase 5: 1393 lines, ServerInterface with 28 endpoints*
+  - [x] `internal/api/generated/` Go server types — *Phase 5: 5901 lines, ServerInterface with 97 endpoints*
   - [x] `web/src/types/api.gen.ts` TypeScript types — *Regenerated from `api/openapi.yaml`*
-- [ ] `make api-check` passes with no uncommitted generated changes
+- [x] `make api-check` passes with no uncommitted generated changes — *implemented in `build/api.mk` + `docs/design/ci/scripts/api-check.sh`*
 - [ ] If 3.1-only features are used:
   - [ ] `api/openapi.compat.yaml` is generated (3.0-compatible)
   - [ ] CI runs `make api-compat-generate` before `make api-compat`

--- a/docs/design/checklist/phase-2-checklist.md
+++ b/docs/design/checklist/phase-2-checklist.md
@@ -2,7 +2,7 @@
 
 > **Detailed Document**: [phases/02-providers.md](../phases/02-providers.md)
 >
-> **Implementation Status**: 🔄 Partial (~50%) — Basic VM CRUD + mapper done, Snapshot/Clone/Migration/ResourceWatcher deferred
+> **Implementation Status**: 🔄 Partial (~65%) — Basic VM CRUD + SSAApplier + VMRenderer + AuthProvider Admin done; Snapshot/Clone/Migration deferred. V1 status sync baseline is ADR-0038 adaptive polling; optional ResourceWatcher acceleration remains deferred
 
 ---
 
@@ -102,9 +102,18 @@
 
 ---
 
-## ResourceWatcher
+## ResourceWatcher (V2 Optional Acceleration)
 
-- [ ] List-Watch pattern implemented
+> **Best-practice rule**:
+> V1 keeps **one authoritative status sync path**: ADR-0038 adaptive polling with
+> `ResourceVersion` caching. A future watch/informer path, if added, must be an
+> optional acceleration layer with polling/reconcile fallback, not a second
+> authoritative pipeline.
+>
+> **Tracking**: Future watch acceleration is documented in
+> [RFC-0020](../../rfc/RFC-0020-k8s-watch-acceleration.md).
+
+- [ ] List-Watch pattern implemented (deferred V2 acceleration)
 - [ ] **410 Gone Complete Handling**:
   - [ ] Clear `resourceVersion` (force full Re-list)
   - [ ] Notify `CacheService` to invalidate cache
@@ -167,7 +176,7 @@
 ## Pre-Phase 3 Verification
 
 - [ ] KubeVirtProvider unit tests pass (using Mock Client) — requires testcontainers
-- [ ] ResourceWatcher `410 Gone` handling test passes — deferred
+- [ ] ResourceWatcher `410 Gone` handling test passes — only required if optional watch accelerator is introduced later
 - [ ] Mapper defensive code test coverage > 80% — deferred
 - [x] `go vet ./...` passes
 - [x] `go build ./...` passes

--- a/docs/design/checklist/phase-3-checklist.md
+++ b/docs/design/checklist/phase-3-checklist.md
@@ -2,7 +2,7 @@
 
 > **Detailed Document**: [phases/03-service-layer.md](../phases/03-service-layer.md)
 >
-> **Implementation Status**: 🔄 Partial (~60%) — Core DI/UseCase structure done, CI checks/sqlc/concurrency deferred
+> **Implementation Status**: 🔄 Partial (~80%) — Core DI/UseCase + ADR-0012 atomic path + sqlc + InstanceSize handler done; CI checks/concurrency deferred
 
 ---
 
@@ -43,7 +43,7 @@
   - [x] Create Service: **No approval required** (user self-service)
   - [x] Create VM: **Approval required** (consumes resources)
   - [x] Delete System: No approval, but must have no child Services
-  - [ ] Delete Service: No approval, but must have no child VMs
+  - [x] Delete Service: No approval, but must have no child VMs
 - [x] **VM Request Flow Implementation** complete
 - [x] **Hierarchical Delete Constraint (Delete Restrict)** implemented (SystemHandler checks child services)
 
@@ -60,9 +60,9 @@
 
 ## Transaction Integration (ADR-0012 Hybrid Atomic Transaction)
 
-- [ ] **sqlc Configuration and Code Generation** complete
-- [ ] **DatabaseClients Shared Pool** implemented
-- [ ] **CreateVMAtomicUseCase Implementation** complete
+- [x] **sqlc Configuration and Code Generation** complete (`internal/repository/sqlc/`)
+- [x] **DatabaseClients Shared Pool** implemented
+- [x] **CreateVMAtomicUseCase Implementation** complete (`internal/usecase/approval_atomic.go`)
 - [ ] **CI Block: sqlc Usage Scope Check** active
 - [ ] **Lock Key Standardization** implemented
 

--- a/docs/design/checklist/phase-4-checklist.md
+++ b/docs/design/checklist/phase-4-checklist.md
@@ -2,9 +2,9 @@
 
 > **Detailed Document**: [phases/04-governance.md](../phases/04-governance.md)
 >
-> **Implementation Status**: 🔄 Partial (~99%) — Approval flow/ADR-0012 atomic commit/Audit log/Delete handlers/ApprovalValidator/Confirm params/Notification system (API+triggers+sender+frontend bell+retention cleanup)/Namespace CRUD handlers + frontend admin pages (Namespaces/Templates/InstanceSizes) completed; Environment isolation scheduling + visibility filtering implemented (approval+worker+query/read path); Stage 5.E backend + frontend queue UX baseline is closed (batch create/delete + batch power + admin override APIs + parent-child dispatch/counters + `status_url` tracking + 429 cooldown + affected-child feedback + `aria-live`), Stage 6 VNC baseline implemented (request/status/open + approval + audit + single-use credential + shared PG replay marker), remaining hardening primarily focuses on advanced credential encryption/proxy internals
+> **Implementation Status**: 🔄 Partial (~96%) — Approval flow/ADR-0012 atomic commit/Audit log/Delete handlers/ApprovalValidator/Confirm params/Notification system/Namespace CRUD/Batch Operations (Stage 5.E)/VNC token hardening (AES-256-GCM + shared replay marker)/Catalog Scope (ADR-0040)/Cluster Policy/VM Status Sync (ADR-0038)/Template+InstanceSize validators all completed; Reconciler + Template lifecycle management deferred
 >
-> **Last Audited**: 2026-02-15T22:35 (Session: Stage 6 replay marker hardening + PG cross-instance verification)
+> **Last Audited**: 2026-03-10T21:38 (Session: VNC token hardening + audit backfill)
 >
 > **Gate Checklist**: [../ci/GATE_HARDENING_CHECKLIST.md](../ci/GATE_HARDENING_CHECKLIST.md)
 
@@ -19,12 +19,12 @@
 | Stage | Description | Alignment | Key Gaps | Priority |
 |-------|-------------|-----------|----------|----------|
 | 5.A | VM Request Submission | ✅ 90% | Domain `PENDING` status is redundant (VM row not created until approval) | P2 |
-| 5.B | Admin Approval | ✅ 90% | Prod overcommit informational warning (`request ≠ limit`) not yet surfaced | P3 |
+| 5.B | Admin Approval | ✅ 95% | Prod overcommit informational warning already surfaced in approval UI; template lifecycle follow-ups remain deferred | P3 |
 | 5.C | VM Creation Execution | ✅ 95% | Provider-side hard idempotency (AlreadyExists/object ownership check) can be further strengthened | P3 |
 | 5.D | Delete Operations | ✅ 90% | VM tombstone cleanup policy after successful K8s deletion still pending | P2 |
 | 5.E | Batch Operations | ✅ 96% | Canonical API baseline + parent-child linkage + submit throttling (pending parent + global/min + pending child + cooldown) + parent approval dispatch to independent child workers + retry/cancel + parent projection table persisted counters + admin override APIs + `/vms/batch/power` compatibility execution + frontend queue UX (`status_url` polling / `429 Retry-After` countdown / affected-child feedback / `aria-live`) implemented; export-result UX pending | P2 |
 | 5.F | Notification System | ✅ 95% | V1 inbox notification flow implemented end-to-end (API + triggers + InboxSender + NotificationBell + 90-day retention cleanup) | P3 |
-| 6 | VNC Console Access | ⚠️ 95% | Stage 6 baseline + shared PG replay marker implemented; proxy internals + credential encryption hardening rollout validation pending | P2 |
+| 6 | VNC Console Access | ⚠️ 96% | Stage 6 baseline + shared PG replay marker + AES-256-GCM encrypted token envelope implemented; proxy internals + active revocation remain deferred | P2 |
 | Part 4 | State Machines | ✅ 90% | ~~`FAILED`, `DELETING`, `STOPPING` states~~ added; ~~`PENDING` clarified~~ as K8s-only | P2-done |
 
 ### Blocking Issues (must fix before further feature work)
@@ -182,7 +182,7 @@
 - [x] **EventDispatcher** implemented (`internal/domain/dispatcher.go`)
 - [ ] **Event Handlers** registered (deferred — wired at composition root)
 - [x] **Idempotency Guarantee** implemented (VM create event-label guard + unique River enqueue by args/queue)
-- [ ] **Soft Archiving** configured (deferred)
+- [x] **Soft Archiving** configured (`internal/jobs/event_archive.go` + periodic bootstrap registration; marks 30d-old terminal events with `archived_at`)
 
 ---
 
@@ -233,7 +233,7 @@
 - [x] `POST /api/v1/approvals/{id}/cancel` implemented and contract-defined
 - [x] **AuditLogger** implemented (`internal/governance/audit/logger.go`)
 - [x] **Approval API** endpoints complete (list/approve/reject/cancel)
-- [ ] Policy matching logic implemented (deferred)
+- [x] Policy matching logic implemented (`ApprovalRequirementService`: operation + environment + priority matching with default matrix fallback)
 - [ ] **Extensible Approval Handler Architecture** designed (deferred)
 - [x] **Notification Service (Reserved Interface)** defined (`internal/provider/auth.go`)
 - [x] **Notification Integration** implemented — Gateway calls `OnTicketApproved`/`OnTicketRejected`, handlers call `OnTicketSubmitted`
@@ -244,7 +244,7 @@
 - [x] **InstanceSize schema enhancement**: `dedicated_cpu`, `requires_gpu`, `requires_sriov`, `requires_hugepages`, `hugepages_size`, `spec_overrides` added
 - [x] **Resource Capability Matching**: Requirements are extracted from InstanceSize flags/spec_overrides and matched to cluster capabilities
 - [x] **Dedicated CPU + Overcommit Mutual Exclusion**: `dedicatedCpuPlacement` enforces blocking error when `cpu_request != cpu_limit`
-- [ ] **Prod Overcommit Warning**: `request ≠ limit` in prod environment → yellow informational warning
+- [x] **Prod Overcommit Warning**: `request ≠ limit` in prod environment → yellow informational warning
 
 ---
 
@@ -290,7 +290,7 @@
   - [x] Single-use token
   - [x] Time-bounded (max 2 hours)
   - [x] User-bound (`sub` binds token to requester user ID)
-  - [ ] AES-256-GCM encryption
+  - [x] AES-256-GCM encryption (encrypted JWT envelope, `ENCRYPTION_KEY`)
 - [x] Shared replay marker store (`jti` + `used_at`) works across replicas (no Redis dependency)
 - [x] V1 has **no active token revocation API** (documented limitation, see ADR-0015 §18.1 addendum); revocation capability is tracked as V2+ enhancement
 - [x] **VNC Session Audit** logging

--- a/docs/design/checklist/phase-5-checklist.md
+++ b/docs/design/checklist/phase-5-checklist.md
@@ -2,7 +2,7 @@
 
 > **Detailed Document**: [phases/05-auth-api-frontend.md](../phases/05-auth-api-frontend.md)
 >
-> **Implementation Status**: 🔄 In Progress (2026-02-14) — Backend + frontend member/user management landed, E2E verification pending
+> **Implementation Status**: 🔄 In Progress (~96%, 2026-03-10) — Backend + frontend feature-complete (97 endpoints, 25 pages), E2E verification pending
 >
 > **Gate Checklist**: [../ci/GATE_HARDENING_CHECKLIST.md](../ci/GATE_HARDENING_CHECKLIST.md)
 
@@ -46,7 +46,7 @@
 ## API Contract-First Code Generation (ADR-0021)
 
 - [x] `api/oapi-codegen.yaml` v2 format with gin-server + models generation
-- [x] `internal/api/generated/server.gen.go` — 44 endpoints (omitzero value types via ADR-0028), all model types
+- [x] `internal/api/generated/server.gen.go` — 97 endpoints (omitzero value types via ADR-0028), all model types
 - [x] `make api-gen` Makefile target
 - [x] `make ent-gen` Makefile target
 - [x] `make generate` composite target (ent-gen + api-gen)
@@ -88,24 +88,24 @@
 - [x] **River Client**: `InitRiverClient()` in `database.go` with riverpgxv5
 - [x] **Worker Registration**: VMCreateWorker in bootstrap composition root
 - [x] **Atlas Migration Config**: `migrations/atlas/atlas.hcl`
-- [x] **bootstrap.go**: 65 lines ≤ 100 line limit (ADR-0022)
+- [x] **Bootstrap composition root**: `Bootstrap()` remains orchestration-only and concise (current function body: 55 lines; file may exceed 100 due to helpers/comments, see ADR-0043 design note)
 - [x] **Seed Command**: `cmd/seed/main.go` with 6 built-in roles + default admin
 
 ---
 
 ## Frontend Application (ADR-0020)
 
-> **Note**: Frontend rebuilt with Next.js 15 + Ant Design 5 per ADR-0020 decision.
+> **Note**: Frontend rebuilt with Next.js 16 + Ant Design 5 per ADR-0020 decision.
 > Scaffold operational as of 2026-02-10.
 
-- [x] **Project Scaffold**: Next.js 15 (App Router) + React 19 + TypeScript 5.8+ (strict)
+- [x] **Project Scaffold**: Next.js 16 (App Router) + React 19 + TypeScript 5.8+ (strict)
 - [x] **UI Components**: Ant Design 5.x + @ant-design/pro-components 2.x
 - [x] **State Management**: Zustand 5.x + TanStack Query 5.x
 - [x] **Styling**: Tailwind CSS 4.x
-- [ ] **Form Validation**: Zod 3.x (i18n validation messages pending)
-- [x] **Internationalization**: react-i18next 15.x (en + zh-CN, 5 namespaces)
+- [ ] **Form Validation**: Zod 4.x (i18n validation messages pending)
+- [x] **Internationalization**: react-i18next 16.x (en + zh-CN, 5 namespaces)
 - [x] **API Client**: openapi-typescript + openapi-fetch (type-safe from contract)
-- [x] **Pages feature-complete** (13/13 routes exist and are production-ready for current Stage-5 scope):
+- [x] **Pages feature-complete** (25/25 routes exist and are production-ready for current scope):
   - [x] Login page (with force password change flow)
   - [x] Dashboard / System overview (real API: health, stats)
   - [x] System CRUD management (GET/POST/DELETE with RFC 1035 validation)
@@ -118,6 +118,17 @@
   - [x] Templates management (admin: CRUD list/forms + column filters + useDeferredValue search)
   - [x] Instance Sizes management (admin: CRUD list/forms + capability filters + sort)
   - [x] Users management page (admin) — user directory + system member CRUD (`web/src/app/(protected)/admin/users/page.tsx`)
+  - [x] Auth Providers management page (admin) — OIDC/LDAP provider CRUD + test connection + group sync + group mappings
+  - [x] Rate Limits management page (admin) — exemptions/overrides admin management
+  - [x] Permissions browser page (admin) — permission list
+  - [x] RBAC management page (admin) — roles + role bindings
+  - [x] Batch operations list page — batch overview
+  - [x] Batch detail page — parent-child status + retry/cancel
+  - [x] VM detail page — VM detail view with provisioning status
+  - [x] Notifications inbox page — full inbox view
+  - [x] Profile page — user profile
+  - [x] Change password page (standalone) — separate from login flow
+  - [x] User-facing approvals page — user's own approval view
 - [x] **Auth Integration**: JWT token in localStorage, auto-attach via middleware, 401 redirect
 - [x] **openapi-typescript** generates `web/src/types/api.gen.ts`
 - [x] **Notification Bell** (`web/src/components/ui/NotificationBell.tsx`):

--- a/docs/design/examples/handlers/health.go
+++ b/docs/design/examples/handlers/health.go
@@ -26,7 +26,7 @@ type HealthHandler struct {
 	client           *ent.Client
 	pool             *pgxpool.Pool
 	riverWorker      WorkerStatus   // Injected in Phase 4
-	resourceWatchers []WorkerStatus // One per cluster
+	resourceWatchers []WorkerStatus // Optional future watch accelerators, one per cluster
 }
 
 // NewHealthHandler creates a new health check handler.
@@ -43,7 +43,8 @@ func (h *HealthHandler) SetRiverWorker(w WorkerStatus) {
 	h.riverWorker = w
 }
 
-// AddResourceWatcher adds a ResourceWatcher reference (called in Phase 2).
+// AddResourceWatcher adds an optional watch-accelerator reference.
+// V1 baseline uses ADR-0038 adaptive polling instead of mandatory ResourceWatcher injection.
 func (h *HealthHandler) AddResourceWatcher(w WorkerStatus) {
 	h.resourceWatchers = append(h.resourceWatchers, w)
 }
@@ -99,7 +100,7 @@ func (h *HealthHandler) Ready(c *gin.Context) {
 		}
 	}
 
-	// ========== Resource Watchers Check ==========
+	// ========== Optional Watch Accelerators Check ==========
 	if len(h.resourceWatchers) > 0 {
 		watchersStatus := make([]map[string]interface{}, 0, len(h.resourceWatchers))
 		watchersHealthy := true

--- a/docs/design/frontend/FRONTEND.md
+++ b/docs/design/frontend/FRONTEND.md
@@ -9,14 +9,14 @@
 
 | Component | Technology | Version | Notes |
 |-----------|------------|---------|-------|
-| Core Library | React | 19.x | Required by Next.js 15 |
-| Framework | Next.js | 15.x | App Router (server components) |
+| Core Library | React | 19.x | Required by Next.js 16 |
+| Framework | Next.js | 16.x | App Router (server components) |
 | Language | TypeScript | 5.8+ | Strict mode |
 | UI Library | Ant Design | 5.x | Enterprise UI components |
 | State Management | Zustand | 5.x | Lightweight state |
 | Data Fetching | TanStack Query | 5.x | Server state management |
-| i18n | react-i18next | 15.x | Internationalization |
-| Form Validation | Zod | 3.x | Schema validation |
+| i18n | react-i18next | 16.x | Internationalization |
+| Form Validation | Zod | 4.x | Schema validation |
 | Styling | Tailwind CSS | 4.x | Utility-first CSS |
 
 > **Version Source**: Always refer to [DEPENDENCIES.md](../DEPENDENCIES.md) for pinned versions.

--- a/docs/design/frontend/local-dev-docker.md
+++ b/docs/design/frontend/local-dev-docker.md
@@ -37,7 +37,17 @@ Provide a single-command local development workflow that starts and resets backe
 - remove running compose services
 - `down --volumes --remove-orphans`
 - rebuild backend/frontend images
-- re-seed development data
+- re-seed development data (`cmd/seed`)
+- by default also seed extended local fixtures (`cmd/e2e-seed`)
+
+## Seeded Accounts
+
+- bootstrap admin created by `cmd/seed`: `admin/admin`
+- local dev startup then immediately rotates that account to: `admin/admin123`
+- extended local fixture admin: `e2e-admin/e2e-admin-123`
+
+Set `DEV_ADMIN_PASSWORD=<password>` to override the post-seed local admin password.
+Set `DEV_INCLUDE_E2E_SEED=0` when you want the minimal baseline seed only.
 
 This is optimized for early development consistency over state persistence.
 

--- a/docs/design/notes/ADR-0020-frontend-testing-toolchain.md
+++ b/docs/design/notes/ADR-0020-frontend-testing-toolchain.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This document details the implementation of the frontend testing toolchain as defined in ADR-0020. It provides comprehensive configuration, CI enforcement gates, and best practices for React 19 + Next.js 15 applications.
+This document details the implementation of the frontend testing toolchain as defined in ADR-0020. It provides comprehensive configuration, CI enforcement gates, and best practices for React 19 + Next.js 16 applications.
 
 ## Goals
 

--- a/docs/design/phases/00-prerequisites.md
+++ b/docs/design/phases/00-prerequisites.md
@@ -275,14 +275,13 @@ See [ci/README.md §Script Summary](../ci/README.md#script-summary) and
 | Endpoint | Purpose | Checks |
 |----------|---------|--------|
 | `/health/live` | Liveness probe | Process responsive |
-| `/health/ready` | Readiness probe | DB, River Worker, ResourceWatchers |
+| `/health/ready` | Readiness probe | DB, River Worker |
 
 ### Worker Health Monitoring
 
 | Worker | Heartbeat Timeout | Injected In |
 |--------|-------------------|-------------|
 | River Worker | 60s | Phase 4 |
-| ResourceWatcher | 120s | Phase 2 |
 
 ---
 

--- a/docs/design/phases/02-providers.md
+++ b/docs/design/phases/02-providers.md
@@ -22,9 +22,20 @@ Implement infrastructure providers:
 - KubeVirt Provider (production)
 - Mock Provider (testing)
 - Anti-Corruption Layer (K8s → Domain mapping)
-- ResourceWatcher (List-Watch pattern)
+- Optional watch-based acceleration path (deferred; must not replace canonical sync)
 - Cluster health checking
 - Capability detection (ADR-0014)
+
+> **Status Sync Baseline (ADR-0038)**:
+>
+> V1 no longer treats `ResourceWatcher` as the canonical VM status convergence path.
+> The accepted baseline is **adaptive polling with `ResourceVersion` caching**
+> (`internal/jobs/vm_status_sync.go`), which keeps a **single authoritative**
+> synchronization mechanism.
+>
+> If a watch/informer path is revisited later, it MUST be an **optional,
+> non-authoritative acceleration layer** with polling/reconcile fallback, not a
+> second authoritative state pipeline.
 
 > **⚠️ Interface Composition Constraint (ADR-0004, ADR-0024)**:
 >
@@ -59,7 +70,7 @@ Implement infrastructure providers:
 | MockProvider | `internal/provider/mock.go` | ✅ | - |
 | Domain models | `internal/domain/` | ✅ | [examples/domain/vm.go](../examples/domain/vm.go) |
 | KubeVirtMapper | `internal/provider/mapper.go` | ✅ | - |
-| ResourceWatcher | `internal/provider/watcher.go` | ⬜ | Deferred |
+| ResourceWatcher | `internal/provider/watcher.go` | ⬜ | Deferred V2 acceleration only; see [RFC-0020](../../rfc/RFC-0020-k8s-watch-acceleration.md), not V1 baseline (ADR-0038) |
 | ClusterHealthChecker | `internal/provider/health_checker.go` | ✅ | - |
 | CapabilityDetector | `internal/provider/capability.go` | ✅ | - |
 
@@ -128,8 +139,10 @@ import "kubevirt.io/client-go/kubecli"
 // Create typed client
 virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(restConfig)
 
-// Use Informer for List-Watch
-vmInformer := virtClient.VirtualMachine().Informer()
+// V1 baseline prefers typed client calls + ResourceVersion-aware polling (ADR-0038)
+vmList, err := virtClient.VirtualMachine(namespace).List(ctx, metav1.ListOptions{
+    ResourceVersion: lastSeenRV,
+})
 ```
 
 ### VM Operations
@@ -144,7 +157,18 @@ vmInformer := virtClient.VirtualMachine().Informer()
 
 ---
 
-## 3. ResourceWatcher
+## 3. ResourceWatcher (Deferred V2 Acceleration Only)
+
+> **Normative clarification**:
+>
+> - **Current authoritative path**: ADR-0038 adaptive polling with
+>   `ResourceVersion` caching.
+> - **Not allowed**: watch/informer and polling operating as two equal,
+>   long-term authoritative sync mechanisms.
+> - **If reintroduced later**: watch/informer may accelerate freshness or local
+>   cache warmup, but periodic polling/reconcile remains the consistency fallback.
+
+See also: [RFC-0020 Optional K8s Watch Acceleration](../../rfc/RFC-0020-k8s-watch-acceleration.md).
 
 ### List-Watch Pattern
 
@@ -163,6 +187,9 @@ Initial List → resourceVersion → Watch Events → Update Cache
 | 3 | **Do not** count toward circuit breaker (410 is normal) |
 | 4 | Read requests return stale data with `cache_status: STALE` |
 | 5 | Write requests return 503 (strong consistency) |
+
+> This section applies only if a future optional watch accelerator is introduced.
+> It is **not** a Phase 2 go-live requirement for the current V1 baseline.
 
 ### Circuit Breaker
 

--- a/docs/design/phases/03-service-layer.md
+++ b/docs/design/phases/03-service-layer.md
@@ -10,7 +10,7 @@
 | KubeVirtProvider | `internal/provider/kubevirt.go` | All interface methods implemented |
 | MockProvider | `internal/provider/mock.go` | Test helper ready |
 | KubeVirtMapper | `internal/provider/mapper.go` | K8s ↔ Domain mapping works |
-| ResourceWatcher | `internal/provider/watcher.go` | List-Watch pattern implemented |
+| VM status sync baseline | `internal/jobs/vm_status_sync.go` | ADR-0038 adaptive polling path implemented |
 | ClusterHealthChecker | `internal/provider/health_checker.go` | Health checks functional |
 | CapabilityDetector | `internal/provider/capability.go` | Feature detection works |
 

--- a/docs/design/phases/04-governance.md
+++ b/docs/design/phases/04-governance.md
@@ -81,7 +81,7 @@ The following features are **explicitly out of scope** for V1:
 
 | Deliverable | File Path | Status | Notes |
 |-------------|-----------|--------|-------|
-| Atlas config | `atlas.hcl` | ⬜ | Deferred (requires running DB) |
+| Atlas config | `atlas.hcl` | ✅ | Config present; migration execution remains environment-dependent |
 | River Jobs | `internal/jobs/vm_create.go`, `vm_delete.go`, `vm_power.go` | ✅ | VMCreate/Delete/Power workers with retry + idempotency guard + audit |
 | EventDispatcher | `internal/domain/dispatcher.go` | ✅ | - |
 | Domain Event Payloads | `internal/domain/event.go` | ✅ | VMCreationPayload, VMDeletePayload, VMPowerPayload |
@@ -95,8 +95,8 @@ The following features are **explicitly out of scope** for V1:
 | Namespace Handlers | `internal/api/handlers/server_namespace.go` | ✅ | CRUD (List/Create/Get/Update/Delete) with environment filter + confirm_name delete gate |
 | Notification Handlers | `internal/api/handlers/server_notification.go` | ✅ | List/UnreadCount/MarkRead/MarkAllRead; triggers/sender integrated; retention cleanup scheduled |
 | Admin Handlers | `internal/api/handlers/server_admin.go` | ✅ | Clusters/Templates/InstanceSizes CRUD + UpdateClusterEnvironment (omitzero adapted) |
-| SSAApplier | `internal/provider/ssa_applier.go` | ⬜ | Deferred |
-| OpenAPI Spec | `api/openapi.yaml` | ✅ | 38 endpoints total; Namespace CRUD + Notification + omitzero value types (ADR-0028) |
+| SSAApplier | `internal/provider/ssa_applier.go` | ✅ | SSA apply + dry-run implementation present |
+| OpenAPI Spec | `api/openapi.yaml` | ✅ | 97 operationIds; includes Namespace/Notification/Batch/VNC/AuthProvider/ClusterPolicy scope |
 
 ---
 
@@ -218,6 +218,10 @@ func (w *EventJobWorker) Work(ctx context.Context, job *river.Job[EventJobArgs])
 ```
 
 ### Soft Archiving
+
+**Implementation status**: ✅ Implemented in `internal/jobs/event_archive.go`,
+registered via `GovernanceModule` and scheduled in `bootstrap.go` as a daily
+River periodic job with `RunOnStart`.
 
 ```go
 // DomainEvent schema
@@ -906,7 +910,7 @@ DELETE /api/v1/systems/{sys_id}?confirm_name=my-system
 | ApprovalTicket.operation_type | ✅ Done | Enum field (`CREATE`/`DELETE`) with `CREATE` default |
 | VM delete approval ticket flow | ✅ Done | DeleteVM use case creates `operation_type=DELETE` ticket and routes through approval gateway |
 
-> **Remaining**: Batch Stage 5.E baseline is implemented end-to-end (backend + frontend queue UX + `status_url` polling + 429 cooldown + affected-child feedback + `aria-live`). Stage 6 VNC baseline and shared PostgreSQL replay marker are implemented; noVNC proxy internals and credential encryption hardening are ongoing.
+> **Remaining**: Batch Stage 5.E baseline is implemented end-to-end (backend + frontend queue UX + `status_url` polling + 429 cooldown + affected-child feedback + `aria-live`). Stage 6 VNC baseline, shared PostgreSQL replay marker, and AES-256-GCM token envelope are implemented; noVNC proxy internals and active revocation remain V2+ work.
 
 ---
 
@@ -925,7 +929,7 @@ DELETE /api/v1/systems/{sys_id}?confirm_name=my-system
 
 | Feature | V1 (Simplified) | Full (V2+) |
 |---------|-----------------|------------|
-| Token tracking | Signed JWT + shared replay marker (`jti`, `used_at`) | Full token lifecycle table + policy controls |
+| Token tracking | AES-256-GCM encrypted JWT + shared replay marker (`jti`, `used_at`) | Full token lifecycle table + policy controls |
 | Token revocation | No active revoke API (TTL + single-use only) | Active revocation API |
 | Session recording | ❌ Not supported | ✅ Optional |
 
@@ -949,10 +953,10 @@ DELETE /api/v1/systems/{sys_id}?confirm_name=my-system
 | **Single Use** | Token invalidated after first connection | JWT `jti` replay marker (`used_at`) in shared store (PostgreSQL recommended) |
 | **Time-Bounded** | Max TTL: 2 hours (configurable) | JWT `exp` claim |
 | **User Binding** | Token includes user ID | JWT `sub` claim |
-| **Encryption** | AES-256-GCM | Shared key management |
+| **Encryption** | AES-256-GCM | Encrypted JWT envelope using shared `ENCRYPTION_KEY` |
 | **Audit Logged** | All sessions recorded | `vnc.access` event (see [master-flow.md §Canonical Action Naming](../interaction-flows/master-flow.md#canonical-action-naming)) |
 
-> **V1 Note**: No active revoke endpoint. Security relies on short TTL + single-use replay protection.
+> **V1 Note**: No active revoke endpoint. Security relies on AES-256-GCM encrypted JWTs, short TTL, and single-use replay protection.
 > Do not introduce Redis dependency for token tracking.
 
 ### API Endpoints
@@ -1489,7 +1493,7 @@ If >50% of resources detected as ghosts, halt and alert.
 - [ ] Audit logs complete
 - [ ] Environment isolation enforced (via Cluster + RoleBinding.allowed_environments)
 - [ ] Delete confirmation mechanism works (tiered by entity/environment)
-- [ ] VNC token security enforced (single-use, time-bounded)
+- [x] VNC token security enforced (single-use, time-bounded, AES-256-GCM encrypted)
 - [ ] **IdP Authentication** (V1):
   - [ ] OIDC login flow works (token validation per checklist)
   - [ ] LDAP login flow works
@@ -1548,7 +1552,7 @@ If >50% of resources detected as ghosts, halt and alert.
 | §15 Cluster Visibility | ✅ Done | Section 6 (this doc) | Namespace/cluster env matching enforced in approval+worker; `allowed_environments` visibility filtering enforced in namespace/VM query-read path |
 | §16 Global Naming | ✅ Done | [01-contracts.md §1.1](01-contracts.md#11-naming-constraints-adr-0019) | RFC 1035 + ADR-0019 extension |
 | §17 Template Snapshot | ✅ Done | [master-flow.md Stage 5.B](../interaction-flows/master-flow.md#stage-5-b) | ApprovalTicket stores immutable snapshot |
-| §18 VNC Permissions | ⚠️ Partial | Section 6.2 (this doc) | V1 Stage 6 baseline implemented (request/status/open + approval + audit + single-use credential); proxy internals hardening continues |
+| §18 VNC Permissions | ⚠️ Partial | Section 6.2 (this doc) | V1 Stage 6 baseline implemented (request/status/open + approval + audit + AES-256-GCM encrypted single-use credential); proxy internals + active revocation remain V2+ |
 | §19 Batch Operations | ⚠️ Partial | Section 5.6 (this doc) | Runtime API + child execution dispatch + two-layer throttling + parent projection persistence + admin override APIs + `/vms/batch/power` compatibility execution implemented (`/vms/batch` submit/query/retry/cancel + `/vms/batch/power` + `/approvals/batch` + `/admin/rate-limits/*`), but frontend queue UX is still pending |
 | §20 Notification System | ✅ V1 Inbox | Section 6.3 (this doc) | Sync writes; external adapters V2+ |
 | §21 Scope Exclusions | 📋 Reference | ADR-0015 | Lists deferred items |

--- a/docs/design/phases/05-auth-api-frontend.md
+++ b/docs/design/phases/05-auth-api-frontend.md
@@ -1,12 +1,13 @@
 # Phase 5: Authentication, API Completion & Frontend
 
-> **Status**: In Progress (~97%)
+> **Status**: In Progress (~96%)
 > **Started**: 2026-02-09
 > **Dependencies**: Phase 0-4 completed
+> **Last Audited**: 2026-03-10 (code-vs-doc alignment audit)
 
 ## Deliverables
 
-> **Last Updated**: 2026-02-14
+> **Last Updated**: 2026-03-10
 
 | Deliverable | File Path | Status | Notes |
 |-------------|-----------|--------|-------|
@@ -15,10 +16,10 @@
 | RBAC Middleware | `internal/middleware/rbac.go` | ✅ | RequirePermission + RequireResourceAccess |
 | Member Handler | `internal/api/handlers/member.go` | ✅ | ResourceRoleBinding CRUD + audit |
 | oapi-codegen config | `api/oapi-codegen.yaml` | ✅ | v2 format, gin-server + models |
-| Generated Server | `internal/api/generated/server.gen.go` | ✅ | 44 endpoints (ADR-0028 omitzero value types), all model types |
+| Generated Server | `internal/api/generated/server.gen.go` | ✅ | 97 endpoints (ADR-0028 omitzero value types), all model types |
 | openapi-typescript | `web/src/types/api.gen.ts` | ✅ | Auto-generated from OpenAPI spec |
 | Seed Command | `cmd/seed/main.go` | ✅ | 6 roles + default admin |
-| Bootstrap | `internal/app/bootstrap.go` | ✅ | 65 lines ≤ 100 limit (ADR-0022) |
+| Bootstrap | `internal/app/bootstrap.go` | ✅ | 107 file lines; `Bootstrap()` function is 55 lines and remains orchestration-only (see ADR-0043 design note) |
 | Frontend: Login | `web/src/app/(auth)/login/page.tsx` | ✅ | Force password change flow |
 | Frontend: Dashboard | `web/src/app/dashboard/page.tsx` | ✅ | System overview + health stats |
 | Frontend: Systems | `web/src/app/systems/page.tsx` | ✅ | CRUD + DELETE with RFC 1035 validation |
@@ -31,6 +32,17 @@
 | Frontend: Templates | `web/src/app/admin/templates/page.tsx` | ✅ | CRUD + column filters + deferred search + JSON spec editor |
 | Frontend: Instance Sizes | `web/src/app/admin/instance-sizes/page.tsx` | ✅ | CRUD + capability filters + sort + JSON spec_overrides editor |
 | Frontend: Users | `web/src/app/(protected)/admin/users/page.tsx` | ✅ | User directory + system member management |
+| Frontend: Auth Providers | `web/src/app/(protected)/admin/auth-providers/page.tsx` | ✅ | OIDC/LDAP provider CRUD + test connection + group sync |
+| Frontend: Rate Limits | `web/src/app/(protected)/admin/rate-limits/page.tsx` | ✅ | Exemptions/overrides admin management |
+| Frontend: Permissions | `web/src/app/(protected)/admin/permissions/page.tsx` | ✅ | Permission browser |
+| Frontend: RBAC | `web/src/app/(protected)/admin/rbac/page.tsx` | ✅ | Role + role binding management |
+| Frontend: Batch Overview | `web/src/app/(protected)/vms/batch/page.tsx` | ✅ | Batch operations list view |
+| Frontend: Batch Detail | `web/src/app/(protected)/vms/batch/[id]/page.tsx` | ✅ | Parent-child status + retry/cancel |
+| Frontend: VM Detail | `web/src/app/(protected)/vms/[id]/page.tsx` | ✅ | VM detail view |
+| Frontend: Notifications | `web/src/app/(protected)/notifications/page.tsx` | ✅ | Full notification inbox |
+| Frontend: Profile | `web/src/app/(protected)/profile/page.tsx` | ✅ | User profile view |
+| Frontend: Change Password | `web/src/app/(auth)/auth/change-password/page.tsx` | ✅ | Standalone password change |
+| Frontend: User Approvals | `web/src/app/(protected)/approvals/page.tsx` | ✅ | User-facing approvals view |
 | Namespace Handlers | `internal/api/handlers/server_namespace.go` | ✅ | CRUD with environment filter + confirm_name delete gate |
 | Notification Handlers | `internal/api/handlers/server_notification.go` | ✅ | List/UnreadCount/MarkRead/MarkAllRead + InboxSender + Triggers + Frontend Bell |
 | Admin Handlers | `internal/api/handlers/server_admin.go` | ✅ | Clusters/Templates/InstanceSizes + UpdateClusterEnvironment |
@@ -137,8 +149,8 @@ Phase 5 bridges the backend to a usable product by implementing:
 - **UI Components**: Ant Design 5.x + @ant-design/pro-components 2.x
 - **State Management**: Zustand 5.x + TanStack Query 5.x
 - **Styling**: Tailwind CSS 4.x
-- **Form Validation**: Zod 3.x
-- **Internationalization**: react-i18next 15.x
+- **Form Validation**: Zod 4.x
+- **Internationalization**: react-i18next 16.x
 - **API Client**: Generated from OpenAPI via `openapi-typescript` + `openapi-fetch`
 
 ### Contract-First Frontend Development
@@ -147,24 +159,33 @@ Phase 5 bridges the backend to a usable product by implementing:
 2. `openapi-fetch` creates type-safe API client (no manual typing)
 3. All API calls are fully typed end-to-end (OpenAPI → Go server → TS client)
 
-### Pages (MVP)
+### Pages (MVP — 25 routes)
 
 - Login page with force password change
+- Change password page (standalone)
 - Dashboard with system overview
 - System/Service CRUD management
-- VM lifecycle management (list, create request, power operations)
-- Approval workbench (admin)
+- VM lifecycle management (list, detail, request wizard, power operations)
+- Approval workbench (admin + user-facing views)
 - Audit log viewer (admin)
 - Clusters management (admin)
 - Namespaces management (admin: CRUD + confirm_name delete)
 - Templates management (admin: CRUD, column filters, deferred search)
 - Instance Sizes management (admin: CRUD, capability filters, sort)
+- Users management (admin)
+- Auth Providers management (admin: CRUD + test connection + group sync)
+- Rate Limits management (admin: exemptions/overrides)
+- Permissions browser (admin)
+- RBAC management (admin: roles + role bindings)
+- Batch operations (list + detail with parent-child status)
+- Notifications inbox
+- Profile page
 
 ---
 
 ## Architecture Constraints
 
-- `bootstrap.go` ≤ 100 lines (ADR-0022) — currently 65 lines
+- `Bootstrap()` remains orchestration-only and concise; file-level line count is not used as a mechanical quality gate (see ADR-0043 design note)
 - Manual DI only (ADR-0013)
 - OpenAPI spec is single source of truth (ADR-0021)
 - No hardcoded API types in frontend — all generated from contract

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -16,7 +16,8 @@
         "docs/adr/ADR-0023-schema-cache-and-api-standards.md"
       ],
       "examples": [
-        "docs/design/examples/config/config.go"
+        "docs/design/examples/config/config.go",
+        "docs/design/examples/handlers/health.go"
       ]
     },
     {

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -2,7 +2,9 @@
 
 > This directory contains RFCs for future features and enhancements.
 >
-> RFCs are proposals that have been evaluated but are not yet scheduled for implementation. Each RFC includes a trigger condition that indicates when it should be considered for implementation.
+> In this repository, RFCs are **feature/change proposals and backlog specs**,
+> not immutable architecture authorities. Each RFC includes a trigger condition
+> that indicates when it should be considered for implementation.
 
 ---
 
@@ -14,27 +16,37 @@
 | [RFC-0002](./RFC-0002-temporal.md) | Temporal Workflow Integration | Deferred | P3 | Multi-level approval needed |
 | [RFC-0003](./RFC-0003-helm-export.md) | Helm Chart Export | Deferred | P2 | User request |
 | [RFC-0004](./RFC-0004-external-approval.md) | External Approval Systems | **Accepted** | **P1** | V1+ optional feature |
-| [RFC-0005](./RFC-0005-event-archiving.md) | Physical Event Archiving ¹ | Deferred | P2 | DomainEvent table too large |
-| [RFC-0006](./RFC-0006-hot-reload.md) | Configuration Admin API ² | Deferred | P2 | Dynamic config via API |
+| [RFC-0005](./RFC-0005-event-archiving.md) | Physical Event Archiving | Deferred | P2 | DomainEvent table too large |
+| [RFC-0006](./RFC-0006-hot-reload.md) | Configuration Admin API | Deferred | P2 | Dynamic config via API |
 | [RFC-0007](./RFC-0007-redis-cache.md) | Redis Cache Support | Deferred | P3 | Cache miss causing bottleneck |
-| [RFC-0008](./RFC-0008-extended-auth.md) | Extended Auth Providers ⁴ | Deferred | P2 | MFA/SAML 2.0 or active token revocation required |
+| [RFC-0008](./RFC-0008-extended-auth.md) | Extended Auth Providers | Deferred | P2 | MFA/SAML 2.0 or active token revocation required |
 | [RFC-0009](./RFC-0009-pgbouncer.md) | PgBouncer Dual Pool | Deferred | P3 | Enterprise deployment |
 | [RFC-0010](./RFC-0010-observability.md) | Observability Stack | Deferred | P2 | Metrics/Tracing required |
-| [RFC-0011](./RFC-0011-vnc-console.md) | VNC Console (noVNC) ³⁴ | **Proposed** | **P1** | V1 core feature |
-| [RFC-0012](./RFC-0012-kubevirt-advanced.md) | KubeVirt Advanced Features ³ | Deferred | P2 | Snapshot/Clone/Migration |
-| [RFC-0013](./RFC-0013-vm-snapshot.md) | VM Snapshot ³ | Deferred | P2 | Backup/Restore needed |
-| [RFC-0014](./RFC-0014-vm-clone.md) | VM Clone ³ | Deferred | P2 | Rapid VM duplication |
+| [RFC-0011](./RFC-0011-vnc-console.md) | VNC Console (noVNC) | Deferred | P2 | Embedded noVNC UX, active revoke, or session recording needed |
+| [RFC-0012](./RFC-0012-kubevirt-advanced.md) | KubeVirt Advanced Features | Deferred | P2 | Snapshot/Clone/Migration |
+| [RFC-0013](./RFC-0013-vm-snapshot.md) | VM Snapshot | Deferred | P2 | Backup/Restore needed |
+| [RFC-0014](./RFC-0014-vm-clone.md) | VM Clone | Deferred | P2 | Rapid VM duplication |
 | [RFC-0015](./RFC-0015-per-cluster-concurrency.md) | Per-Cluster Concurrency | Deferred | P3 | Distributed semaphore needed |
 | [RFC-0016](./RFC-0016-key-rotation.md) | Secret Key Rotation | Proposed | P2 | Compliance or operator request |
 | [RFC-0017](./RFC-0017-external-secret-provider.md) | External Secret Provider | Deferred | P2 | Enterprise KMS/Vault requirement |
 | [RFC-0018](./RFC-0018-external-notification.md) | External Notification Channels | Deferred | P2 | V1 complete; Email/Webhook/Slack requested |
 | [RFC-0019](./RFC-0019-kubevirt-instancetype-adapter.md) | KubeVirt Instancetype Adapter | Deferred | P2 | Instancetype/Preference import-export or cross-cluster migration needed |
+| [RFC-0020](./RFC-0020-k8s-watch-acceleration.md) | Optional K8s Watch Acceleration | Deferred | P3 | Near-realtime VM drift visibility or read acceleration needed |
 
-> **Notes**:
-> - ¹ Soft archiving (`archived_at` field) is implemented in Phase 4; this RFC covers physical archiving to separate tables
-> - ² Basic hot-reload (log level, rate limits) is in Phase 0; this RFC covers API-based config changes
-> - ³ Provider interfaces defined in Phase 1-2; this RFC covers full implementation
-> - ⁴ **Scope reduced by ADR-0015**: Core functionality accepted in [ADR-0015](../adr/ADR-0015-governance-model-v2.md); RFC now covers only advanced features not in ADR. See individual RFC for details.
+## Implementation Reality Check (2026-03-11)
+
+| RFC | Current State |
+|-----|---------------|
+| [RFC-0004](./RFC-0004-external-approval.md) | Registry schema + provider-router foundation are implemented; external webhook/callback adapters are still pending. |
+| [RFC-0005](./RFC-0005-event-archiving.md) | Soft archiving via `archived_at` is implemented; this RFC only covers physical archive tables and purge. |
+| [RFC-0006](./RFC-0006-hot-reload.md) | Limited runtime hot-reload primitives exist; config admin API and multi-instance sync do not. |
+| [RFC-0008](./RFC-0008-extended-auth.md) | Auth-provider admin/plugin-management foundation is implemented; MFA, SAML, and active session revocation remain deferred. |
+| [RFC-0011](./RFC-0011-vnc-console.md) | Stage 6 VNC baseline is implemented end-to-end; this RFC now tracks optional V2+ noVNC/proxy/session enhancements. |
+| [RFC-0012](./RFC-0012-kubevirt-advanced.md), [RFC-0013](./RFC-0013-vm-snapshot.md), [RFC-0014](./RFC-0014-vm-clone.md) | Interfaces and domain types exist, but runtime Snapshot/Clone/Migration provider methods are still deferred. |
+| [RFC-0016](./RFC-0016-key-rotation.md) | Verification-side signing-key compatibility exists; full keyring rotation and re-encryption workflow do not. |
+| [RFC-0017](./RFC-0017-external-secret-provider.md) | `env`/DB bootstrap secret precedence is implemented; external Vault/KMS providers remain deferred. |
+| [RFC-0018](./RFC-0018-external-notification.md) | Internal inbox notification flow is implemented; external email/webhook/slack channels remain deferred. |
+| [RFC-0019](./RFC-0019-kubevirt-instancetype-adapter.md) | Optional instancetype/preference adapter remains fully deferred. |
 
 ---
 
@@ -43,9 +55,31 @@
 | Status | Description |
 |--------|-------------|
 | **Proposed** | Under active discussion |
-| **Accepted** | Approved for implementation (moved to project backlog) |
+| **Accepted** | Feature direction approved for implementation planning/backlog work; does **not** override ADR authority |
 | **Deferred** | Valuable but not currently prioritized |
 | **Rejected** | Evaluated and declined |
+
+---
+
+## Directory Semantics
+
+Use the documentation layers like this:
+
+| Directory | Purpose | Authority |
+|-----------|---------|-----------|
+| `docs/adr/` | Accepted architecture decisions and decision history | **Highest** for architecture; accepted ADRs are immutable |
+| `docs/rfc/` | Future feature proposals, optional capability specs, backlog candidates | Lower than ADR; may evolve until implemented or replaced |
+| `docs/design/notes/` | Implementation notes and rollout details for accepted ADRs | Supports ADRs, not a replacement for them |
+
+**Important rule**:
+- If a feature proposal requires a new architectural decision, create or amend an
+  **ADR**.
+- If a feature is merely optional/deferred future work under existing ADRs, an
+  **RFC** is appropriate.
+
+This means the `rfc/` directory is **not** a misuse in this repository, but it
+should be understood as a **feature backlog/spec directory**, not as an
+alternative authority system parallel to ADRs.
 
 ---
 
@@ -66,7 +100,7 @@ When an RFC's trigger condition is met:
 1. Update RFC status from `Deferred` to `Accepted`
 2. Create implementation tasks in the relevant project
 3. Link RFC to project CHECKLIST.md
-4. If RFC becomes an architectural decision, create corresponding ADR
+4. If implementation requires a new architecture-level commitment, create corresponding ADR
 
 ---
 

--- a/docs/rfc/RFC-0004-external-approval.md
+++ b/docs/rfc/RFC-0004-external-approval.md
@@ -32,6 +32,21 @@ Implement a **pluggable external approval system** with the following characteri
 | **Timeout handling** | Configurable timeout with fallback behavior |
 | **Retry with backoff** | Exponential backoff for transient failures |
 
+## Current State (2026-03-11)
+
+Current codebase already implements the shared foundation for this RFC:
+
+- `external_approval_systems` schema and migration exist for adapter registry data
+- `ApprovalProviderRouter` is wired, with the built-in provider as the only active V1 backend
+- request submission handlers already route through the provider-router seam
+
+The following pieces are still not implemented:
+
+- outbound webhook adapters for ServiceNow/JIRA/internal OA
+- signed callback endpoint and polling-mode external decision ingestion
+- admin CRUD/API and UI for managing external approval systems
+- retry/timeout/fallback behavior against a real external backend
+
 ### Architecture
 
 ```

--- a/docs/rfc/RFC-0006-hot-reload.md
+++ b/docs/rfc/RFC-0006-hot-reload.md
@@ -9,7 +9,8 @@
 
 ## Problem
 
-Current configuration hot-reload uses file-based `fsnotify`. Future requirements may include:
+Current runtime configuration changes are intentionally narrow and process-local.
+Future requirements may include:
 - Runtime configuration changes via REST API
 - Multi-instance configuration synchronization
 - Configuration change audit trail
@@ -18,7 +19,11 @@ Current configuration hot-reload uses file-based `fsnotify`. Future requirements
 
 ## Current State
 
-V1.0 uses file-based hot-reload with fsnotify watching config files.
+V1.0 only has limited runtime hot-reload primitives today, most notably zap
+`AtomicLevel` for dynamic log-level changes. It does **not** yet provide a
+general configuration admin API or cross-instance synchronization. This RFC is
+therefore about a broader operator-facing config-management capability, not a
+description of shipped V1 behavior.
 
 ---
 

--- a/docs/rfc/RFC-0008-extended-auth.md
+++ b/docs/rfc/RFC-0008-extended-auth.md
@@ -21,6 +21,18 @@
 > | **SAML 2.0 Support** | ❌ Not covered | **Deferred** |
 > | **Advanced Session Management** | ❌ Not covered | **Deferred** |
 
+## Current State (2026-03-11)
+
+The codebase already includes auth-provider management foundations:
+
+- admin CRUD/type-list/test/sample/group-mapping APIs for auth providers
+- pluggable admin adapter registry with built-in `generic`, `oidc`, `ldap`, and `sso` descriptors
+- JWT middleware support for optional `jwt_verification_keys` during signing-key rollover
+
+This RFC should therefore be read as future work for MFA, SAML 2.0, and active
+session revocation. It should **not** be interpreted as evidence that full
+external login/callback runtime is already complete.
+
 ---
 
 ## Problem

--- a/docs/rfc/RFC-0011-vnc-console.md
+++ b/docs/rfc/RFC-0011-vnc-console.md
@@ -1,8 +1,8 @@
 # RFC-0011: VNC Console (noVNC)
 
-> **Status**: Proposed (V1 simplified implementation)  
-> **Priority**: P1  
-> **Trigger**: ~~Browser-based VM console access required~~ V1 core feature
+> **Status**: Deferred
+> **Priority**: P2
+> **Trigger**: Embedded noVNC UX, active revoke, or session recording required
 
 ---
 
@@ -20,18 +20,33 @@
 > | Audit Logging Requirements | §18 Audit Table |
 > | V1 delivery scope freeze (no active revoke API) | §18.1 Addendum |
 >
-> **This RFC covers frontend implementation only:**
-> - noVNC JavaScript library integration
-> - WebSocket proxy implementation
+> **This RFC now covers only the remaining non-ADR implementation details and enhancements:**
+> - embedded noVNC asset/runtime integration
+> - WebSocket proxy refinements and session lifecycle controls
 > - UI/UX for console access
 >
 > All security and permission logic must conform to ADR-0015 §18 and §18.1 addendum.
+
+## Current State (2026-03-11)
+
+The Stage 6 V1 baseline is already implemented:
+
+- backend endpoints: `POST /api/v1/vms/{vm_id}/console/request`, `GET /api/v1/vms/{vm_id}/console/status`, `GET /api/v1/vms/{vm_id}/vnc`
+- approval-aware request/status flow and `VNC_ACCESS` governance integration
+- encrypted single-use VNC bootstrap tokens with PostgreSQL replay markers
+- frontend launcher that opens the configured noVNC entrypoint using the returned websocket path
+
+This RFC now tracks only the remaining enhancements not required for the V1
+baseline, such as richer embedded noVNC UX, deeper websocket proxy lifecycle
+controls, active revoke APIs, and optional session recording.
 
 ---
 
 ## V1 Implementation Scope
 
-> **V1 adopts a simplified implementation** to balance feature delivery with complexity.
+### Implemented V1 Baseline
+
+> **The shipped baseline uses a simplified implementation** to balance feature delivery with complexity.
 
 | Feature | V1 (Simplified) | Full (V2+) |
 |---------|-----------------|------------|

--- a/docs/rfc/RFC-0012-kubevirt-advanced.md
+++ b/docs/rfc/RFC-0012-kubevirt-advanced.md
@@ -5,8 +5,16 @@
 > **Trigger**: Advanced KubeVirt features required beyond basic VM lifecycle
 
 > **Implementation Boundary**:
-> - **Provider-level methods** (MigrateVM, GetVMMigration, etc.) are implemented in **Phase 2**
-> - **This RFC covers Service-level orchestration**: automated migration policies, hot-plug orchestration, maintenance mode
+> - **Provider interfaces and domain types** are defined in Phase 1-2
+> - **Runtime provider methods** (migration/hot-plug/GPU/SR-IOV) are **not** implemented in V1
+> - **This RFC covers both future provider implementation and higher-level orchestration**: automated migration policies, hot-plug orchestration, maintenance mode
+
+## Current State (2026-03-11)
+
+The `MigrationProvider` seam exists in `internal/provider/interface.go`, but no
+KubeVirt-backed runtime implementation is currently wired into services or API
+handlers. Treat this RFC as future work, not as a description of shipped Phase
+2 behavior.
 
 ---
 

--- a/docs/rfc/RFC-0013-vm-snapshot.md
+++ b/docs/rfc/RFC-0013-vm-snapshot.md
@@ -5,8 +5,17 @@
 > **Trigger**: Backup and restore capabilities required
 
 > **Implementation Boundary**:
-> - **Provider-level methods** (CreateVMSnapshot, GetVMSnapshot, etc.) are implemented in **Phase 2**
-> - **This RFC covers Service-level orchestration**: scheduled backups, retention policies, cross-cluster restore
+> - **Provider interfaces and domain types** are defined in Phase 1-2
+> - **Runtime snapshot provider methods** are **not** implemented in V1
+> - **This RFC covers both future provider implementation and service-level orchestration**: scheduled backups, retention policies, cross-cluster restore
+
+## Current State (2026-03-11)
+
+The `SnapshotProvider` interface exists in `internal/provider/interface.go`, but
+there is no KubeVirt-backed snapshot runtime in the current service/API path.
+The extra lifecycle section below for `instance_size_snapshot` is separate from
+VM snapshot support and should not be read as evidence that KubeVirt snapshot
+operations are already shipped.
 
 ---
 
@@ -27,18 +36,26 @@ type SnapshotService struct {
 
 // CreateSnapshot creates a VM snapshot
 func (s *SnapshotService) CreateSnapshot(ctx context.Context, input CreateSnapshotInput) (*Snapshot, error) {
-    return s.provider.CreateVMSnapshot(ctx, SnapshotSpec{
-        VMName:      input.VMName,
-        Namespace:   input.Namespace,
-        ClusterName: input.ClusterName,
-        Name:        input.SnapshotName,
-    })
+    return s.provider.CreateSnapshot(
+        ctx,
+        input.ClusterName,
+        input.Namespace,
+        input.VMName,
+        input.SnapshotName,
+    )
 }
 
 // RestoreSnapshot restores VM to snapshot state
 func (s *SnapshotService) RestoreSnapshot(ctx context.Context, snapshotID string) error {
     snapshot, _ := s.repo.Get(ctx, snapshotID)
-    return s.provider.RestoreVMFromSnapshot(ctx, snapshot)
+    _, err := s.provider.RestoreFromSnapshot(
+        ctx,
+        snapshot.ClusterName,
+        snapshot.Namespace,
+        snapshot.Name,
+        snapshot.TargetVMName,
+    )
+    return err
 }
 ```
 

--- a/docs/rfc/RFC-0014-vm-clone.md
+++ b/docs/rfc/RFC-0014-vm-clone.md
@@ -5,8 +5,15 @@
 > **Trigger**: Rapid VM duplication required
 
 > **Implementation Boundary**:
-> - **Provider-level methods** (CloneVM, GetVMClone, etc.) are implemented in **Phase 2**
-> - **This RFC covers Service-level orchestration**: data masking, cross-cluster clone, CI/CD integration
+> - **Provider interfaces and domain types** are defined in Phase 1-2
+> - **Runtime clone provider methods** are **not** implemented in V1
+> - **This RFC covers both future provider implementation and service-level orchestration**: data masking, cross-cluster clone, CI/CD integration
+
+## Current State (2026-03-11)
+
+The `CloneProvider` seam exists in `internal/provider/interface.go`, but no
+KubeVirt-backed clone runtime is currently wired into services or handlers.
+Treat this RFC as deferred capability work rather than completed Phase 2 scope.
 
 ---
 
@@ -30,13 +37,13 @@ type CloneService struct {
 
 // CloneVM creates a clone from existing VM
 func (s *CloneService) CloneVM(ctx context.Context, input CloneVMInput) (*Clone, error) {
-    return s.provider.CloneVM(ctx, CloneSpec{
-        SourceVMName:  input.SourceVMName,
-        Namespace:     input.Namespace,
-        ClusterName:   input.ClusterName,
-        TargetName:    input.TargetName,
-        TargetNS:      input.TargetNamespace,
-    })
+    return s.provider.CloneVM(
+        ctx,
+        input.ClusterName,
+        input.Namespace,
+        input.SourceVMName,
+        input.TargetName,
+    )
 }
 ```
 

--- a/docs/rfc/RFC-0016-key-rotation.md
+++ b/docs/rfc/RFC-0016-key-rotation.md
@@ -10,6 +10,14 @@ V1 defers key rotation to reduce complexity. As deployments mature, operators wi
 require periodic rotation of `ENCRYPTION_KEY` and `SESSION_SECRET` without downtime
 or data loss.
 
+## Current State (2026-03-11)
+
+The codebase currently supports only a narrow verification-side compatibility
+path for auth JWT signing-key rollover via `security.jwt_verification_keys`.
+There is still no versioned keyring, re-encryption envelope migration, or
+operator rotation workflow for `ENCRYPTION_KEY` / `SESSION_SECRET`. This RFC
+therefore remains a true future design item.
+
 ## Proposed Solution
 
 Introduce a keyring model with versioned keys:

--- a/docs/rfc/RFC-0018-external-notification.md
+++ b/docs/rfc/RFC-0018-external-notification.md
@@ -43,6 +43,18 @@ type InboxSender struct {
 > - **Internal Inbox** (V1): Synchronous writes within business transaction
 > - **External Channels** (V2+): Async via River Queue for retry resilience
 
+## Current State (2026-03-11)
+
+That V1 foundation is already implemented end-to-end:
+
+- `Sender` interface plus `InboxSender`
+- approval/governance triggers wired to notification writes
+- notification API handlers and frontend bell/unread flows
+- retention cleanup for old inbox notifications
+
+This RFC therefore covers only the external-channel fanout that remains
+deferred: email, webhook, Slack/Teams, async retries, and user preferences.
+
 ---
 
 ## Proposed Solution

--- a/docs/rfc/RFC-0020-k8s-watch-acceleration.md
+++ b/docs/rfc/RFC-0020-k8s-watch-acceleration.md
@@ -1,0 +1,120 @@
+# RFC-0020: Optional K8s Watch Acceleration for VM Status Freshness
+
+> **Status**: Deferred
+> **Priority**: P3
+> **Source**: ADR-0038 follow-up boundary clarification
+> **Trigger**: Near-realtime VM drift visibility or watch-cache-backed read acceleration becomes a product requirement
+
+---
+
+## Problem
+
+The current accepted baseline for VM status convergence is
+[ADR-0038](../adr/ADR-0038-adaptive-k8s-polling.md): adaptive polling with
+`ResourceVersion` caching.
+
+This is a good fit for the platform's current governance-oriented scope, but it
+does not provide near-instant detection of:
+
+- out-of-band VM status changes
+- operator-side interventions outside Shepherd write paths
+- large dashboard/read scenarios that benefit from warm local state
+
+The team needs a documented future path in case lower-latency status freshness
+becomes necessary.
+
+---
+
+## Current State
+
+- `internal/jobs/vm_status_sync.go` is the **only authoritative** status
+  convergence path.
+- No `internal/provider/watcher.go` implementation exists.
+- Phase 2 docs previously treated `ResourceWatcher` as a V1 deliverable; that
+  expectation has now been corrected to match ADR-0038.
+
+---
+
+## Scope Boundary
+
+This RFC does **not** reopen ADR-0038.
+
+If implemented, the watch path must satisfy all of the following:
+
+- It is an **optional acceleration layer**, not a second authoritative pipeline.
+- Polling/reconcile remains the canonical fallback for correctness.
+- Watch health must not gate core write-path correctness.
+- Loss of watch events must degrade to slower freshness, not incorrect state.
+
+---
+
+## Proposed Solution
+
+### High-Level Model
+
+Use Kubernetes `LIST -> WATCH` per cluster to improve freshness, but keep DB
+truth and periodic polling as the final consistency mechanism.
+
+```text
+K8s LIST/WATCH
+    -> local watch event handler
+    -> enqueue immediate sync hint / warm cache
+    -> canonical vm_status_sync polling still persists final state
+```
+
+### Allowed Responsibilities
+
+The watch layer may:
+
+- enqueue an earlier `vm_status_sync` job for affected VMs
+- maintain non-authoritative in-memory/cache snapshots for fast reads
+- emit freshness hints for observability or UI acceleration
+
+The watch layer must **not**:
+
+- become the only path that updates VM state in PostgreSQL
+- replace periodic reconcile/poll fallback
+- introduce a dual-authority state model
+
+### Failure Handling
+
+If introduced later, the watch implementation must handle:
+
+- `410 Gone` / expired `resourceVersion` by re-listing
+- reconnect with jitter/backoff
+- watch bookmarks when available
+- multi-replica ownership / leader-election or equivalent single-writer safety
+
+---
+
+## Why Not Needed Now
+
+For the current governance platform scope:
+
+- transitional VMs already use high-frequency polling
+- stable VMs only need drift detection, not realtime control-loop behavior
+- River + PostgreSQL gives a simpler and more governable operational model than
+  long-lived watcher infrastructure
+
+Therefore this RFC is explicitly **deferred** until the trigger conditions are
+met.
+
+---
+
+## Trigger Conditions
+
+Promote this RFC only when one or more of the following becomes true:
+
+- product requires near-realtime external drift visibility (seconds, not minutes)
+- operators need large read-heavy dashboards backed by warm local state
+- polling latency for stable VMs becomes user-visible and unacceptable
+- scale tests show polling alone is no longer the best latency/load trade-off
+
+---
+
+## References
+
+- [ADR-0038: Adaptive K8s Polling](../adr/ADR-0038-adaptive-k8s-polling.md)
+- [ADR-0006: Unified Async Model](../adr/ADR-0006-unified-async-model.md)
+- [ADR-0008: PostgreSQL Stability](../adr/ADR-0008-postgresql-stability.md)
+- [ADR-0033: Realtime Notification Acceleration](../adr/ADR-0033-realtime-notification-acceleration.md)


### PR DESCRIPTION
## Summary

- align design checklists and phase docs with current implementation state
- update RFC current-state notes to distinguish shipped foundations from deferred runtime work
- clarify ADR/RFC governance boundaries in docs without modifying accepted ADR decisions

## Validation

- [x] `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- [x] `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

## Issue

Refs #340
Refs #338