### PR TITLE
feat(web): extract preset catalog groundwork for ADR-0044

### DIFF
--- a/web/src/features/admin-instance-sizes/instanceSizePresets.test.ts
+++ b/web/src/features/admin-instance-sizes/instanceSizePresets.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildInstanceSizePresetValues } from './instanceSizePresets';
+
+describe('instanceSizePresets', () => {
+    it('builds the linux test preset with linked overcommit values', () => {
+        const preset = buildInstanceSizePresetValues('linux-test');
+        const spec = JSON.parse(preset.spec_text) as {
+            spec?: {
+                template?: {
+                    spec?: {
+                        nodeSelector?: Record<string, string>;
+                    };
+                };
+            };
+        };
+
+        expect(preset).toMatchObject({
+            catalog_scope: 'test',
+            cpu_cores: 4,
+            memory_gi: 8,
+            disk_gb: 60,
+            cpu_overcommit_enabled: true,
+            cpu_request: 2,
+            memory_overcommit_enabled: true,
+            memory_request_gi: 4,
+            dedicated_cpu: false,
+            enabled: true,
+        });
+        expect(
+            spec.spec?.template?.spec?.nodeSelector,
+        ).toMatchObject({
+            'kubevirt.io/ksm-enabled': 'true',
+        });
+    });
+
+    it('builds the windows prod preset with dedicated cpu and hugepages spec', () => {
+        const preset = buildInstanceSizePresetValues('windows-prod');
+        const spec = JSON.parse(preset.spec_text) as {
+            spec?: {
+                template?: {
+                    spec?: {
+                        domain?: {
+                            cpu?: Record<string, unknown>;
+                            memory?: Record<string, unknown>;
+                            features?: {
+                                hyperv?: {
+                                    vendorid?: Record<string, unknown>;
+                                    spinlocks?: Record<string, unknown>;
+                                };
+                            };
+                            clock?: Record<string, unknown>;
+                        };
+                    };
+                };
+            };
+        };
+
+        expect(preset.catalog_scope).toBe('prod');
+        expect(preset.dedicated_cpu).toBe(true);
+        expect(preset.cpu_overcommit_enabled).toBe(false);
+        expect(
+            spec.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement,
+        ).toBe(true);
+        expect(
+            spec.spec?.template?.spec?.domain?.memory,
+        ).toMatchObject({
+            hugepages: {
+                pageSize: '2Mi',
+            },
+        });
+        expect(
+            spec.spec?.template?.spec?.domain?.features?.hyperv?.vendorid,
+        ).toMatchObject({
+            enabled: true,
+            vendorid: 'KubeVirt',
+        });
+        expect(
+            spec.spec?.template?.spec?.domain?.features?.hyperv?.spinlocks,
+        ).toMatchObject({
+            enabled: true,
+            spinlocks: 8191,
+        });
+        expect(
+            spec.spec?.template?.spec?.domain?.clock,
+        ).toMatchObject({
+            utc: {},
+            timer: {
+                hpet: { present: false },
+                pit: { tickPolicy: 'delay' },
+                rtc: { tickPolicy: 'delay' },
+                hyperv: {},
+            },
+        });
+    });
+});

--- a/web/src/features/admin-instance-sizes/instanceSizePresets.ts
+++ b/web/src/features/admin-instance-sizes/instanceSizePresets.ts
@@ -1,0 +1,25 @@
+import {
+    CURATED_INSTANCE_SIZE_PRESET_ITEMS,
+    type CuratedInstanceSizePresetFormValues,
+    type CuratedInstanceSizePresetKey,
+} from '@/presets/catalog';
+
+export type InstanceSizePresetKey = CuratedInstanceSizePresetKey;
+
+export type InstanceSizePresetFormValues = CuratedInstanceSizePresetFormValues;
+
+const instanceSizePresetItemByKey = Object.fromEntries(
+    CURATED_INSTANCE_SIZE_PRESET_ITEMS.map((item) => [item.key, item]),
+) as Record<InstanceSizePresetKey, (typeof CURATED_INSTANCE_SIZE_PRESET_ITEMS)[number]>;
+
+export const INSTANCE_SIZE_PRESET_ORDER: InstanceSizePresetKey[] = CURATED_INSTANCE_SIZE_PRESET_ITEMS.map(
+    (item) => item.key as InstanceSizePresetKey,
+);
+
+export function buildInstanceSizePresetValues(key: InstanceSizePresetKey): InstanceSizePresetFormValues {
+    return { ...instanceSizePresetItemByKey[key].values };
+}
+
+export function getInstanceSizePresetLabelKey(key: InstanceSizePresetKey): string {
+    return instanceSizePresetItemByKey[key].labelKey;
+}

