### PR TITLE
chore(ci): align local ci-checks target with canonical scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,10 +139,12 @@ clean:
 docker:
 	docker build -t kubevirt-shepherd:latest .
 
-## ci-checks: Run CI check scripts
+## ci-checks: Run canonical CI check scripts wired in GitHub Actions
 ci-checks:
 	@echo "Running CI checks..."
 	@$(MAKE) test-shepherd-linter
+	@bash docs/design/ci/scripts/check_manual_di.sh
+	@bash docs/design/ci/scripts/check_sqlc_usage.sh
 	@for script in docs/design/ci/scripts/*.sh; do \
 		echo "Running $$script..."; \
 		bash "$$script" || exit 1; \


### PR DESCRIPTION
## Summary

- point `make ci-checks` at the tracked `docs/design/ci/scripts/check_manual_di.sh`
- point `make ci-checks` at the tracked `docs/design/ci/scripts/check_sqlc_usage.sh`
- keep the local `Makefile` target aligned with the governance scripts GitHub Actions already uses

## Validation

- `make ci-checks`
- `TEST_GUARD_INCLUDE_WORKTREE=0 bash docs/design/ci/scripts/check_changed_code_has_tests.sh`

Refs #355
