### PR TITLE
fix(vm): provision namespaces and persist truthful lifecycle status

### DIFF
--- a/internal/jobs/vm_create.go
+++ b/internal/jobs/vm_create.go
@@ -393,18 +393,10 @@ func validateNamespaceClusterEnvironment(namespaceEnv, clusterEnv string) error 
 
 func mapCreatedVMStatusToRow(created *domain.VM) vm.Status {
 	if created == nil {
-		return vm.StatusRUNNING
+		return vm.StatusCREATING
 	}
 
-	// Stage 5.C in master-flow mandates CREATING -> RUNNING|FAILED.
-	// For create-time provider statuses other than explicit FAILED, we persist RUNNING
-	// and rely on vm_status_sync (ADR-0038) for later reconciliation.
-	switch created.Status {
-	case domain.VMStatusFailed:
-		return vm.StatusFAILED
-	default:
-		return vm.StatusRUNNING
-	}
+	return mapDomainStatusToEntVM(created.Status)
 }
 
 func resolveEffectiveSelectionIDs(

--- a/internal/jobs/vm_create_test.go
+++ b/internal/jobs/vm_create_test.go
@@ -502,9 +502,9 @@ func TestMapCreatedVMStatusToRow(t *testing.T) {
 		expect entvm.Status
 	}{
 		{
-			name:   "nil vm defaults to running",
+			name:   "nil vm defaults to creating",
 			vm:     nil,
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusCREATING,
 		},
 		{
 			name:   "running stays running",
@@ -517,44 +517,44 @@ func TestMapCreatedVMStatusToRow(t *testing.T) {
 			expect: entvm.StatusFAILED,
 		},
 		{
-			name:   "creating promoted to running",
+			name:   "creating stays creating",
 			vm:     &domain.VM{Status: domain.VMStatusCreating},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusCREATING,
 		},
 		{
-			name:   "pending promoted to running",
+			name:   "pending stays pending",
 			vm:     &domain.VM{Status: domain.VMStatusPending},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusPENDING,
 		},
 		{
-			name:   "unknown promoted to running",
+			name:   "unknown stays unknown",
 			vm:     &domain.VM{Status: domain.VMStatusUnknown},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusUNKNOWN,
 		},
 		{
-			name:   "stopping maps to stopping",
+			name:   "stopping stays stopping",
 			vm:     &domain.VM{Status: domain.VMStatusStopping},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusSTOPPING,
 		},
 		{
 			name:   "stopped maps to stopped",
 			vm:     &domain.VM{Status: domain.VMStatusStopped},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusSTOPPED,
 		},
 		{
 			name:   "deleting maps to deleting",
 			vm:     &domain.VM{Status: domain.VMStatusDeleting},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusDELETING,
 		},
 		{
 			name:   "migrating maps to migrating",
 			vm:     &domain.VM{Status: domain.VMStatusMigrating},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusMIGRATING,
 		},
 		{
 			name:   "paused maps to paused",
 			vm:     &domain.VM{Status: domain.VMStatusPaused},
-			expect: entvm.StatusRUNNING,
+			expect: entvm.StatusPAUSED,
 		},
 	}
 

--- a/internal/jobs/vm_status_sync.go
+++ b/internal/jobs/vm_status_sync.go
@@ -196,20 +196,43 @@ func (w *VMStatusSyncWorker) Work(ctx context.Context, job *river.Job[VMStatusSy
 		// Reschedule at the same interval — transient failures should not change tier.
 		return w.scheduleNext(ctx, eventID, vmRow.PollIntervalSec)
 	}
+	now := time.Now()
 	if vmList == nil || len(vmList.Items) == 0 || vmList.Items[0] == nil {
-		// Create flow race is expected: VM row exists but K8s object not yet visible.
-		logger.Warn("vm_status_sync: VM not visible on cluster yet, will retry",
+		newStatus := reconcileMissingVMStatus(vmRow, now)
+		newTier := tierForStatus(newStatus)
+		newInterval := intervalForTier(newTier)
+		highTierSince := deriveHighTierSince(vmRow, newTier, now)
+
+		logger.Warn("vm_status_sync: VM not visible on cluster",
 			zap.String("vm_id", vmID),
 			zap.String("cluster", clusterID),
 			zap.String("namespace", vmRow.Namespace),
 			zap.String("name", vmRow.Name),
+			zap.String("new_status", string(newStatus)),
 		)
-		return w.scheduleNext(ctx, eventID, vmRow.PollIntervalSec)
+
+		update := w.entClient.VM.UpdateOneID(vmID).
+			SetStatus(newStatus).
+			SetPollingTier(newTier).
+			SetPollIntervalSec(newInterval).
+			SetLastPolledAt(now).
+			ClearLastK8sRv()
+
+		if highTierSince == nil {
+			update = update.ClearHighTierSince()
+		} else {
+			update = update.SetHighTierSince(*highTierSince)
+		}
+
+		if _, err := update.Save(ctx); err != nil {
+			return fmt.Errorf("vm_status_sync: persist missing-vm status for vm %s: %w", vmID, err)
+		}
+
+		return w.scheduleNext(ctx, eventID, newInterval)
 	}
 	domainVM := vmList.Items[0]
 
 	// Step 3: Determine new DB status and polling tier.
-	now := time.Now()
 	observedStatus := mapDomainStatusToEntVM(domainVM.Status)
 	newStatus := reconcileCreateBootstrapStatus(vmRow, observedStatus, now)
 	newTier := tierForStatus(newStatus)
@@ -395,6 +418,10 @@ func reconcileCreateBootstrapStatus(vmRow *ent.VM, observed vm.Status, now time.
 		return vm.StatusCREATING
 	}
 	return observed
+}
+
+func reconcileMissingVMStatus(vmRow *ent.VM, now time.Time) vm.Status {
+	return reconcileCreateBootstrapStatus(vmRow, vm.StatusUNKNOWN, now)
 }
 
 func shouldHoldCreateBootstrapStatus(vmRow *ent.VM, observed vm.Status, now time.Time) bool {

--- a/internal/jobs/vm_status_sync_test.go
+++ b/internal/jobs/vm_status_sync_test.go
@@ -298,3 +298,37 @@ func TestReconcileCreateBootstrapStatus(t *testing.T) {
 		}
 	})
 }
+
+func TestReconcileMissingVMStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	t.Run("hold_missing_vm_as_creating_during_bootstrap", func(t *testing.T) {
+		t.Parallel()
+
+		vmRow := &ent.VM{
+			Status:      vm.StatusRUNNING,
+			PollingTier: vm.PollingTierHigh,
+			CreatedAt:   now.Add(-30 * time.Second),
+		}
+		got := reconcileMissingVMStatus(vmRow, now)
+		if got != vm.StatusCREATING {
+			t.Fatalf("reconcileMissingVMStatus() = %s, want %s", got, vm.StatusCREATING)
+		}
+	})
+
+	t.Run("missing_vm_becomes_unknown_after_bootstrap_window", func(t *testing.T) {
+		t.Parallel()
+
+		vmRow := &ent.VM{
+			Status:      vm.StatusRUNNING,
+			PollingTier: vm.PollingTierHigh,
+			CreatedAt:   now.Add(-createBootstrapGraceWindow - time.Second),
+		}
+		got := reconcileMissingVMStatus(vmRow, now)
+		if got != vm.StatusUNKNOWN {
+			t.Fatalf("reconcileMissingVMStatus() = %s, want %s", got, vm.StatusUNKNOWN)
+		}
+	})
+}

