### PR TITLE
chore(ci): consolidate CI gate script sources

### DIFF
--- a/docs/design/checklist/phase-3-checklist.md
+++ b/docs/design/checklist/phase-3-checklist.md
@@ -13,7 +13,7 @@
   - [x] All dependency assembly centralized in this file
   - [x] Layered construction: Infrastructure → Repository → Service → UseCase → Handler
 - [ ] **CI Check**:
-  - [ ] `scripts/ci/check_manual_di.sh` created
+  - [ ] `docs/design/ci/scripts/check_manual_di.sh` created
   - [ ] Forbidden to instantiate Service/Repository outside `internal/app/`
   - [ ] Forbidden to initialize dependencies in `init()` functions
 - [ ] **Standards**:

--- a/docs/design/ci/scripts/check_dead_tests.go
+++ b/docs/design/ci/scripts/check_dead_tests.go
@@ -1,6 +1,6 @@
 //go:build ignore
 
-// scripts/ci/check_dead_tests.go
+// docs/design/ci/scripts/check_dead_tests.go
 
 /*
 Dead test detection - CI warning (non-blocking)

--- a/docs/design/ci/scripts/check_ent_codegen.go
+++ b/docs/design/ci/scripts/check_ent_codegen.go
@@ -1,6 +1,6 @@
 //go:build ignore
 
-// scripts/ci/check_ent_codegen.go
+// docs/design/ci/scripts/check_ent_codegen.go
 
 /*
 Ent code generation synchronization check - CI enforced
@@ -11,7 +11,7 @@ Rules:
 3. Generated files must be committed.
 
 Usage:
-  go run scripts/ci/check_ent_codegen.go
+  go run docs/design/ci/scripts/check_ent_codegen.go
 
 Or in CI:
   cd ent && go generate . && git diff --exit-code

--- a/docs/design/ci/scripts/check_k8s_in_transaction.go
+++ b/docs/design/ci/scripts/check_k8s_in_transaction.go
@@ -1,6 +1,6 @@
 //go:build ignore
 
-// scripts/ci/check_k8s_in_transaction.go
+// docs/design/ci/scripts/check_k8s_in_transaction.go
 
 /*
 K8s-in-transaction check - code review assistant

--- a/docs/design/ci/scripts/check_manual_di.sh
+++ b/docs/design/ci/scripts/check_manual_di.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# scripts/ci/check_manual_di.sh
+# docs/design/ci/scripts/check_manual_di.sh
 # Strict Manual DI Policy Check
 #
 # Goal: keep dependency wiring centralized under internal/app/.
@@ -10,7 +10,7 @@
 # 3. Forbid Redis imports (Redis dependency removed)
 # 4. Forbid Wire imports (Wire dependency removed)
 #
-# Usage: ./check_manual_di.sh
+# Usage: bash docs/design/ci/scripts/check_manual_di.sh
 # Exit code: 0 = pass, 1 = violations
 
 set -e

--- a/docs/design/ci/scripts/check_no_redis_import.sh
+++ b/docs/design/ci/scripts/check_no_redis_import.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# scripts/ci/check_no_redis_import.go
+# docs/design/ci/scripts/check_no_redis_import.sh
 # Redis import prohibition check
 #
 # 2026-01-18 architecture simplification: Redis dependency removed.

--- a/docs/design/ci/scripts/check_repository_tests.go
+++ b/docs/design/ci/scripts/check_repository_tests.go
@@ -1,6 +1,6 @@
 //go:build ignore
 
-// scripts/ci/check_repository_tests.go
+// docs/design/ci/scripts/check_repository_tests.go
 
 /*
 Repository test coverage check - CI enforced

--- a/docs/design/ci/scripts/check_sqlc_usage.sh
+++ b/docs/design/ci/scripts/check_sqlc_usage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# check_sqlc_usage.sh - Enforce ADR-0012 sqlc usage restrictions
+# docs/design/ci/scripts/check_sqlc_usage.sh - Enforce ADR-0012 sqlc usage restrictions
 #
 # This script ensures sqlc is only used in whitelisted directories.
 # ADR-0012 specifies that sqlc should ONLY be used for core atomic transactions.
@@ -12,22 +12,14 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+SQLC_IMPORT='kv-shepherd.io/shepherd/internal/repository/sqlc'
 
-# Whitelisted directories where sqlc usage is allowed
+# Whitelisted directories where sqlc usage is allowed (ADR-0012).
 ALLOWED_DIRS=(
     "internal/repository/sqlc/"
     "internal/usecase/"
-    "docs/"           # Documentation examples are allowed
-    "test/"           # Test files are allowed
-    "*_test.go"       # Test files are allowed
 )
 
-# Check if the project root has sqlc-generated code
 PROJECT_ROOT="${1:-.}"
 
 echo "=========================================="
@@ -43,46 +35,45 @@ echo ""
 # Find all Go files that import sqlc package
 VIOLATIONS=()
 
-# Search for sqlc imports outside whitelisted directories
-while IFS= read -r -d '' file; do
-    # Check if file is in allowed directory
-    is_allowed=false
-    for allowed in "${ALLOWED_DIRS[@]}"; do
-        if [[ "$file" == *"$allowed"* ]] || [[ "$file" == *_test.go ]]; then
-            is_allowed=true
-            break
-        fi
-    done
-    
-    if [ "$is_allowed" = false ]; then
-        # Check if file imports sqlc
-        if grep -q "repository/sqlc" "$file" 2>/dev/null; then
-            VIOLATIONS+=("$file")
-        fi
-    fi
-done < <(find "$PROJECT_ROOT" -name "*.go" -type f -print0 2>/dev/null || true)
+# Find all .go files that import the sqlc package outside the allowlist.
+matches=$(grep -rl --include="*.go" "${SQLC_IMPORT}" "${PROJECT_ROOT}/internal" "${PROJECT_ROOT}/cmd" 2>/dev/null | grep -v "_test.go" || true)
 
 # Report results
+if [ -n "${matches}" ]; then
+    while IFS= read -r file; do
+        rel_path="${file#"${PROJECT_ROOT}/"}"
+
+        allowed=false
+        for allowed_dir in "${ALLOWED_DIRS[@]}"; do
+            if [[ "${rel_path}" == ${allowed_dir}* ]]; then
+                allowed=true
+                break
+            fi
+        done
+
+        if [ "${allowed}" = false ]; then
+            VIOLATIONS+=("${rel_path}")
+        fi
+    done <<< "${matches}"
+fi
+
 if [ ${#VIOLATIONS[@]} -gt 0 ]; then
-    echo -e "${RED}❌ VIOLATION: sqlc usage found outside whitelisted directories!${NC}"
+    echo "❌ VIOLATION: sqlc usage found outside whitelisted directories!"
     echo ""
     echo "The following files import sqlc but are NOT in allowed directories:"
     echo ""
     for violation in "${VIOLATIONS[@]}"; do
-        echo "  ✗ $violation"
+        echo "  ✗ ${violation}"
+        grep -n "${SQLC_IMPORT}" "${PROJECT_ROOT}/${violation}" --max-count=3 2>/dev/null | sed 's/^/    /'
+        echo ""
     done
-    echo ""
     echo "ADR-0012 restricts sqlc usage to:"
     echo "  - internal/repository/sqlc/ (query definitions)"
     echo "  - internal/usecase/ (atomic transaction orchestration)"
-    echo ""
-    echo "If you need sqlc in other locations, update ADR-0012 first."
     exit 1
-else
-    echo -e "${GREEN}✓ All sqlc usages are within allowed directories${NC}"
-    echo ""
-    echo "Checked: $(find "$PROJECT_ROOT" -name "*.go" -type f 2>/dev/null | wc -l) Go files"
 fi
+
+echo "✅ All sqlc usages are within allowed directories"
 
 echo ""
 echo "=========================================="

--- a/docs/design/ci/scripts/check_test_assertions.go
+++ b/docs/design/ci/scripts/check_test_assertions.go
@@ -1,6 +1,6 @@
 //go:build ignore
 
-// scripts/ci/check_test_assertions.go
+// docs/design/ci/scripts/check_test_assertions.go
 
 /*
 Test assertion check - CI enforced

--- a/docs/design/ci/scripts/check_validate_spec.go
+++ b/docs/design/ci/scripts/check_validate_spec.go
@@ -1,6 +1,6 @@
 //go:build ignore
 
-// scripts/ci/check_validate_spec.go
+// docs/design/ci/scripts/check_validate_spec.go
 
 /*
 ValidateSpec transaction check - CI enforced

--- a/docs/design/phases/03-service-layer.md
+++ b/docs/design/phases/03-service-layer.md
@@ -52,7 +52,7 @@ Integrate service layer with providers:
 | SystemHandler | `internal/api/handlers/system.go` | ✅ | - |
 | **InstanceSizeService** | `internal/service/instance_size_service.go` | ✅ | [ADR-0018](../../adr/ADR-0018-instance-size-abstraction.md) |
 | **InstanceSizeHandler** | `internal/api/handlers/instance_size.go` | ⬜ | Deferred |
-| CI check | `scripts/ci/check_manual_di.sh` | ⬜ | Deferred |
+| CI check | `docs/design/ci/scripts/check_manual_di.sh` | ⬜ | Deferred |
 
 ---
 
@@ -176,14 +176,15 @@ func Bootstrap(cfg *config.Config) (*App, error) {
 
 | Rule | Enforcement |
 |------|-------------|
-| Service layer must not manage transactions | `check_transaction_boundary.go` |
-| K8s calls forbidden inside transactions | `check_k8s_in_transaction.go` |
+| Service layer must not manage transactions | `shepherd-arch` (tx boundary analyzer) |
+| K8s calls forbidden inside transactions | `shepherd-arch/k8sintransaction` |
 | Transaction boundaries at UseCase layer | - |
 
 > ⚠️ **Developer Guidance**: Run these checks locally before committing:
 > ```bash
-> go run scripts/ci/check_transaction_boundary.go ./...
-> go run scripts/ci/check_k8s_in_transaction.go ./...
+> make lint
+> # Optional: run the standalone script when iterating on transaction-safe K8s boundaries
+> go run docs/design/ci/scripts/check_k8s_in_transaction.go ./...
 > ```
 >
 > **Anti-Pattern (ADR-0012)**: K8s API calls inside DB transactions cause:

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -158,6 +158,8 @@
         "docs/design/checklist/phase-4-checklist.md"
       ],
       "adrs": [
+        "docs/adr/ADR-0012-hybrid-transaction.md",
+        "docs/adr/ADR-0013-manual-di.md",
         "docs/adr/ADR-0017-vm-request-flow-clarification.md"
       ]
     },


### PR DESCRIPTION
## Summary

Consolidates CI gate scripts so `docs/design/ci/scripts/` remains the single source of truth.

- Updates docs that referenced `scripts/ci/*` to use canonical `docs/design/ci/scripts/*`
- Tightens `check_sqlc_usage.sh` to look for the canonical sqlc import path
- Normalizes script header comments to the canonical path
- Updates traceability manifest as required by design-doc governance

## Discussion

Refs #365
