### PR TITLE
chore(dev): support host frontend dev mode

### DIFF
--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -45,10 +45,13 @@ services:
 
   nginx:
     image: nginx:1.27-alpine
+    environment:
+      WEB_UPSTREAM: "${WEB_UPSTREAM:-host.docker.internal:3001}"
     ports:
       - "3000:80"
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/default.conf.template:/etc/nginx/templates/default.conf.template:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
-      - web
       - server

--- a/deploy/dev/nginx/default.conf.template
+++ b/deploy/dev/nginx/default.conf.template
@@ -22,9 +22,9 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # All UI routes are served by Next.js dev server.
+    # All UI routes are served by the Next.js dev server.
     location / {
-        proxy_pass http://web:3000;
+        proxy_pass http://${WEB_UPSTREAM};
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header Upgrade $http_upgrade;

--- a/deploy/dev/start-dev.sh
+++ b/deploy/dev/start-dev.sh
@@ -12,6 +12,25 @@ LOCK_HASH_FILE="${NODE_MODULES_DIR}/.package-lock.hash"
 SERVICES_TO_DELETE=("db" "server" "web" "nginx")
 COMPOSE_CMD=(docker compose -f "${COMPOSE_FILE}")
 DEV_INCLUDE_E2E_SEED="${DEV_INCLUDE_E2E_SEED:-1}"
+DEV_FRONTEND_MODE="${DEV_FRONTEND_MODE:-host}"
+DEV_FRONTEND_PORT="${DEV_FRONTEND_PORT:-3001}"
+DEV_INGRESS_PORT="${DEV_INGRESS_PORT:-3000}"
+FRONTEND_PID_FILE="${ROOT_DIR}/tmp/dev-web.pid"
+FRONTEND_LOG_FILE="${ROOT_DIR}/tmp/dev-web.log"
+KEEP_DB=0
+
+usage() {
+    cat <<'EOF'
+Usage: ./start-dev.sh [--keep-db] [--frontend-docker]
+
+Options:
+  --keep-db          Preserve the existing dev PostgreSQL container/data and only
+                     recreate app services.
+  --frontend-docker  Run the frontend inside Docker instead of the default host
+                     Next.js dev server. This is slower but useful as a fallback.
+  -h, --help         Show this help message.
+EOF
+}
 
 require_cmd() {
     local cmd="$1"
@@ -30,8 +49,97 @@ compute_sha256() {
     fi
 }
 
+base64_file() {
+    local file="$1"
+    if base64 -w0 "$file" >/dev/null 2>&1; then
+        base64 -w0 "$file"
+    else
+        base64 <"$file" | tr -d '\n'
+    fi
+}
+
 json_string() {
     node -p 'JSON.stringify(process.argv[1])' "$1"
+}
+
+compute_allowed_dev_origins() {
+    node -e '
+        const os = require("os");
+        const origins = new Set(["localhost", "127.0.0.1"]);
+        const hostname = os.hostname();
+        if (hostname) {
+            origins.add(hostname);
+        }
+        for (const infos of Object.values(os.networkInterfaces())) {
+            for (const info of infos || []) {
+                if (info && info.family === "IPv4" && !info.internal) {
+                    origins.add(info.address);
+                }
+            }
+        }
+        process.stdout.write(Array.from(origins).join(","));
+    '
+}
+
+stop_host_frontend() {
+    if [[ ! -f "${FRONTEND_PID_FILE}" ]]; then
+        return 0
+    fi
+
+    local pid=""
+    pid="$(cat "${FRONTEND_PID_FILE}" 2>/dev/null || true)"
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1; then
+        echo "Stopping existing host frontend (pid ${pid})..."
+        kill "${pid}" >/dev/null 2>&1 || true
+        for _ in {1..20}; do
+            if ! kill -0 "${pid}" >/dev/null 2>&1; then
+                break
+            fi
+            sleep 1
+        done
+    fi
+    rm -f "${FRONTEND_PID_FILE}"
+}
+
+start_host_frontend() {
+    local allowed_origins=""
+    allowed_origins="$(compute_allowed_dev_origins)"
+    mkdir -p "$(dirname "${FRONTEND_PID_FILE}")"
+    stop_host_frontend
+
+    echo "Starting frontend on host (Next.js dev server on :${DEV_FRONTEND_PORT})..."
+    (
+        cd "${ROOT_DIR}/web"
+        DEV_ALLOWED_ORIGINS="${allowed_origins}" \
+        NEXT_PUBLIC_API_URL="/api/v1" \
+        INTERNAL_API_URL="http://localhost:8080" \
+        setsid ./node_modules/.bin/next dev --hostname 0.0.0.0 --port "${DEV_FRONTEND_PORT}" >"${FRONTEND_LOG_FILE}" 2>&1 < /dev/null &
+        echo $! > "${FRONTEND_PID_FILE}"
+    )
+}
+
+wait_for_host_frontend() {
+    local pid=""
+    pid="$(cat "${FRONTEND_PID_FILE}" 2>/dev/null || true)"
+
+    echo "Waiting for frontend (http://127.0.0.1:${DEV_FRONTEND_PORT})..."
+    for _ in {1..45}; do
+        if curl -fsS "http://127.0.0.1:${DEV_FRONTEND_PORT}/" >/dev/null; then
+            echo " frontend ready"
+            return 0
+        fi
+        if [[ -n "${pid}" ]] && ! kill -0 "${pid}" >/dev/null 2>&1; then
+            echo " frontend exited unexpectedly"
+            tail -n 200 "${FRONTEND_LOG_FILE}" || true
+            return 1
+        fi
+        printf "."
+        sleep 2
+    done
+
+    echo " frontend did not become ready in time"
+    tail -n 200 "${FRONTEND_LOG_FILE}" || true
+    return 1
 }
 
 login_token() {
@@ -94,26 +202,69 @@ require_cmd npm
 require_cmd node
 require_cmd curl
 
-if ! [[ "$HOST_USER_ID" =~ ^[0-9]+$ ]] || ! [[ "$HOST_GROUP_ID" =~ ^[0-9]+$ ]]; then
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-db)
+            KEEP_DB=1
+            shift
+            ;;
+        --frontend-docker)
+            DEV_FRONTEND_MODE="docker"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            echo ""
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if ! [[ "${HOST_USER_ID}" =~ ^[0-9]+$ ]] || ! [[ "${HOST_GROUP_ID}" =~ ^[0-9]+$ ]]; then
     echo "USER_ID/GROUP_ID must be numeric. USER_ID=${HOST_USER_ID}, GROUP_ID=${HOST_GROUP_ID}"
     exit 1
 fi
 
+if [[ "${DEV_FRONTEND_MODE}" != "host" && "${DEV_FRONTEND_MODE}" != "docker" ]]; then
+    echo "DEV_FRONTEND_MODE must be 'host' or 'docker'. Current value: ${DEV_FRONTEND_MODE}"
+    exit 1
+fi
+
+WEB_UPSTREAM="host.docker.internal:${DEV_FRONTEND_PORT}"
+COMPOSE_SERVICES=("db" "server" "nginx")
+if [[ "${DEV_FRONTEND_MODE}" == "docker" ]]; then
+    WEB_UPSTREAM="web:3000"
+    COMPOSE_SERVICES=("db" "server" "web" "nginx")
+fi
+
 echo "Checking development environment status..."
-echo "Resetting development environment (clear DB data every run)..."
-
-for svc in "${SERVICES_TO_DELETE[@]}"; do
-    echo "  Removing service: $svc"
-    "${COMPOSE_CMD[@]}" rm -s -f -v "$svc" || true
-done
-
-"${COMPOSE_CMD[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+stop_host_frontend
+if [[ "${KEEP_DB}" == "1" ]]; then
+    echo "Resetting development environment (preserve DB container/data)..."
+    for svc in server web nginx; do
+        echo "  Removing service: $svc"
+        "${COMPOSE_CMD[@]}" rm -s -f -v "$svc" || true
+    done
+    echo "  Preserving service: db"
+else
+    echo "Resetting development environment (clear DB data every run)..."
+    for svc in "${SERVICES_TO_DELETE[@]}"; do
+        echo "  Removing service: $svc"
+        "${COMPOSE_CMD[@]}" rm -s -f -v "$svc" || true
+    done
+    "${COMPOSE_CMD[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+fi
 echo "Cleanup complete."
 
 echo "Building backend binaries on host (reuse local Go cache)..."
 mkdir -p "${ROOT_DIR}/build/bin"
 (
-    cd "$ROOT_DIR"
+    cd "${ROOT_DIR}"
     GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/shepherd ./cmd/server/...
     GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/seed ./cmd/seed/...
     GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w" -o build/bin/e2e-seed ./cmd/e2e-seed/...
@@ -125,23 +276,28 @@ DOCKER_BUILDKIT=1 docker build --network=host \
     -t shepherd-server -f "${ROOT_DIR}/Dockerfile" "${ROOT_DIR}"
 
 current_lock_hash="$(compute_sha256 "${ROOT_DIR}/web/package-lock.json")"
-if [ ! -d "$NODE_MODULES_DIR" ] || [ ! -f "$LOCK_HASH_FILE" ] || [ "$(cat "$LOCK_HASH_FILE" 2>/dev/null || true)" != "$current_lock_hash" ]; then
+if [ ! -d "${NODE_MODULES_DIR}" ] || [ ! -f "${LOCK_HASH_FILE}" ] || [ "$(cat "${LOCK_HASH_FILE}" 2>/dev/null || true)" != "${current_lock_hash}" ]; then
     echo "Installing frontend dependencies into ${NODE_MODULES_DIR}..."
     (cd "${ROOT_DIR}/web" && npm ci)
-    mkdir -p "$NODE_MODULES_DIR"
-    printf "%s" "$current_lock_hash" > "$LOCK_HASH_FILE"
+    mkdir -p "${NODE_MODULES_DIR}"
+    printf "%s" "${current_lock_hash}" > "${LOCK_HASH_FILE}"
 else
     echo "Reusing frontend dependencies from ${NODE_MODULES_DIR}..."
 fi
 
-echo "Packaging frontend image (shepherd-web)..."
-DOCKER_BUILDKIT=1 docker build --network=host \
-    --build-arg "USER_ID=${HOST_USER_ID}" \
-    --build-arg "GROUP_ID=${HOST_GROUP_ID}" \
-    -t shepherd-web -f "${ROOT_DIR}/deploy/dev/web.Dockerfile" "${ROOT_DIR}/web"
+if [[ "${DEV_FRONTEND_MODE}" == "docker" ]]; then
+    echo "Packaging frontend image (shepherd-web)..."
+    DOCKER_BUILDKIT=1 docker build --network=host \
+        --build-arg "USER_ID=${HOST_USER_ID}" \
+        --build-arg "GROUP_ID=${HOST_GROUP_ID}" \
+        -t shepherd-web -f "${ROOT_DIR}/deploy/dev/web.Dockerfile" "${ROOT_DIR}/web"
+fi
 
-echo "Starting development environment (db -> server -> web -> nginx)..."
-USER_ID="$HOST_USER_ID" GROUP_ID="$HOST_GROUP_ID" "${COMPOSE_CMD[@]}" up -d
+echo "Starting development environment (${COMPOSE_SERVICES[*]})..."
+USER_ID="${HOST_USER_ID}" \
+GROUP_ID="${HOST_GROUP_ID}" \
+WEB_UPSTREAM="${WEB_UPSTREAM}" \
+"${COMPOSE_CMD[@]}" up -d "${COMPOSE_SERVICES[@]}"
 
 echo "Waiting for database..."
 until "${COMPOSE_CMD[@]}" exec -T db pg_isready -U shepherd -d shepherd_db >/dev/null 2>&1; do
@@ -161,7 +317,7 @@ for _ in {1..30}; do
     printf "."
     sleep 2
 done
-if [ "$backend_ready" != "true" ]; then
+if [[ "${backend_ready}" != "true" ]]; then
     echo " backend did not become ready in time"
     "${COMPOSE_CMD[@]}" logs --tail=200 server || true
     exit 1
@@ -171,15 +327,28 @@ echo "Seeding development data..."
 "${COMPOSE_CMD[@]}" exec -T server /usr/local/bin/seed >/dev/null
 rotate_default_admin_password "${DEV_ADMIN_PASSWORD}"
 if [[ "${DEV_INCLUDE_E2E_SEED}" == "1" ]]; then
-    "${COMPOSE_CMD[@]}" exec -T server /usr/local/bin/e2e-seed >/dev/null
+    E2E_SEED_ENV=()
+    DEV_KUBECONFIG_FILE="${ROOT_DIR}/k8s-admin.yaml"
+    if [[ -f "${DEV_KUBECONFIG_FILE}" ]]; then
+        echo " importing live dev cluster from ${DEV_KUBECONFIG_FILE}"
+        E2E_SEED_ENV=(-e "E2E_KUBECONFIG_B64=$(base64_file "${DEV_KUBECONFIG_FILE}")")
+    else
+        echo " no local k8s-admin.yaml found; e2e seed will register an unreachable stub cluster"
+    fi
+    "${COMPOSE_CMD[@]}" exec -T "${E2E_SEED_ENV[@]}" server /usr/local/bin/e2e-seed >/dev/null
     echo " seed complete (baseline + extended fixtures)"
 else
     echo " seed complete (baseline only; set DEV_INCLUDE_E2E_SEED=1 to include extended fixtures)"
 fi
 
-echo "Waiting for ingress (http://localhost:3000)..."
+if [[ "${DEV_FRONTEND_MODE}" == "host" ]]; then
+    start_host_frontend
+    wait_for_host_frontend
+fi
+
+echo "Waiting for ingress (http://localhost:${DEV_INGRESS_PORT})..."
 for _ in {1..30}; do
-    if curl -fsS http://localhost:3000/ >/dev/null; then
+    if curl -fsS "http://localhost:${DEV_INGRESS_PORT}/" >/dev/null; then
         echo " ingress ready"
         break
     fi
@@ -189,15 +358,25 @@ done
 
 echo "Prewarming common routes..."
 for route in / /login /dashboard; do
-    curl -fsS "http://localhost:3000${route}" >/dev/null || true
+    curl -fsS "http://localhost:${DEV_INGRESS_PORT}${route}" >/dev/null || true
 done
 echo " warmup complete"
 
 echo ""
 echo "Development environment is UP"
-echo "  - Web (nginx ingress): http://localhost:3000"
+echo "  - Web (nginx ingress): http://localhost:${DEV_INGRESS_PORT}"
 echo "  - Backend direct:      http://localhost:8080"
 echo "  - DB:                  localhost:5432"
+echo "  - Frontend mode:       ${DEV_FRONTEND_MODE}"
+if [[ "${DEV_FRONTEND_MODE}" == "host" ]]; then
+    echo "  - Frontend direct:     http://localhost:${DEV_FRONTEND_PORT}"
+    echo "  - Frontend log:        ${FRONTEND_LOG_FILE}"
+fi
+if [[ "${KEEP_DB}" == "1" ]]; then
+    echo "  - DB reset mode:       preserved (--keep-db)"
+else
+    echo "  - DB reset mode:       rebuilt (default)"
+fi
 echo "  - Seeded users:        admin/${DEV_ADMIN_PASSWORD} (rotated from bootstrap admin/admin)"
 if [[ "${DEV_INCLUDE_E2E_SEED}" == "1" ]]; then
     echo "                         e2e-admin/e2e-admin-123"

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from "next";
 
+const allowedDevOrigins = (process.env.DEV_ALLOWED_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
+  allowedDevOrigins,
+
   // Transpile antd and pro-components for proper SSR/CSR handling
   transpilePackages: ["antd", "@ant-design/pro-components"],
 


### PR DESCRIPTION
## Summary

Improves local dev bootstrap by allowing the Next.js dev server to run on the host (default) while nginx proxies UI traffic via a template-driven upstream.

Key points:
- `deploy/dev/start-dev.sh`: add `--keep-db` and `--frontend-docker`; default host frontend on `:${DEV_FRONTEND_PORT:-3001}`
- `deploy/dev/docker-compose.yml` + nginx template: proxy UI to `${WEB_UPSTREAM}`
- `web/next.config.ts`: set `allowedDevOrigins` from `DEV_ALLOWED_ORIGINS`

## Discussion

Issue: N/A (dev workflow improvement)