--- a/web/src/features/admin-templates/templatePresets.test.ts
+++ b/web/src/features/admin-templates/templatePresets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildTemplatePresetValues,
+    getTemplateCloudInitExample,
+    getTemplateImageURLSuggestions,
+    getTemplateOSVersionSuggestions,
+    getTemplatePresetGroups,
+    getTemplatePVCNameSuggestions,
+    getTemplatePVCNamespaceSuggestions,
+} from './templatePresets';
+
+describe('templatePresets', () => {
+    it('builds the linux prod preset from the kubevirt template defaults', () => {
+        expect(buildTemplatePresetValues('linux-prod')).toMatchObject({
+            os_family: 'linux',
+            os_version: 'Kylin V10',
+            catalog_scope: 'prod',
+            source_type: 'cdi_pvc_clone',
+            pvc_namespace: 'vm-muban',
+            pvc_name: 'kylinv10-image',
+            enabled: true,
+        });
+    });
+
+    it('provides os-aware suggestions instead of empty inputs only', () => {
+        expect(getTemplateOSVersionSuggestions('linux')).toContain('openEuler 22.03');
+        expect(getTemplateOSVersionSuggestions('linux')).toContain('Fedora');
+        expect(getTemplateOSVersionSuggestions('windows')).toContain('Windows Server 2022');
+        expect(getTemplatePVCNameSuggestions('windows')).toContain('win2022-image');
+        expect(getTemplatePVCNamespaceSuggestions()).toContain('vm-muban');
+        expect(getTemplateImageURLSuggestions('linux')).not.toHaveLength(0);
+    });
+
+    it('returns cloud-init examples for both linux and windows', () => {
+        expect(getTemplateCloudInitExample('linux')).toContain('#cloud-config');
+        expect(getTemplateCloudInitExample('windows')).toContain('#ps1_sysnative');
+    });
+
+    it('exposes curated and official preset groups for catalog-style picking', () => {
+        const groups = getTemplatePresetGroups();
+        expect(groups.map((group) => group.sourceType)).toEqual(['official', 'curated']);
+        expect(groups[0]?.items.some((item) => item.key === 'official-fedora-eval')).toBe(true);
+    });
+
+    it('uses CDI image import for official starter presets', () => {
+        expect(buildTemplatePresetValues('official-fedora-eval')).toMatchObject({
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/fedora:latest',
+        });
+        expect(buildTemplatePresetValues('official-ubuntu-eval')).toMatchObject({
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/ubuntu:latest',
+        });
+    });
+});

