### PR TITLE
docs(adr): append ADR-0046 amendments to ADR-0015 and ADR-0018

### DIFF
--- a/docs/adr/ADR-0015-governance-model-v2.md
+++ b/docs/adr/ADR-0015-governance-model-v2.md
@@ -2384,3 +2384,14 @@ DELETE /api/v1/systems/{id}?confirm_name=shop
 > - Core auth-provider runtime remains plugin-standard and provider-agnostic.
 > - Frontend provider type options must come from discovery API, not hardcoded OIDC/LDAP arrays.
 > - CI must keep enforcing this boundary using dedicated plugin-boundary checks.
+
+### ADR-0046: Schema Mask Field Visibility Tiers (2026-03-13)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §5 Template Layered Design (`quick_fields`, `advanced_fields`) | **AMENDED** | Field visibility now has three UI-only tiers: `quick_fields`, `advanced_fields`, and optional `professional_fields` for rare/expert-only paths. | [ADR-0046](./ADR-0046-schema-mask-field-visibility-tiers.md) |
+
+> **Implementation Guidance**:
+> - `professional_fields` is a presentation tier only; it must not change authorization, validation, approval, or runtime behavior.
+> - Admin UI must keep `professional_fields` hidden by default and require explicit opt-in before exposing expert-only paths.
+> - `mask.quick_fields` remains the required array in schema responses; `advanced_fields` and `professional_fields` stay optional mask lists.

--- a/docs/adr/ADR-0018-instance-size-abstraction.md
+++ b/docs/adr/ADR-0018-instance-size-abstraction.md
@@ -2331,6 +2331,17 @@ RUNNING/STOPPED → DELETING → DELETED (terminal)
 > - Schema acquisition: Graceful degradation (ADR-0023)
 > - Validation result: Strict pass/fail, no silent degradation (ADR-0018)
 
+### ADR-0046: Schema Mask Field Visibility Tiers (2026-03-13)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §5 Template Layered Design / Template field visibility control | **AMENDED** | `SchemaMask` formally adds optional `professional_fields` as a third UI-only visibility tier alongside `quick_fields` and `advanced_fields`. | [ADR-0046](./ADR-0046-schema-mask-field-visibility-tiers.md) |
+
+> **Implementation Guidance**:
+> - Treat `professional_fields` mask paths with the same validation and audit coverage as `quick_fields` and `advanced_fields`.
+> - `professional_fields` remains opt-in UI exposure only; it must not introduce separate authorization, scheduling, or provisioning semantics.
+> - `mask.quick_fields` stays required in API responses even when empty.
+
 ---
 
 _End of ADR-0018_


### PR DESCRIPTION
## Summary

Append ADR-0046 follow-up amendment sections to the accepted ADRs that it changes, without rewriting their original decision text.

## Changes

- ADR-0015: add an append-only amendment for the third schema-mask visibility tier (`professional_fields`)
- ADR-0018: add an append-only amendment clarifying `professional_fields` as a UI-only tier with the same validation/audit coverage as other mask paths

## Validation

- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`
- `go run docs/design/ci/scripts/check_markdown_links.go`
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`

## Related Issues

- Refs: #363