### PR TITLE
docs(flow): sync accepted ADR governance docs

### DIFF
--- a/docs/design/checklist/phase-4-checklist.md
+++ b/docs/design/checklist/phase-4-checklist.md
@@ -202,7 +202,7 @@
 - [ ] **Template Scope** (after ADR-0018):
   - [ ] OS image source (DataVolume, ContainerDisk, PVC reference)
   - [ ] Cloud-init YAML (SSH keys, one-time password, network config)
-  - [ ] Field visibility (`quick_fields`, `advanced_fields` for UI)
+  - [ ] Field visibility (`quick_fields`, `advanced_fields`, `professional_fields` for UI)
   - [ ] ❌ No Go Template variables (removed per ADR-0018)
   - [ ] ❌ No RequiredFeatures/Hardware (moved to InstanceSize per ADR-0018)
 - [ ] **Template Lifecycle Management** complete (draft → active → deprecated → archived)

--- a/docs/design/interaction-flows/master-flow.md
+++ b/docs/design/interaction-flows/master-flow.md
@@ -158,6 +158,9 @@ Define bootstrapping behavior for schema-driven platform setup and secure first 
 │  │          display_name: "GPU Devices"                                                     │ │
 │  │        - path: "spec.template.spec.domain.memory.hugepages.pageSize"                     │ │
 │  │          display_name: "Hugepages Size"                                                  │ │
+│  │      professional_fields:                                                                │ │
+│  │        - path: "spec.template.spec.domain.features.hyperv.relaxed.enabled"               │ │
+│  │          display_name: "Hyper-V Relaxed"                                                 │ │
 │  │                                                                                          │ │
 │  │    👉 Mask references Schema paths only; field types and options come from Schema       │ │
 │  │                                                                                          │ │
@@ -952,7 +955,7 @@ external systems are integrated as provider plugins without changing approval st
 │  │  - `cdi_image_import` persistent root disk imported by CDI                               │
 │  │  - `cdi_pvc_clone` persistent root disk cloned from source PVC via CDI                   │
 │  │  - cloud-init config (admin customizable)                                                │
-│  │  - field visibility control (quick_fields / advanced_fields)                             │
+│  │  - field visibility control (quick_fields / advanced_fields / professional_fields)       │
 │  │                                                                                          │
 │  │  💡 Hardware capability requirements (GPU/SR-IOV/Hugepages) moved to InstanceSize         │
 │  │  💡 Direct existing-PVC boot is not a supported product mode                              │

--- a/docs/design/phases/04-governance.md
+++ b/docs/design/phases/04-governance.md
@@ -417,7 +417,7 @@ func GetEffectiveSpec(ticket *ApprovalTicket) (*VMSpec, error) {
 |----------|-------------|
 | OS image source | DataVolume, ContainerDisk, PVC reference |
 | Cloud-init YAML | SSH keys, one-time password, network config |
-| Field visibility | `quick_fields`, `advanced_fields` for UI |
+| Field visibility | `quick_fields`, `advanced_fields`, `professional_fields` for UI |
 | ❌ ~~Go Template variables~~ | **REMOVED** - Too complex, error-prone |
 | ❌ ~~RequiredFeatures/Hardware~~ | **MOVED** to InstanceSize per ADR-0018 |
 

--- a/docs/design/traceability/master-flow.json
+++ b/docs/design/traceability/master-flow.json
@@ -256,6 +256,7 @@
         "docs/adr/ADR-0006-unified-async-model.md",
         "docs/adr/ADR-0012-hybrid-transaction.md",
         "docs/adr/ADR-0017-vm-request-flow-clarification.md",
+        "docs/adr/ADR-0018-instance-size-abstraction.md",
         "docs/adr/ADR-0040-catalog-scope-for-template-and-instancesize.md",
         "docs/adr/ADR-0042-cluster-policy-governance-model.md",
         "docs/adr/ADR-0045-cluster-resolved-root-volume-provisioning.md"

--- a/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
+++ b/docs/i18n/zh-CN/design/interaction-flows/master-flow.md
@@ -157,6 +157,9 @@
 │  │          display_name: "GPU 设备"                                                        │ │
 │  │        - path: "spec.template.spec.domain.memory.hugepages.pageSize"                     │ │
 │  │          display_name: "Hugepages 大小"                                                  │ │
+│  │      professional_fields:                                                                │ │
+│  │        - path: "spec.template.spec.domain.features.hyperv.relaxed.enabled"               │ │
+│  │          display_name: "Hyper-V Relaxed"                                                 │ │
 │  │                                                                                          │ │
 │  │    👉 Mask 只引用 Schema 路径，字段类型和选项由 Schema 定义                               │ │
 │  │                                                                                          │ │
@@ -947,7 +950,7 @@ Schema 缓存生命周期与降级行为，请以以下文档为准：
 │  │  - `cdi_image_import` 通过 CDI 导入的持久化根盘                                            │ │
 │  │  - `cdi_pvc_clone` 通过 CDI 从源 PVC 克隆的持久化根盘                                      │ │
 │  │  - cloud-init 配置 (管理员可自定义)                                                        │ │
-│  │  - 字段可见性控制 (quick_fields / advanced_fields)                                        │ │
+│  │  - 字段可见性控制 (quick_fields / advanced_fields / professional_fields)                  │ │
 │  │                                                                                          │ │
 │  │  💡 注意: 硬件能力要求 (GPU/SR-IOV/Hugepages) 已移至 InstanceSize 配置                     │ │
 │  │  💡 直接从已有 PVC 启动 VM 不是受支持的产品模式                                             │ │


### PR DESCRIPTION
## Summary
- sync phase-4 checklist wording after ADR-0044/0045/0046 acceptance
- update master-flow examples and field-visibility wording for `professional_fields`
- refresh zh-CN master-flow wording and traceability references

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

Refs #373