### PR TITLE
fix(provider): detect storage classes during health checks

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -70,6 +70,7 @@ type PersistentVolumeClaimClient interface {
 // StorageClassClient abstracts cluster-scoped StorageClass reads.
 type StorageClassClient interface {
 	Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*storagev1.StorageClass, error)
+	List(ctx context.Context, opts k8smetav1.ListOptions) (*storagev1.StorageClassList, error)
 }
 
 // EventClient abstracts namespace-scoped Kubernetes Event reads.

--- a/internal/provider/health_checker.go
+++ b/internal/provider/health_checker.go
@@ -3,10 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kv-shepherd.io/shepherd/internal/pkg/logger"
 )
@@ -27,8 +29,12 @@ type ClusterHealth struct {
 	Status          ClusterStatus `json:"status"`
 	KubeVirtVersion string        `json:"kubevirt_version,omitempty"`
 	EnabledFeatures []string      `json:"enabled_features,omitempty"` // ADR-0014: merged GA + explicit featureGates
-	LastChecked     time.Time     `json:"last_checked"`
-	Error           string        `json:"error,omitempty"`
+	StorageClasses  []string      `json:"storage_classes,omitempty"`  // ADR-0015: auto-detected cluster StorageClasses
+	// StorageClassesDetected distinguishes a successful empty detection result from
+	// a degraded health check where StorageClass listing was skipped or failed.
+	StorageClassesDetected bool      `json:"storage_classes_detected,omitempty"`
+	LastChecked            time.Time `json:"last_checked"`
+	Error                  string    `json:"error,omitempty"`
 }
 
 // ClusterHealthChecker performs periodic health checks on registered clusters.
@@ -117,6 +123,19 @@ func (c *ClusterHealthChecker) CheckCluster(ctx context.Context, clusterName str
 		}
 	}
 
+	if storageClient := client.StorageClass(); storageClient != nil {
+		storageClasses, detectErr := detectStorageClasses(ctx, storageClient)
+		if detectErr != nil {
+			logger.Warn("storage class detection failed",
+				zap.String("cluster", clusterName),
+				zap.Error(detectErr),
+			)
+		} else {
+			health.StorageClasses = storageClasses
+			health.StorageClassesDetected = true
+		}
+	}
+
 	return health
 }
 
@@ -176,4 +195,22 @@ func (c *ClusterHealthChecker) checkAll(ctx context.Context, clusterNames []stri
 		health := c.CheckCluster(ctx, name)
 		c.UpdateHealth(health)
 	}