--- a/internal/provider/capability_test.go
+++ b/internal/provider/capability_test.go
@@ -253,6 +253,7 @@ func (s *stubClusterClient) StorageProfile() StorageProfileClient { return nil }
 func (s *stubClusterClient) PVC() PersistentVolumeClaimClient     { return nil }
 func (s *stubClusterClient) StorageClass() StorageClassClient     { return nil }
 func (s *stubClusterClient) Events() EventClient                  { return nil }
+func (s *stubClusterClient) Namespaces() NamespaceClient          { return nil }
 func (s *stubClusterClient) Pods() PodClient                      { return nil }
 func (s *stubClusterClient) Authorization() AuthorizationClient   { return nil }
 func (s *stubClusterClient) SSA() DynamicSSAClient                { return nil }

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -8,6 +8,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
@@ -21,6 +22,10 @@ type DynamicSSAClient interface {
 	// ApplyYAML submits YAML bytes as an SSA Patch to Kubernetes.
 	// fieldManager is always FieldOwner ("kubevirt-shepherd").
 	ApplyYAML(ctx context.Context, namespace string, yamlData []byte) (*unstructured.Unstructured, error)
+
+	// ApplyClusterScopedYAML submits cluster-scoped YAML bytes as an SSA Patch.
+	// Used for non-namespaced resources such as Namespace.
+	ApplyClusterScopedYAML(ctx context.Context, gvr schema.GroupVersionResource, yamlData []byte) (*unstructured.Unstructured, error)
 
 	// DryRunApplyYAML validates YAML via SSA DryRun without creating the resource.
 	DryRunApplyYAML(ctx context.Context, namespace string, yamlData []byte) error
@@ -78,6 +83,11 @@ type EventClient interface {
 	List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*corev1.EventList, error)
 }
 