--- a/web/src/features/admin-templates/templatePresets.ts
+++ b/web/src/features/admin-templates/templatePresets.ts
@@ -1,0 +1,99 @@
+import {
+    CURATED_TEMPLATE_PRESET_ITEMS,
+    curatedLinuxCloudInitExample,
+    curatedWindowsCloudInitExample,
+    OFFICIAL_TEMPLATE_PRESET_ITEMS,
+    type CuratedTemplatePresetKey,
+    type OfficialTemplatePresetKey,
+    type TemplatePresetFormValues,
+} from '@/presets/catalog';
+
+export type TemplatePresetKey = CuratedTemplatePresetKey | OfficialTemplatePresetKey;
+
+const templatePresetItems = [
+    ...OFFICIAL_TEMPLATE_PRESET_ITEMS,
+    ...CURATED_TEMPLATE_PRESET_ITEMS,
+] as const;
+
+const templatePresetItemByKey = Object.fromEntries(
+    templatePresetItems.map((item) => [item.key, item]),
+) as Record<TemplatePresetKey, (typeof templatePresetItems)[number]>;
+
+export const TEMPLATE_PRESET_ORDER: TemplatePresetKey[] = [
+    ...OFFICIAL_TEMPLATE_PRESET_ITEMS.map((item) => item.key as OfficialTemplatePresetKey),
+    ...CURATED_TEMPLATE_PRESET_ITEMS.map((item) => item.key as CuratedTemplatePresetKey),
+];
+
+export const TEMPLATE_OS_FAMILY_OPTIONS = [
+    { labelKey: 'templates.os_family_linux', value: 'linux' as const },
+    { labelKey: 'templates.os_family_windows', value: 'windows' as const },
+];
+
+export function buildTemplatePresetValues(key: TemplatePresetKey): TemplatePresetFormValues {
+    return { ...templatePresetItemByKey[key].values };
+}
+
+export function getTemplatePresetGroups() {
+    return [
+        {
+            sourceType: 'official' as const,
+            titleKey: 'catalog.source_official',
+            descriptionKey: 'templates.official_group_description',
+            items: OFFICIAL_TEMPLATE_PRESET_ITEMS,
+        },
+        {
+            sourceType: 'curated' as const,
+            titleKey: 'catalog.source_curated',
+            descriptionKey: 'templates.curated_group_description',
+            items: CURATED_TEMPLATE_PRESET_ITEMS,
+        },
+    ];
+}
+
+export function getTemplateOSVersionSuggestions(osFamily?: string): string[] {
+    const wanted = (osFamily ?? '').trim().toLowerCase();
+    return Array.from(
+        new Set(
+            templatePresetItems
+                .filter((preset) => wanted === '' || preset.osFamily === wanted)
+                .map((preset) => preset.osVersion),
+        ),
+    );
+}
+
+export function getTemplatePVCNamespaceSuggestions(): string[] {
+    return Array.from(
+        new Set(
+            templatePresetItems
+                .map((preset) => preset.pvcNamespace)
+                .filter((value): value is string => typeof value === 'string' && value.trim() !== ''),
+        ),
+    );
+}
+
+export function getTemplatePVCNameSuggestions(osFamily?: string): string[] {
+    const wanted = (osFamily ?? '').trim().toLowerCase();
+    return Array.from(
+        new Set(
+            templatePresetItems
+                .filter((preset) => wanted === '' || preset.osFamily === wanted)
+                .map((preset) => preset.pvcName)
+                .filter((value): value is string => typeof value === 'string' && value.trim() !== ''),
+        ),
+    );
+}
+
+export function getTemplateImageURLSuggestions(osFamily?: string): string[] {
+    const wanted = (osFamily ?? '').trim().toLowerCase();
+    return Array.from(
+        new Set(
+            templatePresetItems
+                .filter((preset) => wanted === '' || preset.osFamily === wanted)
+                .flatMap((preset) => preset.imageUrlExamples),
+        ),
+    );
+}
+
+export function getTemplateCloudInitExample(osFamily: 'linux' | 'windows'): string {
+    return osFamily === 'windows' ? curatedWindowsCloudInitExample : curatedLinuxCloudInitExample;
+}