+}
+
+func detectStorageClasses(ctx context.Context, storageClient StorageClassClient) ([]string, error) {
+	list, err := storageClient.List(ctx, k8smetav1.ListOptions{ResourceVersion: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		item := &list.Items[i]
+		if item.Name == "" {
+			continue
+		}
+		names = append(names, item.Name)
+	}
+	sort.Strings(names)
+	return names, nil
 }

--- a/internal/provider/health_checker_test.go
+++ b/internal/provider/health_checker_test.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+)
+
+func init() {
+	_ = logger.Init("error", "json")
+}
+
+type stubHealthStorageClassClient struct {
+	list *storagev1.StorageClassList
+	err  error
+}
+
+func (s *stubHealthStorageClassClient) Get(_ context.Context, _ string, _ k8smetav1.GetOptions) (*storagev1.StorageClass, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *stubHealthStorageClassClient) List(_ context.Context, _ k8smetav1.ListOptions) (*storagev1.StorageClassList, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.list == nil {
+		return &storagev1.StorageClassList{}, nil
+	}
+	return s.list, nil
+}
+
+type stubHealthClusterClient struct {
+	kvCR         KubeVirtCRClient
+	storageClass StorageClassClient
+}
+
+func (s *stubHealthClusterClient) VM() VirtualMachineClient             { return nil }
+func (s *stubHealthClusterClient) VMI() VirtualMachineInstanceClient    { return nil }
+func (s *stubHealthClusterClient) DataVolume() DataVolumeClient         { return nil }
+func (s *stubHealthClusterClient) StorageProfile() StorageProfileClient { return nil }
+func (s *stubHealthClusterClient) PVC() PersistentVolumeClaimClient     { return nil }
+func (s *stubHealthClusterClient) StorageClass() StorageClassClient     { return s.storageClass }
+func (s *stubHealthClusterClient) Events() EventClient                  { return nil }
+func (s *stubHealthClusterClient) Pods() PodClient                      { return nil }
+func (s *stubHealthClusterClient) Authorization() AuthorizationClient   { return nil }
+func (s *stubHealthClusterClient) SSA() DynamicSSAClient                { return nil }
+func (s *stubHealthClusterClient) KubeVirt() KubeVirtCRClient           { return s.kvCR }
+
+func TestClusterHealthChecker_CheckCluster_DetectsStorageClasses(t *testing.T) {
+	t.Parallel()
+
+	checker := NewClusterHealthChecker(func(_ string) (KubeVirtClusterClient, error) {
+		return &stubHealthClusterClient{
+			kvCR: &stubKVCRClient{version: "1.7.0"},
+			storageClass: &stubHealthStorageClassClient{
+				list: &storagev1.StorageClassList{
+					Items: []storagev1.StorageClass{
+						{ObjectMeta: k8smetav1.ObjectMeta{Name: "zeta"}},
+						{ObjectMeta: k8smetav1.ObjectMeta{Name: "alpha"}},
+					},
+				},
+			},
+		}, nil
+	}, 0)
+
+	health := checker.CheckCluster(context.Background(), "cluster-a")
+
+	if health.Status != ClusterStatusHealthy {
+		t.Fatalf("status = %s, want %s", health.Status, ClusterStatusHealthy)
+	}
+	if !health.StorageClassesDetected {
+		t.Fatal("expected StorageClassesDetected=true")
+	}
+	if got, want := health.StorageClasses, []string{"alpha", "zeta"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("storage classes = %v, want %v", got, want)
+	}
+}
+
+func TestClusterHealthChecker_CheckCluster_StorageClassDetectionGracefullyDegrades(t *testing.T) {
+	t.Parallel()
+
+	checker := NewClusterHealthChecker(func(_ string) (KubeVirtClusterClient, error) {
+		return &stubHealthClusterClient{
+			kvCR: &stubKVCRClient{version: "1.7.0"},
+			storageClass: &stubHealthStorageClassClient{
+				err: fmt.Errorf("forbidden"),
+			},
+		}, nil
+	}, 0)
+
+	health := checker.CheckCluster(context.Background(), "cluster-a")
+
+	if health.Status != ClusterStatusHealthy {
+		t.Fatalf("status = %s, want %s", health.Status, ClusterStatusHealthy)
+	}
+	if health.StorageClassesDetected {
+		t.Fatal("expected StorageClassesDetected=false on degraded detection")
+	}
+	if len(health.StorageClasses) != 0 {
+		t.Fatalf("storage classes = %v, want empty slice", health.StorageClasses)
+	}
+}

--- a/internal/provider/kubecli_adapter.go
+++ b/internal/provider/kubecli_adapter.go
@@ -221,6 +221,10 @@ func (c *kubevirtStorageClassClient) Get(ctx context.Context, name string, opts 
 	return c.client.StorageV1().StorageClasses().Get(ctx, name, opts)
 }
 
+func (c *kubevirtStorageClassClient) List(ctx context.Context, opts k8smetav1.ListOptions) (*storagev1.StorageClassList, error) {
+	return c.client.StorageV1().StorageClasses().List(ctx, opts)
+}
+
 type kubevirtEventClient struct {
 	client kubecli.KubevirtClient
 }


### PR DESCRIPTION
## Summary
- expose cluster-scoped storage class listing on provider clients
- detect and persist discovered storage classes during cluster health checks
- cover the provider health-check path with dedicated tests

## Verification
- go test ./...
- make lint
- TEST_GUARD_INCLUDE_WORKTREE=0 bash docs/design/ci/scripts/check_changed_code_has_tests.sh

Refs #344