### PR TITLE
test(e2e): modernize dev bootstrap and live fixture seeding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod go mod download
 COPY . .
 RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod --mount=type=cache,id=shepherd-go-build,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/shepherd ./cmd/server/...
 RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod --mount=type=cache,id=shepherd-go-build,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/seed ./cmd/seed/...
+RUN --mount=type=cache,id=shepherd-go-mod,target=/go/pkg/mod --mount=type=cache,id=shepherd-go-build,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /build/bin/e2e-seed ./cmd/e2e-seed/...
 
 # Stage 2: Runtime
 FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /build/bin/shepherd /usr/local/bin/shepherd
 COPY --from=builder /build/bin/seed /usr/local/bin/seed
+COPY --from=builder /build/bin/e2e-seed /usr/local/bin/e2e-seed
 
 USER nonroot:nonroot
 
@@ -31,6 +33,7 @@ FROM gcr.io/distroless/static-debian12:nonroot AS dev-runtime
 
 COPY build/bin/shepherd /usr/local/bin/shepherd
 COPY build/bin/seed /usr/local/bin/seed
+COPY build/bin/e2e-seed /usr/local/bin/e2e-seed
 
 USER nonroot:nonroot
 

--- a/cmd/e2e-seed/main.go
+++ b/cmd/e2e-seed/main.go
@@ -20,6 +20,7 @@ import (
 	entauthprovider "kv-shepherd.io/shepherd/ent/authprovider"
 	entbatchapprovalticket "kv-shepherd.io/shepherd/ent/batchapprovalticket"
 	entcluster "kv-shepherd.io/shepherd/ent/cluster"
+	entclusterpolicy "kv-shepherd.io/shepherd/ent/clusterpolicy"
 	entdomainevent "kv-shepherd.io/shepherd/ent/domainevent"
 	entinstancesize "kv-shepherd.io/shepherd/ent/instancesize"
 	entnamespaceregistry "kv-shepherd.io/shepherd/ent/namespaceregistry"
@@ -49,10 +50,53 @@ const (
 	defaultServiceName   = "e2e-service"
 	defaultTemplateName  = "e2e-template"
 	defaultSizeName      = "e2e-small"
+	defaultCloneNSName   = "golden-images"
 
 	defaultRunningVMID = "vm-e2e-running"
 	defaultStoppedVMID = "vm-e2e-stopped"
+
+	defaultTemplateImageURL  = "docker://quay.io/containerdisks/ubuntu:22.04"
+	defaultTemplateCloudInit = `#cloud-config
+hostname: e2e-template
+manage_etc_hosts: true
+users:
+  - default
+package_update: false
+`
+
+	seedActor = "e2e-seed"
 )
+
+type templateFixture struct {
+	Name         string
+	DisplayName  string
+	Description  string
+	SourceType   string
+	ImageURL     string
+	CloudInit    string
+	OsFamily     string
+	OsVersion    string
+	CatalogScope enttemplate.CatalogScope
+}
+
+type instanceSizeFixture struct {
+	Name              string
+	DisplayName       string
+	Description       string
+	CPUCores          float64
+	MemoryGi          float64
+	DiskGB            int
+	CPURequest        float64
+	MemoryRequestGi   float64
+	DedicatedCPU      bool
+	RequiresGPU       bool
+	RequiresSriov     bool
+	RequiresHugepages bool
+	HugepagesSize     string
+	SpecOverrides     map[string]interface{}
+	CatalogScope      entinstancesize.CatalogScope
+	SortOrder         int
+}
 
 type fixtureConfig struct {
 	AdminUsername string
@@ -97,6 +141,7 @@ func run() error {
 
 	fx := loadFixtureConfig()
 	client := db.EntClient
+	skipAPIManagedFixtures := envBool("E2E_SKIP_API_MANAGED_FIXTURES")
 
 	adminID, err := ensureAdminUser(ctx, client, fx)
 	if err != nil {
@@ -106,26 +151,41 @@ func run() error {
 		return fmt.Errorf("ensure admin role binding: %w", bindErr)
 	}
 
-	if nsErr := ensureNamespaceRegistry(ctx, client, fx); nsErr != nil {
-		return fmt.Errorf("ensure namespace: %w", nsErr)
+	if skipAPIManagedFixtures {
+		if nsErr := ensureExistingNamespaceRegistry(ctx, client, fx.NamespaceName); nsErr != nil {
+			return fmt.Errorf("require namespace: %w", nsErr)
+		}
+	} else {
+		if nsErr := ensureNamespaceRegistry(ctx, client, fx); nsErr != nil {
+			return fmt.Errorf("ensure namespace: %w", nsErr)
+		}
 	}
-	clusterID, err := ensureCluster(ctx, client, fx)
+
+	clusterID, err := resolveClusterID(ctx, client, fx, skipAPIManagedFixtures)
 	if err != nil {
-		return fmt.Errorf("ensure cluster: %w", err)
+		return fmt.Errorf("resolve cluster: %w", err)
 	}
-	systemID, err := ensureSystem(ctx, client, fx)
+	serviceID, err := resolveServiceID(ctx, client, fx, skipAPIManagedFixtures)
 	if err != nil {
-		return fmt.Errorf("ensure system: %w", err)
+		return fmt.Errorf("resolve service: %w", err)
 	}
-	serviceID, err := ensureService(ctx, client, fx, systemID)
-	if err != nil {
-		return fmt.Errorf("ensure service: %w", err)
-	}
-	if tplErr := ensureTemplate(ctx, client, fx); tplErr != nil {
-		return fmt.Errorf("ensure template: %w", tplErr)
-	}
-	if sizeErr := ensureInstanceSize(ctx, client, fx); sizeErr != nil {
-		return fmt.Errorf("ensure instance size: %w", sizeErr)
+	if skipAPIManagedFixtures {
+		if tplErr := ensureExistingTemplate(ctx, client, fx.TemplateName); tplErr != nil {
+			return fmt.Errorf("require template: %w", tplErr)
+		}
+		if sizeErr := ensureExistingInstanceSize(ctx, client, fx.SizeName); sizeErr != nil {
+			return fmt.Errorf("require instance size: %w", sizeErr)
+		}
+	} else {
+		if tplErr := ensureTemplate(ctx, client, fx); tplErr != nil {
+			return fmt.Errorf("ensure template: %w", tplErr)
+		}
+		if cleanupErr := resetManagedInstanceSizes(ctx, client); cleanupErr != nil {
+			return fmt.Errorf("reset instance sizes: %w", cleanupErr)
+		}
+		if sizeErr := ensureInstanceSize(ctx, client, fx); sizeErr != nil {
+			return fmt.Errorf("ensure instance size: %w", sizeErr)
+		}
 	}
 	if runningVMErr := ensureVM(ctx, client, fx.RunningVMID, "vm-live", "01", entvm.StatusRUNNING, fx.NamespaceName, clusterID, serviceID, fx.AdminUsername); runningVMErr != nil {
 		return fmt.Errorf("ensure running vm: %w", runningVMErr)
@@ -187,6 +247,15 @@ func envOrDefault(key, fallback string) string {
 		return fallback
 	}
 	return v
+}
+
+func envBool(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 type clusterSeedInput struct {
@@ -340,6 +409,76 @@ func ensureNamespaceRegistry(ctx context.Context, client *ent.Client, fx fixture
 	return err
 }
 
+func ensureExistingNamespaceRegistry(ctx context.Context, client *ent.Client, namespaceName string) error {
+	_, err := client.NamespaceRegistry.Query().
+		Where(entnamespaceregistry.NameEQ(namespaceName)).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return fmt.Errorf("namespace %q not found; seed API-managed fixtures before running cmd/e2e-seed with E2E_SKIP_API_MANAGED_FIXTURES=1", namespaceName)
+		}
+		return err
+	}
+	return nil
+}
+
+func resolveClusterID(ctx context.Context, client *ent.Client, fx fixtureConfig, skipAPIManagedFixtures bool) (string, error) {
+	if !skipAPIManagedFixtures {
+		clusterID, err := ensureCluster(ctx, client, fx)
+		if err != nil {
+			return "", err
+		}
+		if policyErr := ensureClusterPolicy(ctx, client, clusterID, fx); policyErr != nil {
+			return "", policyErr
+		}
+		return clusterID, nil
+	}
+
+	clusterObj, err := client.Cluster.Query().
+		Where(entcluster.NameEQ(fx.ClusterName)).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return "", fmt.Errorf("cluster %q not found; seed API-managed fixtures before running cmd/e2e-seed with E2E_SKIP_API_MANAGED_FIXTURES=1", fx.ClusterName)
+		}
+		return "", err
+	}
+	return clusterObj.ID, nil
+}
+
+func resolveServiceID(ctx context.Context, client *ent.Client, fx fixtureConfig, skipAPIManagedFixtures bool) (string, error) {
+	if !skipAPIManagedFixtures {
+		systemID, err := ensureSystem(ctx, client, fx)
+		if err != nil {
+			return "", err
+		}
+		return ensureService(ctx, client, fx, systemID)
+	}
+
+	systemObj, err := client.System.Query().
+		Where(entsystem.NameEQ(fx.SystemName)).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return "", fmt.Errorf("system %q not found; seed API-managed fixtures before running cmd/e2e-seed with E2E_SKIP_API_MANAGED_FIXTURES=1", fx.SystemName)
+		}
+		return "", err
+	}
+	serviceObj, err := client.Service.Query().
+		Where(
+			entservice.NameEQ(fx.ServiceName),
+			entservice.HasSystemWith(entsystem.IDEQ(systemObj.ID)),
+		).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return "", fmt.Errorf("service %q under system %q not found; seed API-managed fixtures before running cmd/e2e-seed with E2E_SKIP_API_MANAGED_FIXTURES=1", fx.ServiceName, fx.SystemName)
+		}
+		return "", err
+	}
+	return serviceObj.ID, nil
+}
+
 func ensureCluster(ctx context.Context, client *ent.Client, fx fixtureConfig) (string, error) {
 	clusterInput, err := resolveClusterSeedInput(fx)
 	if err != nil {
@@ -381,6 +520,216 @@ func ensureCluster(ctx context.Context, client *ent.Client, fx fixtureConfig) (s
 		return "", err
 	}
 	return updated.ID, nil
+}
+
+// ensureClusterPolicy creates or updates a permissive ClusterPolicy row for the
+// e2e cluster. Without this, the approval modal's cluster dropdown marks all
+// clusters as incompatible (CLUSTER_POLICY_NOT_CONFIGURED) and the approve
+// action fails with "selected cluster is required for create approval".
+func ensureClusterPolicy(ctx context.Context, client *ent.Client, clusterID string, fx fixtureConfig) error {
+	existing, err := client.ClusterPolicy.Query().
+		Where(entclusterpolicy.ClusterIDEQ(clusterID)).
+		Only(ctx)
+	if err != nil && !ent.IsNotFound(err) {
+		return err
+	}
+
+	allowedCloneNamespaces := []string{defaultCloneNSName}
+	if namespaceName := strings.TrimSpace(fx.NamespaceName); namespaceName != "" && namespaceName != defaultCloneNSName {
+		allowedCloneNamespaces = append(allowedCloneNamespaces, namespaceName)
+	}
+	allowedHugepagesSizes := []string{"2Mi", "1Gi"}
+
+	if existing == nil {
+		id, _ := uuid.NewV7()
+		_, createErr := client.ClusterPolicy.Create().
+			SetID(id.String()).
+			SetClusterID(clusterID).
+			SetAllowCPUOvercommit(true).
+			SetAllowMemoryOvercommit(true).
+			SetAllowDedicatedCPU(true).
+			SetAllowGpu(true).
+			SetAllowSriov(true).
+			SetAllowHugepages(true).
+			SetAllowedHugepagesSizes(allowedHugepagesSizes).
+			SetAllowCdiClone(true).
+			SetAllowedCloneSourceNamespaces(allowedCloneNamespaces).
+			SetCreatedBy("e2e-seed").
+			Save(ctx)
+		return createErr
+	}
+
+	// Update existing policy to ensure it remains permissive.
+	_, err = client.ClusterPolicy.UpdateOneID(existing.ID).
+		SetAllowCPUOvercommit(true).
+		SetAllowMemoryOvercommit(true).
+		SetAllowDedicatedCPU(true).
+		SetAllowGpu(true).
+		SetAllowSriov(true).
+		SetAllowHugepages(true).
+		SetAllowedHugepagesSizes(allowedHugepagesSizes).
+		SetAllowCdiClone(true).
+		SetAllowedCloneSourceNamespaces(allowedCloneNamespaces).
+		SetUpdatedBy("e2e-seed").
+		Save(ctx)
+	return err
+}
+
+func liveTemplateFixture(fx fixtureConfig) templateFixture {
+	description := fmt.Sprintf("Live E2E Ubuntu template for namespace %s", fx.NamespaceName)
+	if strings.TrimSpace(fx.NamespaceName) == "" {
+		description = "Live E2E Ubuntu template"
+	}
+
+	return templateFixture{
+		Name:         fx.TemplateName,
+		DisplayName:  "Ubuntu 22.04 (E2E)",
+		Description:  description,
+		SourceType:   "cdi_image_import",
+		ImageURL:     defaultTemplateImageURL,
+		CloudInit:    defaultTemplateCloudInit,
+		OsFamily:     "linux",
+		OsVersion:    "22.04",
+		CatalogScope: enttemplate.CatalogScopeAll,
+	}
+}
+
+func liveInstanceSizeFixtures(fx fixtureConfig) []instanceSizeFixture {
+	return []instanceSizeFixture{
+		{
+			Name:            fx.SizeName,
+			DisplayName:     "E2E Small",
+			Description:     "Small baseline overcommit profile for live E2E",
+			CPUCores:        1,
+			MemoryGi:        2,
+			DiskGB:          60,
+			CPURequest:      0.5,
+			MemoryRequestGi: 1,
+			CatalogScope:    entinstancesize.CatalogScopeAll,
+			SortOrder:       10,
+		},
+		{
+			Name:            "e2e-overcommit",
+			DisplayName:     "E2E Overcommit",
+			Description:     "CPU and memory overcommit example for live E2E",
+			CPUCores:        4,
+			MemoryGi:        8,
+			DiskGB:          80,
+			CPURequest:      2,
+			MemoryRequestGi: 6,
+			CatalogScope:    entinstancesize.CatalogScopeAll,
+			SortOrder:       20,
+		},
+		{
+			Name:            "e2e-dedicated",
+			DisplayName:     "E2E Dedicated CPU",
+			Description:     "Dedicated CPU example for live E2E",
+			CPUCores:        4,
+			MemoryGi:        8,
+			DiskGB:          80,
+			CPURequest:      4,
+			MemoryRequestGi: 8,
+			DedicatedCPU:    true,
+			SpecOverrides: nestedSpecOverrides(
+				map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"cpu": map[string]interface{}{
+									"dedicatedCpuPlacement": true,
+								},
+							},
+						},
+					},
+				},
+			),
+			CatalogScope: entinstancesize.CatalogScopeAll,
+			SortOrder:    30,
+		},
+		{
+			Name:        "e2e-gpu",
+			DisplayName: "E2E GPU",
+			Description: "GPU workload example for live E2E",
+			CPUCores:    8,
+			MemoryGi:    16,
+			DiskGB:      120,
+			RequiresGPU: true,
+			SpecOverrides: nestedSpecOverrides(
+				map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"gpus": []interface{}{
+										map[string]interface{}{"name": "gpu0", "deviceName": "nvidia.com/A10"},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			CatalogScope: entinstancesize.CatalogScopeAll,
+			SortOrder:    40,
+		},
+		{
+			Name:              "e2e-hugepages",
+			DisplayName:       "E2E Hugepages",
+			Description:       "Hugepages workload example for live E2E",
+			CPUCores:          4,
+			MemoryGi:          8,
+			DiskGB:            80,
+			RequiresHugepages: true,
+			HugepagesSize:     "2Mi",
+			SpecOverrides: nestedSpecOverrides(
+				map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"memory": map[string]interface{}{
+									"hugepages": map[string]interface{}{
+										"pageSize": "2Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			CatalogScope: entinstancesize.CatalogScopeAll,
+			SortOrder:    50,
+		},
+		{
+			Name:          "e2e-sriov",
+			DisplayName:   "E2E SR-IOV",
+			Description:   "SR-IOV workload example for live E2E",
+			CPUCores:      4,
+			MemoryGi:      8,
+			DiskGB:        80,
+			RequiresSriov: true,
+			SpecOverrides: nestedSpecOverrides(
+				map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"interfaces": []interface{}{
+										map[string]interface{}{"name": "sriov-net-1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			CatalogScope: entinstancesize.CatalogScopeAll,
+			SortOrder:    60,
+		},
+	}
+}
+
+func nestedSpecOverrides(spec map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"spec": spec}
 }
 
 func ensureSystem(ctx context.Context, client *ent.Client, fx fixtureConfig) (string, error) {
@@ -448,8 +797,9 @@ func ensureService(ctx context.Context, client *ent.Client, fx fixtureConfig, sy
 }
 
 func ensureTemplate(ctx context.Context, client *ent.Client, fx fixtureConfig) error {
+	fixture := liveTemplateFixture(fx)
 	obj, err := client.Template.Query().
-		Where(enttemplate.NameEQ(fx.TemplateName)).
+		Where(enttemplate.NameEQ(fixture.Name)).
 		Only(ctx)
 	if err != nil {
 		if !ent.IsNotFound(err) {
@@ -458,58 +808,155 @@ func ensureTemplate(ctx context.Context, client *ent.Client, fx fixtureConfig) e
 		id, _ := uuid.NewV7()
 		_, createErr := client.Template.Create().
 			SetID(id.String()).
-			SetName(fx.TemplateName).
-			SetDisplayName("E2E Template").
-			SetDescription("e2e template - ContainerDisk boot").
-			SetSourceType("image").
-			SetImageURL("quay.io/containerdisks/ubuntu:22.04").
-			SetOsFamily("linux").
-			SetOsVersion("ubuntu-22.04").
+			SetName(fixture.Name).
+			SetDisplayName(fixture.DisplayName).
+			SetDescription(fixture.Description).
+			SetSourceType(fixture.SourceType).
+			SetImageURL(fixture.ImageURL).
+			SetCloudInit(fixture.CloudInit).
+			SetOsFamily(fixture.OsFamily).
+			SetOsVersion(fixture.OsVersion).
+			SetCatalogScope(fixture.CatalogScope).
 			SetEnabled(true).
 			SetCreatedBy("e2e-seed").
 			Save(ctx)
 		return createErr
 	}
 
+	// Normalize stale rows to the current ADR-0036 template shape so the admin
+	// edit form reads a complete, canonical record instead of mixed legacy fields.
 	_, err = client.Template.UpdateOneID(obj.ID).
-		SetDisplayName("E2E Template").
-		SetDescription("e2e template - ContainerDisk boot").
+		SetDisplayName(fixture.DisplayName).
+		SetDescription(fixture.Description).
+		SetSourceType(fixture.SourceType).
+		SetImageURL(fixture.ImageURL).
+		ClearPvcName().
+		ClearPvcNamespace().
+		SetCloudInit(fixture.CloudInit).
+		SetOsFamily(fixture.OsFamily).
+		SetOsVersion(fixture.OsVersion).
+		SetCatalogScope(fixture.CatalogScope).
 		SetEnabled(true).
 		Save(ctx)
 	return err
 }
 
 func ensureInstanceSize(ctx context.Context, client *ent.Client, fx fixtureConfig) error {
-	obj, err := client.InstanceSize.Query().
-		Where(entinstancesize.NameEQ(fx.SizeName)).
-		Only(ctx)
-	if err != nil {
-		if !ent.IsNotFound(err) {
+	fixtures := liveInstanceSizeFixtures(fx)
+	for i := range fixtures {
+		fixture := &fixtures[i]
+		if err := upsertInstanceSizeFixture(ctx, client, *fixture); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func resetManagedInstanceSizes(ctx context.Context, client *ent.Client) error {
+	_, err := client.InstanceSize.Delete().
+		Where(entinstancesize.CreatedByEQ(seedActor)).
+		Exec(ctx)
+	return err
+}
+
+func ensureExistingTemplate(ctx context.Context, client *ent.Client, templateName string) error {
+	_, err := client.Template.Query().
+		Where(enttemplate.NameEQ(templateName)).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return fmt.Errorf("template %q not found; seed API-managed fixtures before running cmd/e2e-seed with E2E_SKIP_API_MANAGED_FIXTURES=1", templateName)
+		}
+		return err
+	}
+	return nil
+}
+
+func ensureExistingInstanceSize(ctx context.Context, client *ent.Client, sizeName string) error {
+	_, err := client.InstanceSize.Query().
+		Where(entinstancesize.NameEQ(sizeName)).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return fmt.Errorf("instance size %q not found; seed API-managed fixtures before running cmd/e2e-seed with E2E_SKIP_API_MANAGED_FIXTURES=1", sizeName)
+		}
+		return err
+	}
+	return nil
+}
+
+func upsertInstanceSizeFixture(ctx context.Context, client *ent.Client, fixture instanceSizeFixture) error {
+	obj, err := client.InstanceSize.Query().
+		Where(entinstancesize.NameEQ(fixture.Name)).
+		Only(ctx)
+	if err != nil && !ent.IsNotFound(err) {
+		return err
+	}
+
+	if obj == nil {
 		id, _ := uuid.NewV7()
-		_, createErr := client.InstanceSize.Create().
+		create := client.InstanceSize.Create().
 			SetID(id.String()).
-			SetName(fx.SizeName).
-			SetDisplayName("E2E Small").
-			SetDescription("e2e size").
-			SetCPUCores(2).
-			SetMemoryGi(4.0).
-			SetDiskGB(40).
+			SetName(fixture.Name).
+			SetDisplayName(fixture.DisplayName).
+			SetDescription(fixture.Description).
+			SetCPUCores(fixture.CPUCores).
+			SetMemoryGi(fixture.MemoryGi).
+			SetDiskGB(fixture.DiskGB).
+			SetDedicatedCPU(fixture.DedicatedCPU).
+			SetRequiresGpu(fixture.RequiresGPU).
+			SetRequiresSriov(fixture.RequiresSriov).
+			SetRequiresHugepages(fixture.RequiresHugepages).
+			SetCatalogScope(fixture.CatalogScope).
+			SetSortOrder(fixture.SortOrder).
 			SetEnabled(true).
-			SetCreatedBy("e2e-seed").
-			Save(ctx)
+			SetCreatedBy(seedActor)
+		if fixture.CPURequest > 0 {
+			create = create.SetCPURequest(fixture.CPURequest)
+		}
+		if fixture.MemoryRequestGi > 0 {
+			create = create.SetMemoryRequestGi(fixture.MemoryRequestGi)
+		}
+		if fixture.HugepagesSize != "" {
+			create = create.SetHugepagesSize(fixture.HugepagesSize)
+		}
+		if len(fixture.SpecOverrides) > 0 {
+			create = create.SetSpecOverrides(fixture.SpecOverrides)
+		}
+		_, createErr := create.Save(ctx)
 		return createErr
 	}
 
-	_, err = client.InstanceSize.UpdateOneID(obj.ID).
-		SetDisplayName("E2E Small").
-		SetDescription("e2e size").
-		SetCPUCores(2).
-		SetMemoryGi(4.0).
-		SetDiskGB(40).
-		SetEnabled(true).
-		Save(ctx)
+	update := client.InstanceSize.UpdateOneID(obj.ID).
+		SetDisplayName(fixture.DisplayName).
+		SetDescription(fixture.Description).
+		SetCPUCores(fixture.CPUCores).
+		SetMemoryGi(fixture.MemoryGi).
+		SetDiskGB(fixture.DiskGB).
+		SetDedicatedCPU(fixture.DedicatedCPU).
+		SetRequiresGpu(fixture.RequiresGPU).
+		SetRequiresSriov(fixture.RequiresSriov).
+		SetRequiresHugepages(fixture.RequiresHugepages).
+		SetCatalogScope(fixture.CatalogScope).
+		SetSortOrder(fixture.SortOrder).
+		SetEnabled(true)
+	if fixture.CPURequest > 0 {
+		update = update.SetCPURequest(fixture.CPURequest)
+	} else {
+		update = update.ClearCPURequest()
+	}
+	if fixture.MemoryRequestGi > 0 {
+		update = update.SetMemoryRequestGi(fixture.MemoryRequestGi)
+	} else {
+		update = update.ClearMemoryRequestGi()
+	}
+	if fixture.HugepagesSize != "" {
+		update = update.SetHugepagesSize(fixture.HugepagesSize)
+	} else {
+		update = update.ClearHugepagesSize()
+	}
+	update = update.SetSpecOverrides(fixture.SpecOverrides)
+	_, err = update.Save(ctx)
 	return err
 }
 

--- a/cmd/e2e-seed/main_test.go
+++ b/cmd/e2e-seed/main_test.go
@@ -1,133 +1,62 @@
 package main
 
-import (
-	"encoding/base64"
-	"strings"
-	"testing"
+import "testing"
 
-	entcluster "kv-shepherd.io/shepherd/ent/cluster"
-)
+func TestLiveInstanceSizeFixtures_UseNestedSpecOverrides(t *testing.T) {
+	fixtures := liveInstanceSizeFixtures(fixtureConfig{SizeName: defaultSizeName})
 
-func TestEnvOrDefault(t *testing.T) {
-	t.Setenv("E2E_TEST_KEY", "")
-	if got := envOrDefault("E2E_TEST_KEY", "fallback"); got != "fallback" {
-		t.Fatalf("envOrDefault empty = %q, want fallback", got)
-	}
+	for _, fixture := range fixtures {
+		if len(fixture.SpecOverrides) == 0 {
+			continue
+		}
 
-	t.Setenv("E2E_TEST_KEY", "  configured  ")
-	if got := envOrDefault("E2E_TEST_KEY", "fallback"); got != "configured" {
-		t.Fatalf("envOrDefault value = %q, want configured", got)
+		if len(fixture.SpecOverrides) != 1 {
+			t.Fatalf("%s: spec_overrides should have exactly one top-level key, got %d", fixture.Name, len(fixture.SpecOverrides))
+		}
+
+		rawSpec, ok := fixture.SpecOverrides["spec"]
+		if !ok {
+			t.Fatalf("%s: spec_overrides must use nested root key \"spec\"", fixture.Name)
+		}
+
+		specMap, ok := rawSpec.(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s: spec_overrides[\"spec\"] must be an object, got %T", fixture.Name, rawSpec)
+		}
+
+		if len(specMap) == 0 {
+			t.Fatalf("%s: spec_overrides[\"spec\"] must not be empty", fixture.Name)
+		}
+
+		for key := range fixture.SpecOverrides {
+			if key != "spec" {
+				t.Fatalf("%s: flat top-level key %q is not allowed in spec_overrides", fixture.Name, key)
+			}
+		}
 	}
 }
 
-func TestLoadFixtureConfig_Defaults(t *testing.T) {
-	t.Setenv("E2E_ADMIN_USERNAME", "")
-	t.Setenv("E2E_ADMIN_PASSWORD", "")
-	t.Setenv("E2E_NAMESPACE", "")
-	t.Setenv("E2E_CLUSTER_API_SERVER", "")
+func TestLiveInstanceSizeFixtures_DefaultSmallProfile(t *testing.T) {
+	fixtures := liveInstanceSizeFixtures(fixtureConfig{SizeName: defaultSizeName})
 
-	cfg := loadFixtureConfig()
-	if cfg.AdminUsername != defaultAdminUsername {
-		t.Fatalf("AdminUsername = %q, want %q", cfg.AdminUsername, defaultAdminUsername)
+	var small *instanceSizeFixture
+	for i := range fixtures {
+		if fixtures[i].Name == defaultSizeName {
+			small = &fixtures[i]
+			break
+		}
 	}
-	if cfg.AdminPassword != defaultAdminPassword {
-		t.Fatalf("AdminPassword = %q, want %q", cfg.AdminPassword, defaultAdminPassword)
+	if small == nil {
+		t.Fatalf("fixture %q not found", defaultSizeName)
 	}
-	if cfg.NamespaceName != defaultNamespaceName {
-		t.Fatalf("NamespaceName = %q, want %q", cfg.NamespaceName, defaultNamespaceName)
-	}
-	if cfg.ClusterAPIURL != defaultClusterAPIURL {
-		t.Fatalf("ClusterAPIURL = %q, want %q", cfg.ClusterAPIURL, defaultClusterAPIURL)
-	}
-}
 
-func TestLoadFixtureConfig_Overrides(t *testing.T) {
-	t.Setenv("E2E_ADMIN_USERNAME", "tester")
-	t.Setenv("E2E_ADMIN_PASSWORD", "password-1")
-	t.Setenv("E2E_NAMESPACE", "ns-live")
-	t.Setenv("E2E_CLUSTER_API_SERVER", "https://override.cluster.invalid")
-	t.Setenv("E2E_VM_RUNNING_ID", "vm-live-x")
-
-	cfg := loadFixtureConfig()
-	if cfg.AdminUsername != "tester" {
-		t.Fatalf("AdminUsername = %q, want tester", cfg.AdminUsername)
+	if small.CPUCores != 1 || small.CPURequest != 0.5 {
+		t.Fatalf("small cpu profile = %.1f/%.1f, want 1.0/0.5", small.CPUCores, small.CPURequest)
 	}
-	if cfg.AdminPassword != "password-1" {
-		t.Fatalf("AdminPassword = %q, want password-1", cfg.AdminPassword)
+	if small.MemoryGi != 2 || small.MemoryRequestGi != 1 {
+		t.Fatalf("small memory profile = %.1f/%.1f, want 2.0/1.0", small.MemoryGi, small.MemoryRequestGi)
 	}
-	if cfg.NamespaceName != "ns-live" {
-		t.Fatalf("NamespaceName = %q, want ns-live", cfg.NamespaceName)
-	}
-	if cfg.RunningVMID != "vm-live-x" {
-		t.Fatalf("RunningVMID = %q, want vm-live-x", cfg.RunningVMID)
-	}
-	if cfg.ClusterAPIURL != "https://override.cluster.invalid" {
-		t.Fatalf("ClusterAPIURL = %q, want override URL", cfg.ClusterAPIURL)
-	}
-}
-
-func TestResolveClusterSeedInput_DefaultFallback(t *testing.T) {
-	t.Setenv("E2E_KUBECONFIG_B64", "")
-
-	input, err := resolveClusterSeedInput(fixtureConfig{ClusterAPIURL: "https://seed-api.invalid"})
-	if err != nil {
-		t.Fatalf("resolveClusterSeedInput() unexpected error: %v", err)
-	}
-	if input.APIServer != "https://seed-api.invalid" {
-		t.Fatalf("APIServer = %q, want %q", input.APIServer, "https://seed-api.invalid")
-	}
-	if input.Status != entcluster.StatusUNREACHABLE {
-		t.Fatalf("Status = %q, want %q", input.Status, entcluster.StatusUNREACHABLE)
-	}
-	if got := strings.TrimSpace(string(input.Kubeconfig)); got == "" {
-		t.Fatal("Kubeconfig should use non-empty fallback stub")
-	}
-}
-
-func TestResolveClusterSeedInput_InvalidBase64(t *testing.T) {
-	t.Setenv("E2E_KUBECONFIG_B64", "%%%not-base64%%%")
-
-	_, err := resolveClusterSeedInput(fixtureConfig{ClusterAPIURL: defaultClusterAPIURL})
-	if err == nil {
-		t.Fatal("resolveClusterSeedInput() expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "decode E2E_KUBECONFIG_B64") {
-		t.Fatalf("error = %v, want decode failure", err)
-	}
-}
-
-func TestResolveClusterSeedInput_UsesKubeconfigServerWhenDefaultAPIURL(t *testing.T) {
-	raw := strings.TrimSpace(`
-apiVersion: v1
-kind: Config
-clusters:
-  - name: c1
-    cluster:
-      server: https://kube-from-config.invalid
-contexts:
-  - name: c1
-    context:
-      cluster: c1
-      user: u1
-current-context: c1
-users:
-  - name: u1
-    user:
-      token: test-token
-`)
-	t.Setenv("E2E_KUBECONFIG_B64", base64.StdEncoding.EncodeToString([]byte(raw)))
-
-	input, err := resolveClusterSeedInput(fixtureConfig{ClusterAPIURL: defaultClusterAPIURL})
-	if err != nil {
-		t.Fatalf("resolveClusterSeedInput() unexpected error: %v", err)
-	}
-	if input.APIServer != "https://kube-from-config.invalid" {
-		t.Fatalf("APIServer = %q, want kubeconfig server", input.APIServer)
-	}
-	if input.Status != entcluster.StatusHEALTHY {
-		t.Fatalf("Status = %q, want %q", input.Status, entcluster.StatusHEALTHY)
-	}
-	if len(input.Kubeconfig) == 0 {
-		t.Fatal("Kubeconfig should not be empty")
+	if small.DiskGB != 60 {
+		t.Fatalf("small disk = %d, want 60", small.DiskGB)
 	}
 }

--- a/deploy/dev/start-dev.sh
+++ b/deploy/dev/start-dev.sh
@@ -6,10 +6,12 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 COMPOSE_FILE="${ROOT_DIR}/deploy/dev/docker-compose.yml"
 HOST_USER_ID="${USER_ID:-$(id -u)}"
 HOST_GROUP_ID="${GROUP_ID:-$(id -g)}"
+DEV_ADMIN_PASSWORD="${DEV_ADMIN_PASSWORD:-admin123}"
 NODE_MODULES_DIR="${ROOT_DIR}/web/node_modules"
 LOCK_HASH_FILE="${NODE_MODULES_DIR}/.package-lock.hash"
 SERVICES_TO_DELETE=("db" "server" "web" "nginx")
 COMPOSE_CMD=(docker compose -f "${COMPOSE_FILE}")
+DEV_INCLUDE_E2E_SEED="${DEV_INCLUDE_E2E_SEED:-1}"
 
 require_cmd() {
     local cmd="$1"
@@ -28,9 +30,68 @@ compute_sha256() {
     fi
 }
 
+json_string() {
+    node -p 'JSON.stringify(process.argv[1])' "$1"
+}
+
+login_token() {
+    local username="$1"
+    local password="$2"
+    local response=""
+
+    response="$(
+        curl -fsS http://localhost:8080/api/v1/auth/login \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":$(json_string "$username"),\"password\":$(json_string "$password")}"
+    )" || return 1
+
+    printf '%s' "$response" | node -e '
+        let data = "";
+        process.stdin.on("data", (chunk) => { data += chunk; });
+        process.stdin.on("end", () => {
+            const parsed = JSON.parse(data);
+            if (typeof parsed.token !== "string" || parsed.token.trim() === "") {
+                process.exit(1);
+            }
+            process.stdout.write(parsed.token.trim());
+        });
+    '
+}
+
+rotate_default_admin_password() {
+    local bootstrap_password="admin"
+    local target_password="$1"
+    local token=""
+
+    if [[ "${target_password}" == "${bootstrap_password}" ]]; then
+        echo " admin password left at bootstrap default"
+        return 0
+    fi
+
+    if token="$(login_token admin "${target_password}" 2>/dev/null)"; then
+        echo " admin password already rotated"
+        return 0
+    fi
+
+    token="$(login_token admin "${bootstrap_password}")" || {
+        echo " failed to login with bootstrap admin credentials"
+        return 1
+    }
+
+    curl -fsS http://localhost:8080/api/v1/auth/change-password \
+        -X POST \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        -d "{\"old_password\":$(json_string "${bootstrap_password}"),\"new_password\":$(json_string "${target_password}")}" \
+        >/dev/null
+
+    echo " admin password rotated to admin/${target_password}"
+}
+
 require_cmd docker
 require_cmd go
 require_cmd npm
+require_cmd node
 require_cmd curl
 
 if ! [[ "$HOST_USER_ID" =~ ^[0-9]+$ ]] || ! [[ "$HOST_GROUP_ID" =~ ^[0-9]+$ ]]; then
@@ -55,6 +116,7 @@ mkdir -p "${ROOT_DIR}/build/bin"
     cd "$ROOT_DIR"
     GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/shepherd ./cmd/server/...
     GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/seed ./cmd/seed/...
+    GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/e2e-seed ./cmd/e2e-seed/...
 )
 
 echo "Packaging backend image (shepherd-server)..."
@@ -105,9 +167,15 @@ if [ "$backend_ready" != "true" ]; then
     exit 1
 fi
 
-echo "Seeding default development data (admin/admin)..."
+echo "Seeding development data..."
 "${COMPOSE_CMD[@]}" exec -T server /usr/local/bin/seed >/dev/null
-echo " seed complete"
+rotate_default_admin_password "${DEV_ADMIN_PASSWORD}"
+if [[ "${DEV_INCLUDE_E2E_SEED}" == "1" ]]; then
+    "${COMPOSE_CMD[@]}" exec -T server /usr/local/bin/e2e-seed >/dev/null
+    echo " seed complete (baseline + extended fixtures)"
+else
+    echo " seed complete (baseline only; set DEV_INCLUDE_E2E_SEED=1 to include extended fixtures)"
+fi
 
 echo "Waiting for ingress (http://localhost:3000)..."
 for _ in {1..30}; do
@@ -130,3 +198,7 @@ echo "Development environment is UP"
 echo "  - Web (nginx ingress): http://localhost:3000"
 echo "  - Backend direct:      http://localhost:8080"
 echo "  - DB:                  localhost:5432"
+echo "  - Seeded users:        admin/${DEV_ADMIN_PASSWORD} (rotated from bootstrap admin/admin)"
+if [[ "${DEV_INCLUDE_E2E_SEED}" == "1" ]]; then
+    echo "                         e2e-admin/e2e-admin-123"
+fi

--- a/scripts/run_e2e_live.sh
+++ b/scripts/run_e2e_live.sh
@@ -19,6 +19,707 @@ log_error() {
   printf '%s ERROR: %s\n' "$(ts_now)" "$*" >&2
 }
 
+json_string() {
+  node -p 'JSON.stringify(process.argv[1])' "$1"
+}
+
+login_api_token() {
+  local username="$1"
+  local password="$2"
+  local response=""
+
+  response="$(
+    curl -fsS "${API_BASE_URL}/api/v1/auth/login" \
+      -H "Content-Type: application/json" \
+      -d "{\"username\":$(json_string "${username}"),\"password\":$(json_string "${password}")}"
+  )" || return 1
+
+  printf '%s' "${response}" | node -e '
+    let raw = "";
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.token !== "string" || parsed.token.trim() === "") {
+        process.exit(1);
+      }
+      process.stdout.write(parsed.token.trim());
+    });
+  '
+}
+
+acquire_cleanup_token() {
+  local token=""
+
+  if token="$(login_api_token "${E2E_ADMIN_USERNAME}" "${E2E_ADMIN_PASSWORD}" 2>/dev/null)"; then
+    printf '%s' "${token}"
+    return 0
+  fi
+
+  if [[ -n "${E2E_NEW_PASSWORD:-}" ]]; then
+    if token="$(login_api_token "${E2E_ADMIN_USERNAME}" "${E2E_NEW_PASSWORD}" 2>/dev/null)"; then
+      printf '%s' "${token}"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+api_get() {
+  local token="$1"
+  local path="$2"
+  api_request_json GET "${token}" "${path}"
+}
+
+api_post_json() {
+  local token="$1"
+  local path="$2"
+  local body="$3"
+  api_request_json POST "${token}" "${path}" "${body}"
+}
+
+api_patch_json() {
+  local token="$1"
+  local path="$2"
+  local body="$3"
+  api_request_json PATCH "${token}" "${path}" "${body}"
+}
+
+api_put_json() {
+  local token="$1"
+  local path="$2"
+  local body="$3"
+  api_request_json PUT "${token}" "${path}" "${body}"
+}
+
+api_request_json() {
+  local method="$1"
+  local token="$2"
+  local path="$3"
+  local body="${4:-}"
+  local response_file=""
+  local http_code=""
+
+  response_file="$(mktemp)"
+  if [[ "${method}" == "GET" ]]; then
+    http_code="$(
+      curl -sS -o "${response_file}" -w '%{http_code}' "${API_BASE_URL}${path}" \
+        -H "Authorization: Bearer ${token}"
+    )" || {
+      rm -f "${response_file}"
+      return 1
+    }
+  else
+    http_code="$(
+      curl -sS -o "${response_file}" -w '%{http_code}' "${API_BASE_URL}${path}" \
+        -X "${method}" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        -d "${body}"
+    )" || {
+      rm -f "${response_file}"
+      return 1
+    }
+  fi
+
+  if [[ "${http_code}" =~ ^[0-9]+$ ]] && (( http_code >= 400 )); then
+    log_error "API ${method} ${path} failed with HTTP ${http_code}"
+    if [[ -s "${response_file}" ]]; then
+      sed 's/^/response body: /' "${response_file}" >&2
+    fi
+    rm -f "${response_file}"
+    return 22
+  fi
+
+  cat "${response_file}"
+  rm -f "${response_file}"
+}
+
+extract_json_id() {
+  local response="$1"
+  printf '%s' "${response}" | node -e '
+    let raw = "";
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const parsed = JSON.parse(raw);
+      const id = typeof parsed.id === "string" ? parsed.id.trim() : "";
+      process.stdout.write(id);
+    });
+  '
+}
+
+find_item_id_by_name() {
+  local response="$1"
+  local target_name="$2"
+  printf '%s' "${response}" | node -e '
+    const target = process.argv[1].trim().toLowerCase();
+    let raw = "";
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const parsed = JSON.parse(raw);
+      const items = Array.isArray(parsed.items) ? parsed.items : [];
+      for (const item of items) {
+        const name = typeof item.name === "string" ? item.name.trim().toLowerCase() : "";
+        if (name !== target) {
+          continue;
+        }
+        const id = typeof item.id === "string" ? item.id.trim() : "";
+        process.stdout.write(id);
+        return;
+      }
+      process.stdout.write("");
+    });
+  ' "${target_name}"
+}
+
+strip_name_from_payload() {
+  local payload="$1"
+  printf '%s' "${payload}" | node -e '
+    let raw = "";
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const parsed = JSON.parse(raw);
+      delete parsed.name;
+      process.stdout.write(JSON.stringify(parsed));
+    });
+  '
+}
+
+build_namespace_payload() {
+  node -e '
+    const payload = {
+      name: process.argv[1],
+      environment: "test",
+      description: "Live E2E namespace"
+    };
+    process.stdout.write(JSON.stringify(payload));
+  ' "${E2E_NAMESPACE}"
+}
+
+build_system_payload() {
+  node -e '
+    const payload = {
+      name: process.argv[1],
+      description: "Live E2E system"
+    };
+    process.stdout.write(JSON.stringify(payload));
+  ' "${E2E_SYSTEM:-e2e-system}"
+}
+
+build_service_payload() {
+  node -e '
+    const payload = {
+      name: process.argv[1],
+      description: "Live E2E service"
+    };
+    process.stdout.write(JSON.stringify(payload));
+  ' "${E2E_SERVICE:-e2e-service}"
+}
+
+build_template_payload() {
+  node - <<'EOF' "${E2E_TEMPLATE:-e2e-template}" "${E2E_NAMESPACE:-e2e-live}"
+const [name, namespace] = process.argv.slice(2);
+const payload = {
+  name,
+  display_name: "Ubuntu 22.04 (E2E)",
+  description: `Live E2E Ubuntu template for namespace ${namespace}`,
+  catalog_scope: "all",
+  source_type: "cdi_image_import",
+  image_url: "docker://quay.io/containerdisks/ubuntu:22.04",
+  cloud_init: [
+    "#cloud-config",
+    "hostname: e2e-template",
+    "manage_etc_hosts: true",
+    "users:",
+    "  - default",
+    "package_update: false"
+  ].join("\n"),
+  os_family: "linux",
+  os_version: "22.04",
+  enabled: true
+};
+process.stdout.write(JSON.stringify(payload));
+EOF
+}
+
+build_cluster_policy_payload() {
+  node - <<'EOF' "${E2E_NAMESPACE:-e2e-live}"
+const namespace = process.argv[2].trim();
+const allowedCloneNamespaces = ["golden-images"];
+if (namespace !== "" && namespace !== "golden-images") {
+  allowedCloneNamespaces.push(namespace);
+}
+const payload = {
+  allow_cpu_overcommit: true,
+  allow_memory_overcommit: true,
+  allow_dedicated_cpu: true,
+  allow_gpu: true,
+  allow_sriov: true,
+  allow_hugepages: true,
+  allowed_hugepages_sizes: ["2Mi", "1Gi"],
+  allow_cdi_clone: true,
+  allowed_clone_source_namespaces: allowedCloneNamespaces,
+  allowed_storage_classes: []
+};
+process.stdout.write(JSON.stringify(payload));
+EOF
+}
+
+live_instance_size_payloads() {
+  node - <<'EOF' "${E2E_SIZE:-e2e-small}"
+const defaultSizeName = process.argv[2];
+const fixtures = [
+  {
+    name: defaultSizeName,
+    display_name: "E2E Small",
+    description: "Baseline general-purpose live E2E size",
+    catalog_scope: "all",
+    cpu_cores: 2,
+    memory_gi: 4,
+    disk_gb: 40,
+    sort_order: 10,
+    enabled: true
+  },
+  {
+    name: "e2e-overcommit",
+    display_name: "E2E Overcommit",
+    description: "CPU and memory overcommit example for live E2E",
+    catalog_scope: "all",
+    cpu_cores: 4,
+    cpu_request: 2,
+    memory_gi: 8,
+    memory_request_gi: 6,
+    disk_gb: 80,
+    sort_order: 20,
+    enabled: true
+  },
+  {
+    name: "e2e-dedicated",
+    display_name: "E2E Dedicated CPU",
+    description: "Dedicated CPU example for live E2E",
+    catalog_scope: "all",
+    cpu_cores: 4,
+    cpu_request: 4,
+    memory_gi: 8,
+    memory_request_gi: 8,
+    disk_gb: 80,
+    dedicated_cpu: true,
+    sort_order: 30,
+    enabled: true
+  },
+  {
+    name: "e2e-gpu",
+    display_name: "E2E GPU",
+    description: "GPU workload example for live E2E",
+    catalog_scope: "all",
+    cpu_cores: 8,
+    memory_gi: 16,
+    disk_gb: 120,
+    requires_gpu: true,
+    sort_order: 40,
+    enabled: true
+  },
+  {
+    name: "e2e-hugepages",
+    display_name: "E2E Hugepages",
+    description: "Hugepages workload example for live E2E",
+    catalog_scope: "all",
+    cpu_cores: 4,
+    memory_gi: 8,
+    disk_gb: 80,
+    requires_hugepages: true,
+    hugepages_size: "2Mi",
+    sort_order: 50,
+    enabled: true
+  },
+  {
+    name: "e2e-sriov",
+    display_name: "E2E SR-IOV",
+    description: "SR-IOV workload example for live E2E",
+    catalog_scope: "all",
+    cpu_cores: 4,
+    memory_gi: 8,
+    disk_gb: 80,
+    requires_sriov: true,
+    sort_order: 60,
+    enabled: true
+  }
+];
+for (const fixture of fixtures) {
+  process.stdout.write(JSON.stringify(fixture) + "\n");
+}
+EOF
+}
+
+ensure_namespace_api() {
+  local token="$1"
+  local existing=""
+  local response=""
+
+  if ! response="$(api_get "${token}" "/api/v1/admin/namespaces?page=1&per_page=100")"; then
+    return 1
+  fi
+  existing="$(find_item_id_by_name "${response}" "${E2E_NAMESPACE}")"
+  if [[ -n "${existing}" ]]; then
+    printf '%s' "${existing}"
+    return 0
+  fi
+
+  if ! response="$(api_post_json "${token}" "/api/v1/admin/namespaces" "$(build_namespace_payload)")"; then
+    return 1
+  fi
+  extract_json_id "${response}"
+}
+
+ensure_system_api() {
+  local token="$1"
+  local system_name="${E2E_SYSTEM:-e2e-system}"
+  local existing=""
+  local response=""
+
+  if ! response="$(api_get "${token}" "/api/v1/systems?page=1&per_page=100")"; then
+    return 1
+  fi
+  existing="$(find_item_id_by_name "${response}" "${system_name}")"
+  if [[ -n "${existing}" ]]; then
+    printf '%s' "${existing}"
+    return 0
+  fi
+
+  if ! response="$(api_post_json "${token}" "/api/v1/systems" "$(build_system_payload)")"; then
+    return 1
+  fi
+  extract_json_id "${response}"
+}
+
+ensure_service_api() {
+  local token="$1"
+  local system_id="$2"
+  local service_name="${E2E_SERVICE:-e2e-service}"
+  local existing=""
+  local response=""
+
+  if ! response="$(api_get "${token}" "/api/v1/systems/${system_id}/services?page=1&per_page=100")"; then
+    return 1
+  fi
+  existing="$(find_item_id_by_name "${response}" "${service_name}")"
+  if [[ -n "${existing}" ]]; then
+    printf '%s' "${existing}"
+    return 0
+  fi
+
+  if ! response="$(api_post_json "${token}" "/api/v1/systems/${system_id}/services" "$(build_service_payload)")"; then
+    return 1
+  fi
+  extract_json_id "${response}"
+}
+
+ensure_cluster_api() {
+  local token="$1"
+  local cluster_name="${E2E_CLUSTER:-e2e-cluster}"
+  local existing=""
+  local response=""
+  local payload=""
+
+  if ! response="$(api_get "${token}" "/api/v1/admin/clusters?page=1&per_page=100")"; then
+    return 1
+  fi
+  existing="$(find_item_id_by_name "${response}" "${cluster_name}")"
+  if [[ -n "${existing}" ]]; then
+    printf '%s' "${existing}"
+    return 0
+  fi
+
+  payload="$(node -e '
+    const payload = {
+      name: process.argv[1],
+      display_name: "E2E Cluster",
+      environment: "test",
+      kubeconfig: process.argv[2]
+    };
+    process.stdout.write(JSON.stringify(payload));
+  ' "${cluster_name}" "${E2E_KUBECONFIG_B64}")"
+  if ! response="$(api_post_json "${token}" "/api/v1/admin/clusters" "${payload}")"; then
+    return 1
+  fi
+  extract_json_id "${response}"
+}
+
+upsert_cluster_policy_api() {
+  local token="$1"
+  local cluster_id="$2"
+  api_put_json "${token}" "/api/v1/admin/clusters/${cluster_id}/policy" "$(build_cluster_policy_payload)" >/dev/null
+}
+
+upsert_template_api() {
+  local token="$1"
+  local template_name="${E2E_TEMPLATE:-e2e-template}"
+  local existing_id=""
+  local response=""
+  local payload=""
+
+  if ! response="$(api_get "${token}" "/api/v1/admin/templates?page=1&per_page=100")"; then
+    return 1
+  fi
+  existing_id="$(find_item_id_by_name "${response}" "${template_name}")"
+  payload="$(build_template_payload)"
+  if [[ -n "${existing_id}" ]]; then
+    api_patch_json "${token}" "/api/v1/admin/templates/${existing_id}" "$(strip_name_from_payload "${payload}")" >/dev/null
+    return 0
+  fi
+
+  api_post_json "${token}" "/api/v1/admin/templates" "${payload}" >/dev/null
+}
+
+upsert_instance_size_api() {
+  local token="$1"
+  local payload="$2"
+  local name=""
+  local existing_id=""
+  local response=""
+
+  name="$(printf '%s' "${payload}" | node -e '
+    let raw = "";
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const parsed = JSON.parse(raw);
+      process.stdout.write(typeof parsed.name === "string" ? parsed.name.trim() : "");
+    });
+  ')"
+  if ! response="$(api_get "${token}" "/api/v1/admin/instance-sizes")"; then
+    return 1
+  fi
+  existing_id="$(find_item_id_by_name "${response}" "${name}")"
+  if [[ -n "${existing_id}" ]]; then
+    api_patch_json "${token}" "/api/v1/admin/instance-sizes/${existing_id}" "${payload}" >/dev/null
+    return 0
+  fi
+
+  api_post_json "${token}" "/api/v1/admin/instance-sizes" "${payload}" >/dev/null
+}
+
+seed_live_api_managed_fixtures() {
+  local token="$1"
+  local namespace_id=""
+  local system_id=""
+  local service_id=""
+  local cluster_id=""
+  local payload=""
+
+  log_info "seeding namespace fixture (${E2E_NAMESPACE})"
+  namespace_id="$(ensure_namespace_api "${token}")"
+  log_info "seeding system fixture (${E2E_SYSTEM:-e2e-system})"
+  system_id="$(ensure_system_api "${token}")"
+  log_info "seeding service fixture (${E2E_SERVICE:-e2e-service})"
+  service_id="$(ensure_service_api "${token}" "${system_id}")"
+  log_info "seeding cluster fixture (${E2E_CLUSTER:-e2e-cluster})"
+  cluster_id="$(ensure_cluster_api "${token}")"
+  log_info "upserting cluster policy for cluster ${cluster_id}"
+  upsert_cluster_policy_api "${token}" "${cluster_id}"
+  log_info "upserting template fixture (${E2E_TEMPLATE:-e2e-template})"
+  upsert_template_api "${token}"
+
+  while IFS= read -r payload; do
+    [[ -z "${payload}" ]] && continue
+    log_info "upserting instance size fixture ($(printf '%s' "${payload}" | node -e 'let raw = ""; process.stdin.on("data", (chunk) => { raw += chunk; }); process.stdin.on("end", () => { const parsed = JSON.parse(raw); process.stdout.write(typeof parsed.name === "string" ? parsed.name : ""); });'))"
+    upsert_instance_size_api "${token}" "${payload}"
+  done < <(live_instance_size_payloads)
+
+  log_info "seeded API-managed live fixtures (namespace=${namespace_id} system=${system_id} service=${service_id} cluster=${cluster_id})"
+}
+
+list_namespace_vms() {
+  local token="$1"
+  local namespace="$2"
+  local page=1
+  local per_page=100
+  local response=""
+  local total_pages=1
+
+  while (( page <= total_pages )); do
+    response="$(
+      curl -fsS -G "${API_BASE_URL}/api/v1/vms" \
+        --data-urlencode "page=${page}" \
+        --data-urlencode "per_page=${per_page}" \
+        --data-urlencode "namespace=${namespace}" \
+        -H "Authorization: Bearer ${token}"
+    )" || return 1
+
+    printf '%s' "${response}" | node -e '
+      let raw = "";
+      process.stdin.on("data", (chunk) => { raw += chunk; });
+      process.stdin.on("end", () => {
+        const parsed = JSON.parse(raw);
+        for (const item of parsed.items ?? []) {
+          const id = typeof item.id === "string" ? item.id.trim() : "";
+          if (id === "") {
+            continue;
+          }
+          const name = typeof item.name === "string" ? item.name.trim() : "";
+          const status = typeof item.status === "string" ? item.status.trim() : "";
+          process.stdout.write(`${id}\t${name}\t${status}\n`);
+        }
+      });
+    '
+
+    total_pages="$(printf '%s' "${response}" | node -e '
+      let raw = "";
+      process.stdin.on("data", (chunk) => { raw += chunk; });
+      process.stdin.on("end", () => {
+        const parsed = JSON.parse(raw);
+        const totalPages = Number(parsed.pagination?.total_pages ?? 1);
+        process.stdout.write(String(Number.isFinite(totalPages) && totalPages > 0 ? totalPages : 1));
+      });
+    ')"
+    page=$((page + 1))
+  done
+}
+
+wait_for_vm_status() {
+  local token="$1"
+  local vm_id="$2"
+  local expected_status="$3"
+  local response=""
+  local current_status=""
+
+  for _ in $(seq 1 40); do
+    response="$(curl -fsS "${API_BASE_URL}/api/v1/vms/${vm_id}" -H "Authorization: Bearer ${token}" 2>/dev/null || true)"
+    current_status="$(printf '%s' "${response}" | node -e '
+      let raw = "";
+      process.stdin.on("data", (chunk) => { raw += chunk; });
+      process.stdin.on("end", () => {
+        if (raw.trim() === "") {
+          process.stdout.write("");
+          return;
+        }
+        try {
+          const parsed = JSON.parse(raw);
+          process.stdout.write(typeof parsed.status === "string" ? parsed.status.trim().toUpperCase() : "");
+        } catch {
+          process.stdout.write("");
+        }
+      });
+    ')"
+    if [[ "${current_status}" == "${expected_status}" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  return 1
+}
+
+wait_for_vm_absent() {
+  local token="$1"
+  local vm_id="$2"
+
+  for _ in $(seq 1 60); do
+    if ! curl -fsS "${API_BASE_URL}/api/v1/vms/${vm_id}" -H "Authorization: Bearer ${token}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  return 1
+}
+
+cleanup_namespace_vms() {
+  local enabled="${E2E_CLEANUP_NAMESPACE_VMS:-1}"
+  local namespace="${E2E_NAMESPACE:-}"
+  local token=""
+  local cleanup_failed=0
+  local vm_entries=""
+  local delete_response=""
+  local ticket_id=""
+
+  if [[ "${enabled}" == "0" ]]; then
+    log_warn "skipping namespace VM cleanup (E2E_CLEANUP_NAMESPACE_VMS=0)"
+    return 0
+  fi
+  if [[ -z "${namespace}" ]]; then
+    log_warn "skipping namespace VM cleanup because E2E_NAMESPACE is empty"
+    return 0
+  fi
+
+  if ! token="$(acquire_cleanup_token)"; then
+    log_warn "failed to acquire API token for namespace VM cleanup"
+    return 1
+  fi
+
+  log_info "cleaning up VMs in namespace ${namespace}"
+
+  if ! vm_entries="$(list_namespace_vms "${token}" "${namespace}")"; then
+    log_warn "failed to list VMs for namespace cleanup"
+    return 1
+  fi
+
+  while IFS=$'\t' read -r vm_id vm_name vm_status; do
+    [[ -z "${vm_id}" ]] && continue
+    vm_status="$(printf '%s' "${vm_status}" | tr '[:lower:]' '[:upper:]')"
+
+    if [[ "${vm_status}" == "RUNNING" || "${vm_status}" == "STARTING" || "${vm_status}" == "UNKNOWN" ]]; then
+      if curl -fsS "${API_BASE_URL}/api/v1/vms/${vm_id}/stop" \
+        -X POST \
+        -H "Authorization: Bearer ${token}" >/dev/null 2>&1; then
+        if ! wait_for_vm_status "${token}" "${vm_id}" "STOPPED"; then
+          log_warn "timed out waiting for VM ${vm_id} to stop before cleanup delete"
+          cleanup_failed=1
+          continue
+        fi
+      else
+        log_warn "failed to request stop for VM ${vm_id} during cleanup"
+        cleanup_failed=1
+        continue
+      fi
+    fi
+
+    delete_response="$(
+      curl -fsS "${API_BASE_URL}/api/v1/vms/${vm_id}?confirm=true" \
+        -X DELETE \
+        -H "Authorization: Bearer ${token}" 2>/dev/null || true
+    )"
+    ticket_id="$(printf '%s' "${delete_response}" | node -e '
+      let raw = "";
+      process.stdin.on("data", (chunk) => { raw += chunk; });
+      process.stdin.on("end", () => {
+        if (raw.trim() === "") {
+          process.stdout.write("");
+          return;
+        }
+        try {
+          const parsed = JSON.parse(raw);
+          const ticketID = typeof parsed.ticket_id === "string" ? parsed.ticket_id.trim() : "";
+          process.stdout.write(ticketID);
+        } catch {
+          process.stdout.write("");
+        }
+      });
+    ')"
+    if [[ -z "${ticket_id}" ]]; then
+      log_warn "failed to create delete approval for VM ${vm_id} during cleanup"
+      cleanup_failed=1
+      continue
+    fi
+
+    if ! curl -fsS "${API_BASE_URL}/api/v1/approvals/${ticket_id}/approve" \
+      -X POST \
+      -H "Authorization: Bearer ${token}" \
+      -H "Content-Type: application/json" \
+      -d '{}' >/dev/null 2>&1; then
+      log_warn "failed to approve delete ticket ${ticket_id} for VM ${vm_id}"
+      cleanup_failed=1
+      continue
+    fi
+
+    if ! wait_for_vm_absent "${token}" "${vm_id}"; then
+      log_warn "timed out waiting for VM ${vm_id} to disappear after cleanup approval"
+      cleanup_failed=1
+    fi
+  done <<< "${vm_entries}"
+
+  return "${cleanup_failed}"
+}
+
 run_live_e2e_preflight_checks() {
   local skip="${E2E_SKIP_PREFLIGHT_GATES:-0}"
   if [[ "${skip}" == "1" ]]; then
@@ -509,6 +1210,11 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v node >/dev/null 2>&1; then
+  log_error "node command not found"
+  exit 1
+fi
+
 pick_free_port() {
   local candidate
   for _ in $(seq 1 80); do
@@ -597,7 +1303,16 @@ DEFAULT_E2E_PASSWORD="${E2E_PASSWORD:-${E2E_ADMIN_PASSWORD:-admin}}"
 export E2E_USERNAME="${DEFAULT_E2E_USERNAME}"
 export E2E_PASSWORD="${DEFAULT_E2E_PASSWORD}"
 export E2E_NEW_PASSWORD="${E2E_NEW_PASSWORD:-admin123}"
+export E2E_CLUSTER="${E2E_CLUSTER:-e2e-cluster}"
+export E2E_SYSTEM="${E2E_SYSTEM:-e2e-system}"
+export E2E_SERVICE="${E2E_SERVICE:-e2e-service}"
+export E2E_TEMPLATE="${E2E_TEMPLATE:-e2e-template}"
+export E2E_SIZE="${E2E_SIZE:-e2e-small}"
 export E2E_NAMESPACE="${E2E_NAMESPACE:-e2e-live}"
+export E2E_VM_RUNNING_ID="${E2E_VM_RUNNING_ID:-vm-e2e-running}"
+export E2E_VM_STOPPED_ID="${E2E_VM_STOPPED_ID:-vm-e2e-stopped}"
+export E2E_VM_RUNNING_NAME="${E2E_VM_RUNNING_NAME:-vm-live}"
+export E2E_VM_STOPPED_NAME="${E2E_VM_STOPPED_NAME:-vm-stopped}"
 
 if [[ -z "${E2E_KUBECONFIG_B64:-}" ]]; then
   DEFAULT_KUBECONFIG_FILE="${ROOT_DIR}/k8s-admin.yaml"
@@ -612,17 +1327,31 @@ if [[ -z "${E2E_KUBECONFIG_B64:-}" ]]; then
   fi
 fi
 
+if [[ -z "${E2E_KUBECONFIG_B64:-}" ]]; then
+  log_error "live E2E requires a real kubeconfig (set E2E_KUBECONFIG_B64 or provide ${ROOT_DIR}/k8s-admin.yaml)"
+  exit 1
+fi
+
 # Keep e2e-seed aligned with the same account to avoid user/data drift.
 export E2E_ADMIN_USERNAME="${E2E_ADMIN_USERNAME:-${E2E_USERNAME}}"
 export E2E_ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-${E2E_PASSWORD}}"
 
 SERVER_PID=""
 cleanup() {
+  local exit_code=$?
+  local cleanup_vm_exit=0
+  set +e
+  cleanup_namespace_vms
+  cleanup_vm_exit=$?
   if [[ -n "$SERVER_PID" ]]; then
     kill "$SERVER_PID" >/dev/null 2>&1 || true
     wait "$SERVER_PID" >/dev/null 2>&1 || true
   fi
   cleanup_next_web_port "${PW_WEB_PORT:-}"
+  if [[ "${cleanup_vm_exit}" -ne 0 ]]; then
+    log_warn "namespace VM cleanup completed with warnings"
+  fi
+  return "${exit_code}"
 }
 trap cleanup EXIT INT TERM
 
@@ -663,7 +1392,13 @@ fi
 
 log_info "seeding baseline data"
 go run ./cmd/seed
-go run ./cmd/e2e-seed
+
+log_info "seeding API-managed live fixtures"
+SEED_API_TOKEN="$(login_api_token "${E2E_ADMIN_USERNAME}" "${E2E_ADMIN_PASSWORD}")"
+seed_live_api_managed_fixtures "${SEED_API_TOKEN}"
+
+log_info "seeding extended low-level fixtures"
+E2E_SKIP_API_MANAGED_FIXTURES=1 go run ./cmd/e2e-seed
 
 log_info "running live-e2e preflight gates"
 run_live_e2e_preflight_checks

--- a/web/tests/e2e/admin-extended-live.spec.ts
+++ b/web/tests/e2e/admin-extended-live.spec.ts
@@ -400,7 +400,7 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         const createModal = getAntModal(page, 'template-create-modal');
         await expect(createModal).toBeVisible();
         await createModal.getByRole('textbox').first().fill(tplName);
-        await createModal.getByLabel(/container image url/i).fill('quay.io/containerdisks/ubuntu:22.04');
+        await createModal.getByLabel(/image url/i).fill('quay.io/containerdisks/ubuntu:22.04');
         await createModal.getByRole('button', { name: 'OK' }).click();
 
         const { body: created } = await expectSchema(createRespPromise, 'Template', 201);
@@ -408,10 +408,16 @@ test.describe('admin-extended live (contract-enforced, no mock, no skip)', () =>
         expect(tplID, 'POST /admin/templates response missing id').toBeTruthy();
 
         // ── PATCH /admin/templates/{id} → Template ────────────────────────────────
+        // First ensure the edit action button is visible before registering the
+        // response promise — the button may take a moment to appear after list
+        // re-render following POST creation.
+        const editBtn = page.getByTestId(`template-action-edit-${tplID}`);
+        await expect(editBtn).toBeVisible({ timeout: 10_000 });
+
         const updateRespPromise = page.waitForResponse(
             (r) => urlPathIncludes(r.url(), `/api/v1/admin/templates/${tplID}`) && r.request().method() === 'PATCH'
         );
-        await page.getByTestId(`template-action-edit-${tplID}`).click();
+        await editBtn.click();
         const editModal = getAntModal(page, 'template-edit-modal');
         await expect(editModal).toBeVisible();
         await editModal.locator('textarea').first().fill('Updated template description by live e2e test');

--- a/web/tests/e2e/admin-flow-live.spec.ts
+++ b/web/tests/e2e/admin-flow-live.spec.ts
@@ -748,7 +748,7 @@ test.describe('admin-flow live (contract-enforced, no mock)', () => {
             const createModal = getAntModal(page, 'template-create-modal');
             await expect(createModal).toBeVisible();
             await createModal.getByRole('textbox').first().fill(templateName);
-            await createModal.getByLabel(/container image url/i).fill('quay.io/containerdisks/ubuntu:22.04');
+            await createModal.getByLabel(/image url/i).fill('quay.io/containerdisks/ubuntu:22.04');
             await createModal.getByRole('button', { name: 'OK' }).click();
 
             const createResp = await createRespPromise;

--- a/web/tests/e2e/edge-cases-live.spec.ts
+++ b/web/tests/e2e/edge-cases-live.spec.ts
@@ -14,7 +14,7 @@
  */
 
 import { expect, test, type Page } from '@playwright/test';
-import { getAntModal, loginWithForcePasswordSupport, selectAntOption, urlPathEndsWith } from './lib/helpers';
+import { ensureSeedSystemAndService, getAntModal, loginWithForcePasswordSupport, selectAntOption, urlPathEndsWith } from './lib/helpers';
 
 const e2eUsername = process.env.E2E_USERNAME ?? 'e2e-admin';
 const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
@@ -66,6 +66,19 @@ test.describe('Edge Cases / Negative Paths', () => {
     });
 
     test.describe('With Admin Auth', () => {
+        test.beforeAll(async ({ request }) => {
+            // Ensure seed system + service exist (idempotent, API-first).
+            const seed = await ensureSeedSystemAndService(request, {
+                username: e2eUsername,
+                primaryPassword: e2ePassword,
+                secondaryPassword: e2eNewPassword,
+                currentPasswordHint: activePassword,
+                systemName: e2eSystemName,
+                serviceName: e2eServiceName,
+            });
+            activePassword = seed.password;
+        });
+
         test.beforeEach(async ({ page }) => {
             await page.addInitScript(() => { window.open = () => null; });
             await loginAdmin(page);

--- a/web/tests/e2e/lib/helpers.ts
+++ b/web/tests/e2e/lib/helpers.ts
@@ -84,19 +84,33 @@ export function urlPathIncludes(url: string, path: string): boolean {
  * @param page - Playwright Page instance
  * @param combobox - Locator for the combobox trigger element
  * @param optionFilter - Optional: filter options by text content (regex or string)
- * @param timeout - Max time to wait for option visibility (default: 5000ms)
+ * @param timeout - Max time to wait for option visibility (default: 15000ms)
  */
 export async function selectAntOption(
     page: Page,
     combobox: Locator,
     optionFilter?: string | RegExp,
-    timeout = 5000
+    timeout = 15_000
 ): Promise<void> {
     const trigger = combobox.first();
     await expect(trigger).toBeVisible({ timeout });
 
     // Step 1: Click to open dropdown
     await trigger.click();
+
+    // Step 1.5: If the Select supports showSearch and a string filter is given,
+    // type the filter text into the search input. This narrows the virtual list
+    // to only matching options, preventing items outside the viewport from being
+    // invisible in the DOM. We use .pressSequentially() for realistic key-by-key
+    // input that triggers Ant's onSearch handler.
+    if (typeof optionFilter === 'string' && optionFilter.length > 0) {
+        const searchInput = trigger.locator('input[type="search"]');
+        if (await searchInput.count() > 0 && await searchInput.isVisible().catch(() => false)) {
+            await searchInput.pressSequentially(optionFilter, { delay: 30 });
+            // Give Ant a moment to re-render filtered options
+            await page.waitForTimeout(200);
+        }
+    }
 
     // Step 2: Wait for any OLD dropdown leave-animations to finish.
     // Ant Design adds `.ant-slide-up-leave` during close animation.
@@ -486,4 +500,83 @@ export async function ensureBatchSubmitPolicyForUser(
     validateResponse('RateLimitUserOverride', await overrideResp.json());
 
     return { password: auth.password, userID };
+}
+
+/**
+ * Idempotent API-first seed: ensure the named system and service exist.
+ *
+ * Uses GET-then-POST pattern — safe to call from multiple test files.
+ * Returns the system and service IDs for downstream consumption.
+ */
+export async function ensureSeedSystemAndService(
+    request: APIRequestContext,
+    options: AuthFlowOptions & {
+        systemName: string;
+        serviceName: string;
+    }
+): Promise<{ password: string; systemId: string; serviceId: string }> {
+    const auth = await getApiTokenWithForcePasswordSupport(request, options);
+    const headers = { Authorization: `Bearer ${auth.token}` };
+
+    // ── Ensure system exists ─────────────────────────────────────────────────
+    const systemsResp = await request.get('/api/v1/systems', { headers });
+    expect(systemsResp.status(), 'GET /systems must return 200 in seed setup').toBe(200);
+    const systemsBody = await systemsResp.json() as {
+        items?: Array<{ id?: string; name?: string }>;
+    };
+    validateResponse('SystemList', systemsBody);
+
+    let system = (systemsBody.items ?? []).find(
+        (item) => (item.name ?? '').trim() === options.systemName
+    );
+    if (!system?.id) {
+        const createResp = await request.post('/api/v1/systems', {
+            headers,
+            data: {
+                name: options.systemName,
+                description: `Auto-seeded by E2E test setup`,
+            },
+        });
+        expect(
+            createResp.status(),
+            `POST /systems returned ${createResp.status()} for seed system "${options.systemName}"`
+        ).toBe(201);
+        const created = await createResp.json() as { id?: string; name?: string };
+        validateResponse('System', created);
+        system = created;
+    }
+    const systemId = (system?.id ?? '').trim();
+    expect(systemId, `Seed system "${options.systemName}" must have an id`).toBeTruthy();
+
+    // ── Ensure service exists under the system ───────────────────────────────
+    const servicesResp = await request.get(`/api/v1/systems/${systemId}/services`, { headers });
+    expect(servicesResp.status(), 'GET /systems/{id}/services must return 200 in seed setup').toBe(200);
+    const servicesBody = await servicesResp.json() as {
+        items?: Array<{ id?: string; name?: string }>;
+    };
+    validateResponse('ServiceList', servicesBody);
+
+    let service = (servicesBody.items ?? []).find(
+        (item) => (item.name ?? '').trim() === options.serviceName
+    );
+    if (!service?.id) {
+        const createResp = await request.post(`/api/v1/systems/${systemId}/services`, {
+            headers,
+            data: {
+                name: options.serviceName,
+                description: `Auto-seeded by E2E test setup`,
+            },
+        });
+        expect(
+            createResp.status(),
+            `POST /systems/${systemId}/services returned ${createResp.status()} for seed service "${options.serviceName}"`
+        ).toBe(201);
+        const created = await createResp.json() as { id?: string; name?: string };
+        validateResponse('Service', created);
+        service = created;
+    }
+    const serviceId = (service?.id ?? '').trim();
+    expect(serviceId, `Seed service "${options.serviceName}" must have an id`).toBeTruthy();
+
+    return { password: auth.password, systemId, serviceId };
 }

--- a/web/tests/e2e/master-flow-live.spec.ts
+++ b/web/tests/e2e/master-flow-live.spec.ts
@@ -51,6 +51,7 @@
 import { expect, test, type APIRequestContext, type Page, type Response } from '@playwright/test';
 import { validateApiResponse } from './lib/schema-validator';
 import {
+  ensureSeedSystemAndService,
   fetchStatusWithStoredToken,
   getAntModal,
   getApiTokenWithForcePasswordSupport,
@@ -550,6 +551,19 @@ async function seedPendingApprovalTicket(request: APIRequestContext): Promise<Ap
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 test.describe('master-flow live (contract-enforced, no mock)', () => {
+  test.beforeAll(async ({ request }) => {
+    // Ensure seed system + service exist (idempotent, API-first).
+    const seed = await ensureSeedSystemAndService(request, {
+      username: e2eUsername,
+      primaryPassword: e2ePassword,
+      secondaryPassword: e2eNewPassword,
+      currentPasswordHint: activePassword,
+      systemName: e2eSystemName,
+      serviceName: e2eServiceName,
+    });
+    activePassword = seed.password;
+  });
+
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       window.open = () => null; // prevent popup interference in CI

--- a/web/tests/e2e/user-selfservice-live.spec.ts
+++ b/web/tests/e2e/user-selfservice-live.spec.ts
@@ -35,6 +35,7 @@ import { expect, test, type APIRequestContext, type Locator, type Page, type Res
 import { validateApiResponse } from './lib/schema-validator';
 import {
     ensureBatchSubmitPolicyForUser,
+    ensureSeedSystemAndService,
     fetchStatusWithStoredToken,
     getAntModal,
     getApiTokenWithForcePasswordSupport,
@@ -51,6 +52,7 @@ const e2ePassword = process.env.E2E_PASSWORD ?? 'e2e-admin-123';
 const e2eNewPassword = process.env.E2E_NEW_PASSWORD ?? (e2ePassword === 'admin' ? 'admin123' : `${e2ePassword}-new`);
 const e2eSystemName = process.env.E2E_SYSTEM ?? 'e2e-system';
 const e2eServiceName = process.env.E2E_SERVICE ?? 'e2e-service';
+const e2eNamespace = process.env.E2E_NAMESPACE ?? 'e2e-test';
 let activePassword = e2ePassword;
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
@@ -122,6 +124,17 @@ async function findTicketCancelButtonAcrossPages(
 
 test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () => {
     test.beforeAll(async ({ request }) => {
+        // Ensure seed system + service exist (idempotent, API-first).
+        const seed = await ensureSeedSystemAndService(request, {
+            username: e2eUsername,
+            primaryPassword: e2ePassword,
+            secondaryPassword: e2eNewPassword,
+            currentPasswordHint: activePassword,
+            systemName: e2eSystemName,
+            serviceName: e2eServiceName,
+        });
+        activePassword = seed.password;
+
         const setup = await ensureBatchSubmitPolicyForUser(request, {
             username: e2eUsername,
             primaryPassword: e2ePassword,
@@ -254,7 +267,7 @@ test.describe('user-selfservice live (contract-enforced, no mock, no skip)', () 
         // operationId: cancelTicket
         // First submit a VM request to get a pending ticket
         const uniqueSuffix = `${Date.now()}`;
-        const requestNamespace = `e2e-cancel-${uniqueSuffix}`;
+        const requestNamespace = e2eNamespace;
         await page.goto('/vms');
         await expect(page.getByRole('heading', { name: 'Virtual Machines' })).toBeVisible();
         await page.getByRole('button', { name: 'Request VM' }).click();

--- a/web/tests/e2e/vm-lifecycle-live.spec.ts
+++ b/web/tests/e2e/vm-lifecycle-live.spec.ts
@@ -38,6 +38,7 @@ import { expect, test, type APIRequestContext, type Page, type Response } from '
 import { validateApiResponse } from './lib/schema-validator';
 import {
     ensureBatchSubmitPolicyForUser,
+    ensureSeedSystemAndService,
     fetchStatusWithStoredToken,
     getApiTokenWithForcePasswordSupport,
     loginWithForcePasswordSupport,
@@ -385,6 +386,17 @@ async function getFirstVMId(page: Page): Promise<string> {
 
 test.describe('vm-lifecycle live (contract-enforced, no mock, no skip)', () => {
     test.beforeAll(async ({ request }) => {
+        // Ensure seed system + service exist (idempotent, API-first).
+        const seed = await ensureSeedSystemAndService(request, {
+            username: e2eUsername,
+            primaryPassword: e2ePassword,
+            secondaryPassword: e2eNewPassword,
+            currentPasswordHint: activePassword,
+            systemName: e2eSystemName,
+            serviceName: e2eServiceName,
+        });
+        activePassword = seed.password;
+
         const setup = await ensureBatchSubmitPolicyForUser(request, {
             username: e2eUsername,
             primaryPassword: e2ePassword,


### PR DESCRIPTION
## Summary
- package and run `e2e-seed` in local dev/runtime flows, including default admin password rotation in `start-dev`
- modernize live E2E fixture bootstrap toward API-managed/current-state fixtures and best-effort namespace VM cleanup
- refresh live Playwright helpers/specs to match current template/size/approval behavior

## Verification
- `go test ./cmd/e2e-seed/...`
- `bash -n deploy/dev/start-dev.sh scripts/run_e2e_live.sh`
- `npm run lint --prefix web`
- `npm run typecheck --prefix web`
- `TEST_GUARD_INCLUDE_WORKTREE=0 bash docs/design/ci/scripts/check_changed_code_has_tests.sh`
- `go run docs/design/ci/scripts/check_master_flow_test_matrix.go`

Refs #348
Refs #310