+// NamespaceClient abstracts cluster-scoped Namespace reads.
+type NamespaceClient interface {
+	Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*corev1.Namespace, error)
+}
+
 // PodClient abstracts namespace-scoped Pod reads used for PVC clone preflight checks.
 type PodClient interface {
 	List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*corev1.PodList, error)
@@ -121,6 +131,7 @@ type KubeVirtClusterClient interface {
 	PVC() PersistentVolumeClaimClient   // PVC reads for provisioning observability
 	StorageClass() StorageClassClient   // StorageClass reads for clone expansion preflight
 	Events() EventClient                // CoreV1 Events for best-effort failure summaries
+	Namespaces() NamespaceClient        // CoreV1 Namespaces for idempotent namespace creation
 	Pods() PodClient                    // CoreV1 Pods for PVC clone in-use preflight
 	Authorization() AuthorizationClient // SAR for CDI clone source RBAC preflight
 	SSA() DynamicSSAClient              // Write: CreateVM/UpdateVM (Unstructured SSA, ADR-0011)

--- a/internal/provider/health_checker_test.go
+++ b/internal/provider/health_checker_test.go
@@ -46,6 +46,7 @@ func (s *stubHealthClusterClient) StorageProfile() StorageProfileClient { return
 func (s *stubHealthClusterClient) PVC() PersistentVolumeClaimClient     { return nil }
 func (s *stubHealthClusterClient) StorageClass() StorageClassClient     { return s.storageClass }
 func (s *stubHealthClusterClient) Events() EventClient                  { return nil }
+func (s *stubHealthClusterClient) Namespaces() NamespaceClient          { return nil }
 func (s *stubHealthClusterClient) Pods() PodClient                      { return nil }
 func (s *stubHealthClusterClient) Authorization() AuthorizationClient   { return nil }
 func (s *stubHealthClusterClient) SSA() DynamicSSAClient                { return nil }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -36,6 +36,12 @@ type InfrastructureProvider interface {
 	ValidateSpec(ctx context.Context, cluster, namespace string, spec *domain.VMSpec) (*domain.ValidationResult, error)
 }
 
+// NamespaceProvisioner ensures a target namespace exists before namespaced
+// resources are validated or created on the cluster.
+type NamespaceProvisioner interface {
+	EnsureNamespace(ctx context.Context, cluster, namespace string) error
+}
+
 // ProvisioningQueryProvider exposes CDI/PVC/event read paths used for boot-disk observability.
 type ProvisioningQueryProvider interface {
 	GetDataVolume(ctx context.Context, cluster, namespace, name string) (*domain.DataVolume, error)

--- a/internal/provider/kubecli_adapter.go
+++ b/internal/provider/kubecli_adapter.go
@@ -121,6 +121,10 @@ func (c *kubevirtClusterClient) Events() EventClient {
 	return &kubevirtEventClient{client: c.client}
 }
 
+func (c *kubevirtClusterClient) Namespaces() NamespaceClient {
+	return &kubevirtNamespaceClient{client: c.client}
+}
+
 func (c *kubevirtClusterClient) Pods() PodClient {
 	return &kubevirtPodClient{client: c.client}
 }
@@ -231,6 +235,14 @@ type kubevirtEventClient struct {
 
 func (c *kubevirtEventClient) List(ctx context.Context, namespace string, opts k8smetav1.ListOptions) (*corev1.EventList, error) {
 	return c.client.CoreV1().Events(namespace).List(ctx, opts)
+}
+
+type kubevirtNamespaceClient struct {
+	client kubecli.KubevirtClient
+}
+
+func (c *kubevirtNamespaceClient) Get(ctx context.Context, name string, opts k8smetav1.GetOptions) (*corev1.Namespace, error) {
+	return c.client.CoreV1().Namespaces().Get(ctx, name, opts)
 }
 
 type kubevirtPodClient struct {

--- a/internal/provider/kubevirt.go
+++ b/internal/provider/kubevirt.go
@@ -9,6 +9,7 @@ import (
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -52,6 +53,40 @@ func (p *KubeVirtProviderImpl) Name() string { return "kubevirt" }
 
 // Type returns the provider type.
 func (p *KubeVirtProviderImpl) Type() string { return "kubevirt" }
+
+// EnsureNamespace idempotently creates the target namespace on the selected
+// cluster when it does not already exist.
+func (p *KubeVirtProviderImpl) EnsureNamespace(ctx context.Context, cluster, namespace string) error {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return fmt.Errorf("ensure namespace: namespace is required")
+	}
+
+	client, err := p.clientFactory(cluster)
+	if err != nil {
+		return fmt.Errorf("get client for cluster %s: %w", cluster, err)
+	}
+
+	opCtx, cancel := p.withTimeout(ctx)
+	defer cancel()
+
+	if _, getErr := client.Namespaces().Get(opCtx, namespace, k8smetav1.GetOptions{}); getErr == nil {
+		return nil
+	} else if !apierrors.IsNotFound(getErr) {
+		return fmt.Errorf("get namespace %s on cluster %s: %w", namespace, cluster, getErr)
+	}
+
+	namespaceManifest := []byte(fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+`, namespace))
+	_, err = client.SSA().ApplyClusterScopedYAML(opCtx, namespaceGVR, namespaceManifest)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("apply namespace %s on cluster %s: %w", namespace, cluster, err)
+	}
+	return nil
+}
 
 // GetVM retrieves a VM from the specified cluster.
 func (p *KubeVirtProviderImpl) GetVM(ctx context.Context, cluster, namespace, name string) (*domain.VM, error) {

--- a/internal/provider/kubevirt_test.go
+++ b/internal/provider/kubevirt_test.go
@@ -183,6 +183,52 @@ func TestKubevirtSSAApplier_DryRunApplyYAML(t *testing.T) {
 	}
 }
 
+func TestKubevirtSSAApplier_ApplyClusterScopedYAML(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	var capturedPatch []byte
+	var capturedPatchType types.PatchType
+	var capturedName string
+
+	dynClient.PrependReactor("patch", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchActionImpl)
+		if !ok {
+			return false, nil, nil
+		}
+		capturedPatch = patchAction.GetPatch()
+		capturedPatchType = patchAction.GetPatchType()
+		capturedName = patchAction.GetName()
+
+		obj := &unstructured.Unstructured{}
+		if err := json.Unmarshal(capturedPatch, &obj.Object); err != nil {
+			return true, nil, fmt.Errorf("unmarshal patch: %w", err)
+		}
+		return true, obj, nil
+	})
+
+	applier := NewKubevirtSSAApplier(dynClient)
+
+	result, err := applier.ApplyClusterScopedYAML(context.Background(), namespaceGVR, []byte(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+`))
+	if err != nil {
+		t.Fatalf("ApplyClusterScopedYAML returned error: %v", err)
+	}
+	if capturedPatchType != types.ApplyPatchType {
+		t.Fatalf("expected ApplyPatchType, got %q", capturedPatchType)
+	}
+	if capturedName != "team-a" {
+		t.Fatalf("expected patch target name=team-a, got %q", capturedName)
+	}
+	if result.GetName() != "team-a" {
+		t.Fatalf("expected name=team-a, got %q", result.GetName())
+	}
+}
+
 func TestKubevirtSSAApplier_GVR(t *testing.T) {
 	// Verify the GVR constants match expected KubeVirt API group.
 	expected := schema.GroupVersionResource{

--- a/internal/provider/mock.go
+++ b/internal/provider/mock.go
@@ -13,7 +13,8 @@ import (
 
 // MockProvider implements InfrastructureProvider for testing without a K8s cluster.
 type MockProvider struct {
-	vms               map[string]*domain.VM                    // key: namespace/name
+	vms               map[string]*domain.VM // key: namespace/name
+	namespaces        map[string]struct{}
 	dataVolumes       map[string]*domain.DataVolume            // key: namespace/name
 	pvcs              map[string]*domain.PersistentVolumeClaim // key: namespace/name
 	storageClasses    map[string]*domain.StorageClass          // key: name
@@ -33,6 +34,7 @@ type cloneSourceAccessDecision struct {
 func NewMockProvider() *MockProvider {
 	return &MockProvider{
 		vms:               make(map[string]*domain.VM),
+		namespaces:        make(map[string]struct{}),
 		dataVolumes:       make(map[string]*domain.DataVolume),
 		pvcs:              make(map[string]*domain.PersistentVolumeClaim),
 		storageClasses:    make(map[string]*domain.StorageClass),
@@ -58,6 +60,7 @@ func (p *MockProvider) Reset() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.vms = make(map[string]*domain.VM)
+	p.namespaces = make(map[string]struct{})
 	p.dataVolumes = make(map[string]*domain.DataVolume)
 	p.pvcs = make(map[string]*domain.PersistentVolumeClaim)
 	p.storageClasses = make(map[string]*domain.StorageClass)
@@ -69,6 +72,16 @@ func (p *MockProvider) Reset() {
 
 func (p *MockProvider) Name() string { return "mock" }
 func (p *MockProvider) Type() string { return "mock" }
+
+func (p *MockProvider) EnsureNamespace(_ context.Context, _, namespace string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	p.namespaces[namespace] = struct{}{}
+	return nil
+}
 
 func (p *MockProvider) GetVM(_ context.Context, _, namespace, name string) (*domain.VM, error) {
 	p.mu.RLock()

--- a/internal/provider/ssa_applier.go
+++ b/internal/provider/ssa_applier.go
@@ -34,6 +34,12 @@ var vmGVR = schema.GroupVersionResource{
 	Resource: vmResource,
 }
 
+var namespaceGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "namespaces",
+}
+
 // KubevirtSSAApplier submits VirtualMachine resources via dynamic client + SSA.
 // Implements DynamicSSAClient.
 //
@@ -67,6 +73,33 @@ func NewKubevirtSSAApplier(dynamicClient dynamic.Interface) *KubevirtSSAApplier 
 // Force=true ensures kubevirt-shepherd owns all fields it declares, overwriting
 // any conflicting field ownership (e.g., manual kubectl edits).
 func (a *KubevirtSSAApplier) ApplyYAML(ctx context.Context, namespace string, yamlData []byte) (*unstructured.Unstructured, error) {
+	return a.applyYAML(ctx, vmGVR, namespace, yamlData, false)
+}
+
+// ApplyClusterScopedYAML submits cluster-scoped YAML bytes via SSA Patch.
+func (a *KubevirtSSAApplier) ApplyClusterScopedYAML(
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	yamlData []byte,
+) (*unstructured.Unstructured, error) {
+	return a.applyYAML(ctx, gvr, "", yamlData, false)
+}
+
+// DryRunApplyYAML validates YAML via SSA DryRun without creating the resource.
+// Used by ValidateSpec to leverage server-side validation (more authoritative
+// than compile-time checks for external CRD fields).
+func (a *KubevirtSSAApplier) DryRunApplyYAML(ctx context.Context, namespace string, yamlData []byte) error {
+	_, err := a.applyYAML(ctx, vmGVR, namespace, yamlData, true)
+	return err
+}
+
+func (a *KubevirtSSAApplier) applyYAML(
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	namespace string,
+	yamlData []byte,
+	dryRun bool,
+) (*unstructured.Unstructured, error) {
 	obj, jsonData, err := a.decodeAndMarshal(yamlData)
 	if err != nil {
 		return nil, err
@@ -77,43 +110,33 @@ func (a *KubevirtSSAApplier) ApplyYAML(ctx context.Context, namespace string, ya
 		return nil, fmt.Errorf("resource name is required in yaml")
 	}
 
-	result, err := a.dynamicClient.
-		Resource(vmGVR).
-		Namespace(namespace).
-		Patch(ctx, name, types.ApplyPatchType, jsonData, k8smetav1.PatchOptions{
-			FieldManager: FieldOwner,
-			Force:        ptr.To(true),
-		})
-	if err != nil {
-		return nil, fmt.Errorf("ssa apply %s/%s: %w", namespace, name, err)
+	namespaceableResource := a.dynamicClient.Resource(gvr)
+	scopeLabel := name
+	var (
+		result   *unstructured.Unstructured
+		patchErr error
+	)
+	if namespace != "" {
+		scopeLabel = fmt.Sprintf("%s/%s", namespace, name)
 	}
 
+	patchOpts := k8smetav1.PatchOptions{
+		FieldManager: FieldOwner,
+		Force:        ptr.To(true),
+	}
+	if dryRun {
+		patchOpts.DryRun = []string{k8smetav1.DryRunAll}
+	}
+
+	if namespace != "" {
+		result, patchErr = namespaceableResource.Namespace(namespace).Patch(ctx, name, types.ApplyPatchType, jsonData, patchOpts)
+	} else {
+		result, patchErr = namespaceableResource.Patch(ctx, name, types.ApplyPatchType, jsonData, patchOpts)
+	}
+	if patchErr != nil {
+		return nil, fmt.Errorf("ssa apply %s %s: %w", gvr.Resource, scopeLabel, patchErr)
+	}
 	return result, nil
-}
-
-// DryRunApplyYAML validates YAML via SSA DryRun without creating the resource.
-// Used by ValidateSpec to leverage server-side validation (more authoritative
-// than compile-time checks for external CRD fields).
-func (a *KubevirtSSAApplier) DryRunApplyYAML(ctx context.Context, namespace string, yamlData []byte) error {
-	obj, jsonData, err := a.decodeAndMarshal(yamlData)
-	if err != nil {
-		return err
-	}
-
-	name := obj.GetName()
-	if name == "" {
-		return fmt.Errorf("resource name is required in yaml")
-	}
-
-	_, err = a.dynamicClient.
-		Resource(vmGVR).
-		Namespace(namespace).
-		Patch(ctx, name, types.ApplyPatchType, jsonData, k8smetav1.PatchOptions{
-			FieldManager: FieldOwner,
-			Force:        ptr.To(true),
-			DryRun:       []string{k8smetav1.DryRunAll},
-		})
-	return err
 }
 
 // decodeAndMarshal converts YAML bytes into an Unstructured object and its JSON

--- a/internal/service/vm_service.go
+++ b/internal/service/vm_service.go
@@ -36,6 +36,9 @@ func (s *VMService) ValidateAndPrepare(ctx context.Context, cluster, namespace s
 	if spec == nil {
 		return nil, apperrors.BadRequest(apperrors.CodeValidationFailed, "spec is required")
 	}
+	if err := s.ensureNamespaceReady(ctx, cluster, namespace); err != nil {
+		return nil, err
+	}
 	if err := ensureRenderedYAML(namespace, spec); err != nil {
 		return nil, apperrors.BadRequest(apperrors.CodeValidationFailed, fmt.Sprintf("render vm yaml: %v", err))
 	}
@@ -69,6 +72,9 @@ func (s *VMService) ListVMs(ctx context.Context, cluster, namespace string, opts
 // ExecuteK8sCreate creates the VM on K8s (outside transaction).
 // Idempotent: handles AlreadyExists error gracefully.
 func (s *VMService) ExecuteK8sCreate(ctx context.Context, cluster, namespace string, spec *domain.VMSpec) (*domain.VM, error) {
+	if err := s.ensureNamespaceReady(ctx, cluster, namespace); err != nil {
+		return nil, err
+	}
 	if err := ensureRenderedYAML(namespace, spec); err != nil {
 		return nil, fmt.Errorf("render vm yaml: %w", err)
 	}
@@ -88,6 +94,20 @@ func (s *VMService) ExecuteK8sCreate(ctx context.Context, cluster, namespace str
 		zap.String("name", vm.Name),
 	)
 	return vm, nil
+}
+
+func (s *VMService) ensureNamespaceReady(ctx context.Context, cluster, namespace string) error {
+	if s == nil || s.infra == nil {
+		return fmt.Errorf("vm infrastructure provider is not configured")
+	}
+	provisioner, ok := s.infra.(provider.NamespaceProvisioner)
+	if !ok {
+		return fmt.Errorf("vm infrastructure provider does not support namespace provisioning")
+	}
+	if err := provisioner.EnsureNamespace(ctx, cluster, namespace); err != nil {
+		return fmt.Errorf("ensure namespace %s on cluster %s: %w", namespace, cluster, err)
+	}
+	return nil
 }
 
 // ensureRenderedYAML renders spec.RenderedYAML when absent, keeping the provider

--- a/internal/service/vm_service_namespace_test.go
+++ b/internal/service/vm_service_namespace_test.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"kv-shepherd.io/shepherd/internal/domain"
+	"kv-shepherd.io/shepherd/internal/pkg/logger"
+	"kv-shepherd.io/shepherd/internal/provider"
+)
+
+func init() {
+	_ = logger.Init("error", "json")
+}
+
+type namespaceProvisioningProviderStub struct {
+	ensureCalls   int
+	validateCalls int
+	createCalls   int
+	lastCluster   string
+	lastNamespace string
+	ensureErr     error
+}
+
+func (s *namespaceProvisioningProviderStub) Name() string { return "stub" }
+func (s *namespaceProvisioningProviderStub) Type() string { return "stub" }
+
+func (s *namespaceProvisioningProviderStub) EnsureNamespace(_ context.Context, cluster, namespace string) error {
+	s.ensureCalls++
+	s.lastCluster = cluster
+	s.lastNamespace = namespace
+	return s.ensureErr
+}
+
+func (s *namespaceProvisioningProviderStub) GetVM(context.Context, string, string, string) (*domain.VM, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) ListVMs(context.Context, string, string, provider.ListOptions) (*domain.VMList, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) CreateVM(_ context.Context, _, namespace string, spec *domain.VMSpec) (*domain.VM, error) {
+	s.createCalls++
+	return &domain.VM{Name: spec.Name, Namespace: namespace, Spec: *spec}, nil
+}
+
+func (s *namespaceProvisioningProviderStub) UpdateVM(context.Context, string, string, string, *domain.VMSpec) (*domain.VM, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) DeleteVM(context.Context, string, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) StartVM(context.Context, string, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) StopVM(context.Context, string, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) RestartVM(context.Context, string, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) PauseVM(context.Context, string, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) UnpauseVM(context.Context, string, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *namespaceProvisioningProviderStub) ValidateSpec(_ context.Context, _, _ string, _ *domain.VMSpec) (*domain.ValidationResult, error) {
+	s.validateCalls++
+	return &domain.ValidationResult{Valid: true}, nil
+}
+
+func TestVMServiceValidateAndPrepare_EnsuresNamespaceFirst(t *testing.T) {
+	t.Parallel()
+
+	infra := &namespaceProvisioningProviderStub{}
+	svc := NewVMService(infra)
+
+	spec := &domain.VMSpec{
+		Name:     "vm-a",
+		CPU:      2,
+		MemoryGi: 4,
+		DiskGB:   50,
+		Image:    "docker://quay.io/containerdisks/ubuntu:22.04",
+	}
+
+	result, err := svc.ValidateAndPrepare(t.Context(), "cluster-a", "team-a", spec)
+	if err != nil {
+		t.Fatalf("ValidateAndPrepare() error = %v", err)
+	}
+	if result == nil || !result.Valid {
+		t.Fatalf("ValidateAndPrepare() result = %#v, want valid", result)
+	}
+	if infra.ensureCalls != 1 {
+		t.Fatalf("EnsureNamespace calls = %d, want 1", infra.ensureCalls)
+	}
+	if infra.validateCalls != 1 {
+		t.Fatalf("ValidateSpec calls = %d, want 1", infra.validateCalls)
+	}
+	if infra.lastCluster != "cluster-a" || infra.lastNamespace != "team-a" {
+		t.Fatalf("EnsureNamespace args = (%q,%q), want (%q,%q)", infra.lastCluster, infra.lastNamespace, "cluster-a", "team-a")
+	}
+}
+
+func TestVMServiceExecuteK8sCreate_EnsuresNamespaceFirst(t *testing.T) {
+	t.Parallel()
+
+	infra := &namespaceProvisioningProviderStub{}
+	svc := NewVMService(infra)
+
+	spec := &domain.VMSpec{
+		Name:     "vm-b",
+		CPU:      2,
+		MemoryGi: 4,
+		DiskGB:   50,
+		Image:    "docker://quay.io/containerdisks/ubuntu:22.04",
+	}
+
+	vm, err := svc.ExecuteK8sCreate(t.Context(), "cluster-b", "team-b", spec)
+	if err != nil {
+		t.Fatalf("ExecuteK8sCreate() error = %v", err)
+	}
+	if vm == nil || vm.Namespace != "team-b" {
+		t.Fatalf("ExecuteK8sCreate() vm = %#v, want namespace team-b", vm)
+	}
+	if infra.ensureCalls != 1 {
+		t.Fatalf("EnsureNamespace calls = %d, want 1", infra.ensureCalls)
+	}
+	if infra.createCalls != 1 {
+		t.Fatalf("CreateVM calls = %d, want 1", infra.createCalls)
+	}
+}
+
+func TestVMServiceValidateAndPrepare_PropagatesNamespaceProvisioningError(t *testing.T) {
+	t.Parallel()
+
+	infra := &namespaceProvisioningProviderStub{ensureErr: fmt.Errorf("forbidden")}
+	svc := NewVMService(infra)
+
+	_, err := svc.ValidateAndPrepare(t.Context(), "cluster-a", "team-a", &domain.VMSpec{
+		Name:     "vm-c",
+		CPU:      2,
+		MemoryGi: 4,
+		DiskGB:   50,
+		Image:    "docker://quay.io/containerdisks/ubuntu:22.04",
+	})
+	if err == nil {
+		t.Fatal("ValidateAndPrepare() expected namespace provisioning error, got nil")
+	}
+	if got := err.Error(); got == "" || !containsAll(got, "ensure namespace team-a", "forbidden") {
+		t.Fatalf("ValidateAndPrepare() error = %q, want namespace provisioning context", got)
+	}
+}
+
+func containsAll(input string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(input, part) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- provision target namespaces through the ADR-0011 SSA path before VM validation and create
- persist truthful create/bootstrap statuses instead of promoting non-running states to RUNNING
- reconcile missing K8s VMs away from stale RUNNING state and cover the path with focused tests

## Verification
- go test ./...
- make lint
- TEST_GUARD_INCLUDE_WORKTREE=0 bash docs/design/ci/scripts/check_changed_code_has_tests.sh

Refs #346