### PR TITLE
docs: propose ADR-0045 review package

### DIFF
--- a/docs/adr/ADR-0045-cluster-resolved-root-volume-provisioning.md
+++ b/docs/adr/ADR-0045-cluster-resolved-root-volume-provisioning.md
@@ -1,0 +1,152 @@
+---
+status: "proposed"
+date: 2026-03-12
+deciders: ["@jindyzhao"]
+consulted: []
+informed: []
+---
+
+# ADR-0045: Cluster-Resolved Root Volume Provisioning Intent
+
+> **Review Period**: Until 2026-03-14 (48-hour minimum)<br>
+> **Discussion**: [Issue #359](https://github.com/kv-shepherd/shepherd/issues/359)<br>
+> **Amends**: `ADR-0018-instance-size-abstraction.md#core-design-principles` *(clarifies lifecycle boundary for storage provisioning intent)*<br>
+> **Relates To**: `ADR-0011-ssa-apply-strategy.md`, `ADR-0017-vm-request-flow-clarification.md`, `ADR-0018-instance-size-abstraction.md`, `ADR-0042-cluster-policy-governance-model.md`
+
+---
+
+## Context and Problem Statement
+
+The platform now needs to expose root-volume provisioning controls derived from
+CDI and Kubernetes PVC semantics, especially `dv_access_modes` and
+`dv_volume_mode`. These settings are cluster-sensitive: the same
+`StorageClass` may expose one or more supported claim-property combinations via
+CDI `StorageProfile`, while catalog authors often do not know the eventual
+target cluster at authoring time.
+
+The question is: where may the platform keep ambiguous storage intent such as
+`auto`, and at what point must it be resolved into explicit runtime values?
+
+## Decision Drivers
+
+* Preserve `InstanceSize` portability across clusters with different storage capabilities
+* Prevent approval and runtime from operating on ambiguous storage intent
+* Keep SSA declarative and explicit by the time VM YAML is rendered
+* Avoid silent drift when cluster storage capabilities change after VM creation
+* Make ambiguous multi-option `StorageProfile` cases auditable and reviewable
+* Align root-volume provisioning behavior with target-cluster governance
+
+## Considered Options
+
+* **Option 1**: Keep `auto` through approval and runtime, re-resolving on every operation
+* **Option 2**: Allow `auto` only in catalog/spec intent; require approval-time resolution and persist explicit runtime values
+* **Option 3**: Forbid `auto` entirely and require catalog authors to always choose explicit storage settings
+
+## Decision Outcome
+
+**Chosen option**: "Option 2", because it preserves reusable catalog intent
+without allowing ambiguous values to leak into approval or runtime behavior.
+
+### Consequences
+
+* ✅ Good, because `InstanceSize` can stay portable when catalog authors do not yet know target-cluster storage capabilities
+* ✅ Good, because approval decisions and rendered VM YAML always operate on explicit `storageClass`, `dv_access_modes`, and `dv_volume_mode`
+* ✅ Good, because later CPU, memory, or disk changes can reuse the previously resolved storage values instead of silently re-resolving `auto`
+* ✅ Good, because ambiguous `StorageProfile` cases become reviewable approval choices instead of hidden backend guesses
+* 🟡 Neutral, because approval UX becomes more stateful: it may need to request additional storage choices when cluster capabilities are ambiguous
+* ❌ Bad, because implementation must persist a per-VM resolved storage profile in addition to catalog intent; mitigation: keep `auto` as authoring-time intent only and treat resolved values as runtime state
+
+### Confirmation
+
+This decision is correctly implemented when all of the following are true:
+
+1. `InstanceSize` may represent storage provisioning intent as either explicit values or `auto`
+2. Approval cannot complete while root-volume provisioning remains unresolved
+3. If the target cluster and storage class expose exactly one valid provisioning mode, approval may resolve it automatically
+4. If multiple valid provisioning modes remain, approval must require an explicit operator choice before completion
+5. The approved VM stores explicit resolved values; runtime records and rendered YAML do not contain `auto`
+6. Subsequent VM updates reuse persisted resolved values instead of re-running `auto` resolution
+7. Storage mode changes after creation are treated as explicit migration/reprovisioning decisions, not ordinary CPU/memory edits
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Keep `auto` through approval and runtime
+
+Treat `auto` as a durable runtime value and re-resolve it whenever approval,
+creation, or later updates occur.
+
+* ✅ Good, because catalog authors need not think about cluster-specific storage details
+* ❌ Bad, because approval outcomes become dependent on hidden backend re-resolution
+* ❌ Bad, because later cluster `StorageProfile` changes can silently alter behavior for existing VMs
+* ❌ Bad, because SSA input would be derived from ambiguous runtime intent rather than explicit desired state
+
+### Option 2: Resolve `auto` at approval and persist explicit runtime values
+
+Keep `auto` only as catalog/spec intent, then resolve it against the target
+cluster during approval and store the explicit result for runtime use.
+
+* ✅ Good, because approval is the first point where target-cluster capabilities are known
+* ✅ Good, because rendered VM YAML stays explicit and deterministic
+* ✅ Good, because later updates can remain stable even if cluster storage defaults drift
+* ❌ Bad, because approval must sometimes collect more information before it can proceed
+
+### Option 3: Forbid `auto` and require explicit catalog values only
+
+Force authors to always choose `storageClass`, `dv_access_modes`, and
+`dv_volume_mode` in the catalog itself.
+
+* ✅ Good, because there is no ambiguous value anywhere in the workflow
+* ❌ Bad, because catalog authors often do not know the eventual target cluster or storage class
+* ❌ Bad, because it reduces reuse of shared `InstanceSize` definitions across clusters
+
+---
+
+## More Information
+
+### Related Decisions
+
+* `ADR-0011-ssa-apply-strategy.md` - SSA remains the write mechanism for explicit desired state
+* `ADR-0017-vm-request-flow-clarification.md` - approval is the governance point where target placement is known
+* `ADR-0018-instance-size-abstraction.md` - `InstanceSize` remains the authoring layer for hardware/provisioning intent
+* `ADR-0042-cluster-policy-governance-model.md` - cluster selection and governance remain explicit post-capability controls
+
+### References
+
+* [CDI API Reference](https://kubevirt.io/cdi-api-reference/main/definitions.html)
+* [KubeVirt Runbook: CDIStorageProfilesIncomplete](https://kubevirt.io/monitoring/runbooks/CDIStorageProfilesIncomplete.html)
+* [KubeVirt Labs: DataVolume / StorageProfile behavior](https://kubevirt.io/labs/kubernetes/lab2.html)
+* Related Issue: [#359](https://github.com/kv-shepherd/shepherd/issues/359)
+
+### Implementation Notes
+
+While this ADR remains proposed:
+
+* Backend storage-profile reads should expose the full supported
+  claim-property combinations, not only a single default volume mode.
+* Approval should treat `auto` as an unresolved authoring value and reject
+  completion until it is mapped to explicit runtime values.
+* If the target cluster exposes multiple candidate storage classes or multiple
+  supported claim-property combinations, approval UX may need a follow-up
+  choice step.
+* Persisted VM/runtime state must store the resolved storage settings so later
+  CPU, memory, or disk changes reuse them without re-running `auto`.
+* Ordinary post-create edits must not implicitly change root-volume access mode
+  or volume mode; such changes require an explicit storage migration or
+  reprovisioning flow.
+
+Revisit this ADR if:
+
+* the platform introduces cluster-agnostic persistent storage capability abstractions
+* CDI upstream defines a stable deterministic precedence rule for multiple
+  `claimPropertySets` that the product chooses to adopt directly
+* the project adds a dedicated storage migration workflow for existing VMs
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-12 | @jindyzhao | Initial draft |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,10 +47,14 @@
 | [ADR-0035](./ADR-0035-auth-provider-plugin-boundary.md) | Auth Provider Plugin Boundary and Type Discovery | **Accepted** | - |
 | [ADR-0036](./ADR-0036-template-instancesize-boundary-enforcement.md) | Template / InstanceSize Boundary Enforcement | **Accepted** | - |
 | [ADR-0037](./ADR-0037-openapi-validation-architecture-and-enforcement-policy.md) | OpenAPI Validation Architecture and Enforcement Policy | **Accepted** | - |
+| [ADR-0038](./ADR-0038-adaptive-k8s-polling.md) | Adaptive K8s VM Status Polling with State-Machine-Driven Backoff | **Accepted** | - |
+| [ADR-0039](./ADR-0039-golangci-lint-custom-analyzer.md) | Architecture Enforcement via golangci-lint Custom Analyzer Plugin | **Accepted** | - |
 | [ADR-0040](./ADR-0040-catalog-scope-for-template-and-instancesize.md) | Catalog Scope for Template and InstanceSize | **Accepted** | - |
 | [ADR-0041](./ADR-0041-power-operation-approval-requirement-service.md) | Power Operation Approval Requirement Service | **Accepted** | - |
 | [ADR-0042](./ADR-0042-cluster-policy-governance-model.md) | Explicit Cluster Policy Governance Model | **Accepted** | - |
+| [ADR-0043](./ADR-0043-bootstrap-orchestration-quality-gate.md) | Clarify Bootstrap Composition-Root Quality Gate | **Proposed** | - |
 | [ADR-0044](./ADR-0044-frontend-built-in-preset-catalog-boundary.md) | Frontend Built-In Preset Catalog Boundary | **Proposed** | - |
+| [ADR-0045](./ADR-0045-cluster-resolved-root-volume-provisioning.md) | Cluster-Resolved Root Volume Provisioning Intent | **Proposed** | - |
 
 > ℹ️ **ADR-0037 Sync Notes**:
 >
@@ -119,6 +123,7 @@ For newcomers, we recommend reading ADRs in this order:
 16. **ADR-0041** (Power Approval Requirement, **Accepted**) → Environment-aware approval decision path for power and VNC operations
 17. **ADR-0042** (Cluster Policy Governance, **Accepted**) → Explicit post-capability governance controls for cluster selection and approval
 18. **ADR-0044** (Frontend Built-In Preset Catalog Boundary, **Proposed**) → Clarifies V1 built-in preset catalogs vs V2 backend marketplace boundary
+19. **ADR-0045** (Cluster-Resolved Root Volume Provisioning, **Proposed**) → Clarifies where storage `auto` intent may exist and when approval must resolve explicit root-volume provisioning values
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/docs/design/notes/ADR-0045-cluster-resolved-root-volume-provisioning.md
+++ b/docs/design/notes/ADR-0045-cluster-resolved-root-volume-provisioning.md
@@ -1,0 +1,57 @@
+# Design Note: ADR-0045 — Cluster-Resolved Root Volume Provisioning
+
+> **Status**: Proposed (ADR-0045 under review until 2026-03-14)  
+> **Related ADR**: [ADR-0045](../../adr/ADR-0045-cluster-resolved-root-volume-provisioning.md)  
+> **Owner**: @jindyzhao  
+> **Created**: 2026-03-12  
+> **Last Updated**: 2026-03-12
+
+## Summary
+
+ADR-0045 proposes a lifecycle boundary for root-volume provisioning settings.
+`InstanceSize` may keep portable storage intent such as `auto`, but approval and
+runtime must never operate on unresolved values. Before approval completes, the
+platform resolves storage intent against the target cluster's `StorageProfile`
+and persists explicit runtime values for the VM.
+
+## Scope
+
+- In scope: root-volume `storageClass`, `dv_access_modes`, and `dv_volume_mode`
+- In scope: approval-time resolution of catalog intent against target-cluster storage capabilities
+- In scope: persisting resolved runtime values for later VM updates
+- Out of scope: redesigning `Template` vs `InstanceSize` catalog boundaries
+- Out of scope: implementing a storage migration workflow for existing VMs
+
+## Pending Changes
+
+Until ADR-0045 is accepted, implementation should follow these constraints:
+
+1. `auto` is allowed only as authoring/catalog intent.
+2. Approval must reject completion if root-volume provisioning remains unresolved.
+3. If target-cluster storage capability resolution is unique, approval may resolve automatically.
+4. If multiple valid combinations remain, approval must require an explicit operator choice.
+5. Persist the resolved storage values with the approved VM/runtime state; do not mutate the shared `InstanceSize`.
+6. Later CPU/memory/disk updates must reuse persisted resolved values instead of re-running `auto`.
+
+## Affected Components
+
+- `internal/domain/provisioning.go`
+- `internal/provider/kubevirt.go`
+- `internal/governance/approval/`
+- `internal/api/handlers/server_approval*.go`
+- `api/openapi.yaml` and generated API types
+- `web/src/features/admin-approvals/`
+- `web/src/features/admin-instance-sizes/`
+
+## Rollout Notes
+
+- Extend backend storage-profile reads to surface complete supported claim-property combinations.
+- Treat approval as the only place where `auto` may be resolved.
+- Rendered VM YAML and persisted runtime records must always contain explicit storage values.
+- If existing VMs do not yet have persisted resolved values, any future rollout must define a safe fallback based on observed PVC/DataVolume state before allowing ordinary updates.
+
+## Revisit Conditions
+
+- ADR-0045 is accepted, rejected, or superseded
+- the project adds a first-class storage migration workflow
+- upstream CDI storage-profile semantics change materially

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -254,7 +254,8 @@
         "docs/adr/ADR-0012-hybrid-transaction.md",
         "docs/adr/ADR-0017-vm-request-flow-clarification.md",
         "docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md",
-        "docs/adr/ADR-0042-cluster-policy-governance-model.md"
+        "docs/adr/ADR-0042-cluster-policy-governance-model.md",
+        "docs/adr/ADR-0045-cluster-resolved-root-volume-provisioning.md"
       ],
       "examples": [
         "docs/design/examples/usecase/create_vm.go"


### PR DESCRIPTION
## Summary

Propose ADR-0045 to define the lifecycle boundary for root-volume provisioning intent:

- `auto` is allowed only at the catalog / authoring layer
- approval must resolve storage intent against the target cluster
- runtime state must persist explicit `storageClass`, `dv_access_modes`, and `dv_volume_mode`
- later VM updates must reuse resolved values instead of re-running `auto`

This PR also adds the paired design note, ADR index entry, and traceability mapping required by repository governance.

## Scope Boundary

This PR contains only the proposed ADR review package:

- proposed ADR document
- design note for proposed impacts
- ADR index update
- traceability update required by governance checks

It does **not** include normative design-doc changes or implementation code.
Those should follow in later PRs after ADR acceptance.

## Validation

- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_master_flow_traceability.go`

## Process Note

Per project workflow, a proposed ADR review package may be merged before acceptance when it contains only ADR-review documentation and required governance metadata. Acceptance and implementation should proceed in later PRs.

Refs #359

Signed-off-by: jindyzhao <jindyzhao0128@gmail.com>