--- a/web/src/presets/catalog/curatedCatalog.ts
+++ b/web/src/presets/catalog/curatedCatalog.ts
@@ -1,0 +1,487 @@
+import type {
+    TemplateCreateRequest,
+    TemplateUpdateRequest,
+} from '@/features/admin-templates/types';
+
+import type {
+    InstanceSizePresetCatalogItem,
+    TemplatePresetCatalogItem,
+} from './types';
+
+export type CuratedTemplatePresetKey =
+    | 'linux-test'
+    | 'linux-prod'
+    | 'windows-test'
+    | 'windows-prod';
+
+export type CuratedInstanceSizePresetKey = CuratedTemplatePresetKey;
+
+export type TemplatePresetFormValues = Partial<TemplateCreateRequest & TemplateUpdateRequest>;
+
+export interface CuratedInstanceSizePresetFormValues {
+    catalog_scope: 'test' | 'prod';
+    cpu_cores: number;
+    memory_gi: number;
+    disk_gb: number;
+    cpu_overcommit_enabled: boolean;
+    cpu_request?: number;
+    memory_overcommit_enabled: boolean;
+    memory_request_gi?: number;
+    dedicated_cpu: boolean;
+    requires_sriov: boolean;
+    spec_text: string;
+    enabled: boolean;
+}
+
+export const curatedLinuxCloudInitExample = `#cloud-config
+ssh_pwauth: true
+disable_root: false
+timezone: Asia/Shanghai
+users:
+  - name: root
+    lock_passwd: false
+  - name: appops
+    lock_passwd: false
+runcmd:
+  - mkdir -p /app
+  - chown -R appops:appops /app
+`;
+
+export const curatedWindowsCloudInitExample = `#ps1_sysnative
+$free = (Get-Disk 0).Size - ((Get-Partition -DiskId 0 | Measure Size -Sum).Sum)
+if ($free -gt 1GB) {
+  $p = New-Partition -DiskNumber 0 -UseMaximumSize -DriveLetter D
+  while (-not (Get-Volume -DriveLetter D -EA 0)) { sleep 1 }
+  Format-Volume -DriveLetter D -FileSystem NTFS -NewFileSystemLabel "DataDisk" -Confirm:$false
+}
+`;
+
+function toSpecText(spec: Record<string, unknown>): string {
+    return JSON.stringify(spec, null, 2);
+}
+
+const linuxBaseSpec = {
+    spec: {
+        runStrategy: 'Always',
+        template: {
+            metadata: {
+                annotations: {
+                    'ovn.kubernetes.io/allow_live_migration': 'true',
+                    'kubevirt.io/allow-pod-bridge-network-live-migration': 'true',
+                },
+            },
+            spec: {
+                evictionStrategy: 'LiveMigrate',
+                domain: {
+                    cpu: {
+                        model: 'host-passthrough',
+                    },
+                    devices: {
+                        autoattachSerialConsole: true,
+                        autoattachMemBalloon: false,
+                        autoattachGraphicsDevice: false,
+                        autoattachVSOCK: true,
+                        networkInterfaceMultiqueue: true,
+                        blockMultiQueue: true,
+                        rng: {},
+                        disks: [
+                            {
+                                name: 'rootfs',
+                                disk: { bus: 'virtio' },
+                            },
+                            {
+                                name: 'cloudinitdisk',
+                                disk: { bus: 'virtio' },
+                            },
+                        ],
+                        interfaces: [
+                            {
+                                bridge: {},
+                                name: 'default',
+                                model: 'virtio',
+                            },
+                        ],
+                    },
+                    machine: {
+                        type: 'q35',
+                    },
+                },
+                livenessProbe: {
+                    guestAgentPing: {},
+                    initialDelaySeconds: 120,
+                    periodSeconds: 20,
+                    failureThreshold: 3,
+                    timeoutSeconds: 5,
+                },
+                terminationGracePeriodSeconds: 0,
+                networks: [
+                    {
+                        name: 'default',
+                        pod: {},
+                    },
+                ],
+            },
+        },
+    },
+};
+
+const windowsBaseSpec = {
+    spec: {
+        runStrategy: 'Always',
+        template: {
+            metadata: {
+                annotations: {
+                    'ovn.kubernetes.io/allow_live_migration': 'true',
+                    'kubevirt.io/allow-pod-bridge-network-live-migration': 'true',
+                },
+            },
+            spec: {
+                evictionStrategy: 'LiveMigrate',
+                domain: {
+                    cpu: {
+                        model: 'host-passthrough',
+                        sockets: 1,
+                        threads: 1,
+                    },
+                    clock: {
+                        utc: {},
+                        timer: {
+                            hpet: { present: false },
+                            pit: { tickPolicy: 'delay' },
+                            rtc: { tickPolicy: 'delay' },
+                            hyperv: {},
+                        },
+                    },
+                    features: {
+                        acpi: { enabled: true },
+                        apic: { enabled: true },
+                        hyperv: {
+                            relaxed: { enabled: true },
+                            vapic: { enabled: true },
+                            spinlocks: { enabled: true, spinlocks: 8191 },
+                            vpindex: { enabled: true },
+                            runtime: { enabled: true },
+                            synic: { enabled: true },
+                            frequencies: { enabled: true },
+                            reset: { enabled: true },
+                            vendorid: { enabled: true, vendorid: 'KubeVirt' },
+                        },
+                    },
+                    devices: {
+                        autoattachMemBalloon: false,
+                        autoattachVSOCK: false,
+                        networkInterfaceMultiqueue: true,
+                        blockMultiQueue: true,
+                        rng: {},
+                        disks: [
+                            {
+                                name: 'rootfs',
+                                bootOrder: 1,
+                                disk: { bus: 'scsi' },
+                            },
+                            {
+                                name: 'cloudinitdisk',
+                                cdrom: { bus: 'sata' },
+                            },
+                        ],
+                        interfaces: [
+                            {
+                                bridge: {},
+                                name: 'default',
+                                model: 'virtio',
+                            },
+                        ],
+                    },
+                    machine: {
+                        type: 'q35',
+                    },
+                },
+                terminationGracePeriodSeconds: 180,
+                networks: [
+                    {
+                        name: 'default',
+                        pod: {},
+                    },
+                ],
+            },
+        },
+    },
+};
+
+export const CURATED_TEMPLATE_PRESET_ITEMS: Array<TemplatePresetCatalogItem<TemplatePresetFormValues>> = [
+    {
+        key: 'linux-test',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'templates.preset_linux_test',
+        descriptionKey: 'templates.curated_group_description',
+        osFamily: 'linux',
+        osVersion: 'openEuler 22.03',
+        pvcNamespace: 'vm-muban',
+        pvcName: 'openeuler2203-image',
+        imageUrlExamples: [
+            'docker://quay.io/containerdisks/fedora:latest',
+            'https://example.invalid/images/openeuler-22.03.qcow2',
+        ],
+        values: {
+            os_family: 'linux',
+            os_version: 'openEuler 22.03',
+            catalog_scope: 'test',
+            source_type: 'cdi_pvc_clone',
+            pvc_namespace: 'vm-muban',
+            pvc_name: 'openeuler2203-image',
+            image_url: undefined,
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'linux-prod',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'templates.preset_linux_prod',
+        descriptionKey: 'templates.curated_group_description',
+        osFamily: 'linux',
+        osVersion: 'Kylin V10',
+        pvcNamespace: 'vm-muban',
+        pvcName: 'kylinv10-image',
+        imageUrlExamples: [
+            'docker://registry.example.com/vm-images/kylin:v10',
+            'https://example.invalid/images/kylin-v10.qcow2',
+        ],
+        values: {
+            os_family: 'linux',
+            os_version: 'Kylin V10',
+            catalog_scope: 'prod',
+            source_type: 'cdi_pvc_clone',
+            pvc_namespace: 'vm-muban',
+            pvc_name: 'kylinv10-image',
+            image_url: undefined,
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'windows-test',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'templates.preset_windows_test',
+        descriptionKey: 'templates.curated_group_description',
+        osFamily: 'windows',
+        osVersion: 'Windows Server 2022',
+        pvcNamespace: 'vm-muban',
+        pvcName: 'win2022-image',
+        imageUrlExamples: [
+            'docker://registry.example.com/vm-images/windows-server-2022:latest',
+            'https://example.invalid/images/windows-server-2022.qcow2',
+        ],
+        values: {
+            os_family: 'windows',
+            os_version: 'Windows Server 2022',
+            catalog_scope: 'test',
+            source_type: 'cdi_pvc_clone',
+            pvc_namespace: 'vm-muban',
+            pvc_name: 'win2022-image',
+            image_url: undefined,
+            cloud_init: curatedWindowsCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'windows-prod',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'templates.preset_windows_prod',
+        descriptionKey: 'templates.curated_group_description',
+        osFamily: 'windows',
+        osVersion: 'Windows Server 2022',
+        pvcNamespace: 'vm-muban',
+        pvcName: 'win2022-image',
+        imageUrlExamples: [
+            'docker://registry.example.com/vm-images/windows-server-2022:latest',
+            'https://example.invalid/images/windows-server-2022.qcow2',
+        ],
+        values: {
+            os_family: 'windows',
+            os_version: 'Windows Server 2022',
+            catalog_scope: 'prod',
+            source_type: 'cdi_pvc_clone',
+            pvc_namespace: 'vm-muban',
+            pvc_name: 'win2022-image',
+            image_url: undefined,
+            cloud_init: curatedWindowsCloudInitExample,
+            enabled: true,
+        },
+    },
+];
+
+export const CURATED_INSTANCE_SIZE_PRESET_ITEMS: Array<InstanceSizePresetCatalogItem<CuratedInstanceSizePresetFormValues>> = [
+    {
+        key: 'linux-test',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'instanceSizes.preset_linux_test',
+        descriptionKey: 'instanceSizes.preset_description',
+        values: {
+            catalog_scope: 'test',
+            cpu_cores: 4,
+            memory_gi: 8,
+            disk_gb: 60,
+            cpu_overcommit_enabled: true,
+            cpu_request: 2,
+            memory_overcommit_enabled: true,
+            memory_request_gi: 4,
+            dedicated_cpu: false,
+            requires_sriov: false,
+            spec_text: toSpecText({
+                ...linuxBaseSpec,
+                spec: {
+                    ...linuxBaseSpec.spec,
+                    template: {
+                        ...linuxBaseSpec.spec.template,
+                        spec: {
+                            ...linuxBaseSpec.spec.template.spec,
+                            nodeSelector: {
+                                'kubevirt.io/ksm-enabled': 'true',
+                            },
+                        },
+                    },
+                },
+            }),
+            enabled: true,
+        },
+    },
+    {
+        key: 'linux-prod',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'instanceSizes.preset_linux_prod',
+        descriptionKey: 'instanceSizes.preset_description',
+        values: {
+            catalog_scope: 'prod',
+            cpu_cores: 4,
+            memory_gi: 8,
+            disk_gb: 60,
+            cpu_overcommit_enabled: false,
+            cpu_request: undefined,
+            memory_overcommit_enabled: false,
+            memory_request_gi: undefined,
+            dedicated_cpu: true,
+            requires_sriov: false,
+            spec_text: toSpecText({
+                ...linuxBaseSpec,
+                spec: {
+                    ...linuxBaseSpec.spec,
+                    template: {
+                        ...linuxBaseSpec.spec.template,
+                        spec: {
+                            ...linuxBaseSpec.spec.template.spec,
+                            domain: {
+                                ...linuxBaseSpec.spec.template.spec.domain,
+                                cpu: {
+                                    ...linuxBaseSpec.spec.template.spec.domain.cpu,
+                                    sockets: 1,
+                                    threads: 1,
+                                    dedicatedCpuPlacement: true,
+                                    isolateEmulatorThread: false,
+                                    numa: {
+                                        guestMappingPassthrough: {},
+                                    },
+                                },
+                                memory: {
+                                    hugepages: {
+                                        pageSize: '2Mi',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+            enabled: true,
+        },
+    },
+    {
+        key: 'windows-test',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'instanceSizes.preset_windows_test',
+        descriptionKey: 'instanceSizes.preset_description',
+        values: {
+            catalog_scope: 'test',
+            cpu_cores: 8,
+            memory_gi: 16,
+            disk_gb: 120,
+            cpu_overcommit_enabled: true,
+            cpu_request: 4,
+            memory_overcommit_enabled: true,
+            memory_request_gi: 8,
+            dedicated_cpu: false,
+            requires_sriov: false,
+            spec_text: toSpecText({
+                ...windowsBaseSpec,
+                spec: {
+                    ...windowsBaseSpec.spec,
+                    template: {
+                        ...windowsBaseSpec.spec.template,
+                        spec: {
+                            ...windowsBaseSpec.spec.template.spec,
+                            nodeSelector: {
+                                'kubevirt.io/ksm-enabled': 'true',
+                            },
+                        },
+                    },
+                },
+            }),
+            enabled: true,
+        },
+    },
+    {
+        key: 'windows-prod',
+        sourceType: 'curated',
+        verificationLevel: 'verified',
+        labelKey: 'instanceSizes.preset_windows_prod',
+        descriptionKey: 'instanceSizes.preset_description',
+        values: {
+            catalog_scope: 'prod',
+            cpu_cores: 8,
+            memory_gi: 16,
+            disk_gb: 120,
+            cpu_overcommit_enabled: false,
+            cpu_request: undefined,
+            memory_overcommit_enabled: false,
+            memory_request_gi: undefined,
+            dedicated_cpu: true,
+            requires_sriov: false,
+            spec_text: toSpecText({
+                ...windowsBaseSpec,
+                spec: {
+                    ...windowsBaseSpec.spec,
+                    template: {
+                        ...windowsBaseSpec.spec.template,
+                        spec: {
+                            ...windowsBaseSpec.spec.template.spec,
+                            domain: {
+                                ...windowsBaseSpec.spec.template.spec.domain,
+                                cpu: {
+                                    ...windowsBaseSpec.spec.template.spec.domain.cpu,
+                                    dedicatedCpuPlacement: true,
+                                    isolateEmulatorThread: false,
+                                    numa: {
+                                        guestMappingPassthrough: {},
+                                    },
+                                },
+                                memory: {
+                                    hugepages: {
+                                        pageSize: '2Mi',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+            enabled: true,
+        },
+    },
+];

--- a/web/src/presets/catalog/index.ts
+++ b/web/src/presets/catalog/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './curatedCatalog';
+export * from './officialTemplateCatalog';

--- a/web/src/presets/catalog/officialTemplateCatalog.ts
+++ b/web/src/presets/catalog/officialTemplateCatalog.ts
@@ -1,0 +1,117 @@
+import type {
+    TemplateCreateRequest,
+    TemplateUpdateRequest,
+} from '@/features/admin-templates/types';
+
+import { curatedLinuxCloudInitExample } from './curatedCatalog';
+import type { TemplatePresetCatalogItem } from './types';
+
+export type OfficialTemplatePresetKey =
+    | 'official-fedora-eval'
+    | 'official-ubuntu-eval'
+    | 'official-centos-stream-eval'
+    | 'official-opensuse-leap-eval'
+    | 'official-debian-eval';
+
+type TemplatePresetFormValues = Partial<TemplateCreateRequest & TemplateUpdateRequest>;
+
+// Official starter templates prefer the portable CDI image import path.
+// This keeps the boot source aligned with the KubeVirt/CDI production-friendly
+// path while still reusing upstream image sources.
+export const OFFICIAL_TEMPLATE_PRESET_ITEMS: Array<TemplatePresetCatalogItem<TemplatePresetFormValues>> = [
+    {
+        key: 'official-fedora-eval',
+        sourceType: 'official',
+        verificationLevel: 'verified',
+        labelKey: 'templates.official_preset_fedora_eval',
+        descriptionKey: 'templates.official_group_description',
+        osFamily: 'linux',
+        osVersion: 'Fedora',
+        imageUrlExamples: ['docker://quay.io/containerdisks/fedora:latest'],
+        values: {
+            os_family: 'linux',
+            os_version: 'Fedora',
+            catalog_scope: 'test',
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/fedora:latest',
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'official-ubuntu-eval',
+        sourceType: 'official',
+        verificationLevel: 'verified',
+        labelKey: 'templates.official_preset_ubuntu_eval',
+        descriptionKey: 'templates.official_group_description',
+        osFamily: 'linux',
+        osVersion: 'Ubuntu',
+        imageUrlExamples: ['docker://quay.io/containerdisks/ubuntu:latest'],
+        values: {
+            os_family: 'linux',
+            os_version: 'Ubuntu',
+            catalog_scope: 'test',
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/ubuntu:latest',
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'official-centos-stream-eval',
+        sourceType: 'official',
+        verificationLevel: 'verified',
+        labelKey: 'templates.official_preset_centos_stream_eval',
+        descriptionKey: 'templates.official_group_description',
+        osFamily: 'linux',
+        osVersion: 'CentOS Stream',
+        imageUrlExamples: ['docker://quay.io/containerdisks/centos-stream:latest'],
+        values: {
+            os_family: 'linux',
+            os_version: 'CentOS Stream',
+            catalog_scope: 'test',
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/centos-stream:latest',
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'official-opensuse-leap-eval',
+        sourceType: 'official',
+        verificationLevel: 'verified',
+        labelKey: 'templates.official_preset_opensuse_leap_eval',
+        descriptionKey: 'templates.official_group_description',
+        osFamily: 'linux',
+        osVersion: 'openSUSE Leap',
+        imageUrlExamples: ['docker://quay.io/containerdisks/opensuse-leap:latest'],
+        values: {
+            os_family: 'linux',
+            os_version: 'openSUSE Leap',
+            catalog_scope: 'test',
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/opensuse-leap:latest',
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+    {
+        key: 'official-debian-eval',
+        sourceType: 'official',
+        verificationLevel: 'verified',
+        labelKey: 'templates.official_preset_debian_eval',
+        descriptionKey: 'templates.official_group_description',
+        osFamily: 'linux',
+        osVersion: 'Debian',
+        imageUrlExamples: ['docker://quay.io/containerdisks/debian:latest'],
+        values: {
+            os_family: 'linux',
+            os_version: 'Debian',
+            catalog_scope: 'test',
+            source_type: 'cdi_image_import',
+            image_url: 'docker://quay.io/containerdisks/debian:latest',
+            cloud_init: curatedLinuxCloudInitExample,
+            enabled: true,
+        },
+    },
+];

--- a/web/src/presets/catalog/types.ts
+++ b/web/src/presets/catalog/types.ts
@@ -1,0 +1,26 @@
+export type PresetCatalogSourceType = 'curated' | 'official' | 'imported';
+
+export type PresetVerificationLevel = 'verified' | 'experimental' | 'unverified';
+
+export interface TemplatePresetCatalogItem<TValues> {
+    key: string;
+    sourceType: PresetCatalogSourceType;
+    verificationLevel: PresetVerificationLevel;
+    labelKey: string;
+    descriptionKey?: string;
+    osFamily: 'linux' | 'windows';
+    osVersion: string;
+    pvcNamespace?: string;
+    pvcName?: string;
+    imageUrlExamples: string[];
+    values: TValues;
+}
+
+export interface InstanceSizePresetCatalogItem<TValues> {
+    key: string;
+    sourceType: PresetCatalogSourceType;
+    verificationLevel: PresetVerificationLevel;
+    labelKey: string;
+    descriptionKey?: string;
+    values: TValues;
+}


### PR DESCRIPTION
## Summary

- extract shared preset catalog types and exports under `web/src/presets/catalog/`
- move initial template and instance-size preset definitions onto the shared helper boundary
- add focused tests for the extracted catalog helpers

## Why this is split separately

The current `wip/implementation` branch mixes ADR-0044, ADR-0045, and ADR-0046 work across overlapping frontend files. This PR lands the catalog data-layer groundwork first so the later preset UX/import-export work has a stable base and a smaller diff.

## Validation

- `npm run test:run --prefix web -- src/features/admin-instance-sizes/instanceSizePresets.test.ts src/features/admin-templates/templatePresets.test.ts`
- `npm run typecheck --prefix web`
- `npm run lint --prefix web -- src/features/admin-instance-sizes/instanceSizePresets.ts src/features/admin-instance-sizes/instanceSizePresets.test.ts src/features/admin-templates/templatePresets.ts src/features/admin-templates/templatePresets.test.ts src/presets/catalog/curatedCatalog.ts src/presets/catalog/index.ts src/presets/catalog/officialTemplateCatalog.ts src/presets/catalog/types.ts`

Closes #379
Refs #357
