### PR TITLE
test(web): audit curated preset catalog invariants

### DIFF
--- a/web/src/presets/catalog/curatedCatalog.audit.test.ts
+++ b/web/src/presets/catalog/curatedCatalog.audit.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { CURATED_INSTANCE_SIZE_PRESET_ITEMS } from './curatedCatalog';
+
+function parseSpecText(specText: string): Record<string, unknown> {
+    return JSON.parse(specText) as Record<string, unknown>;
+}
+
+function getAtPath(value: unknown, pathText: string): unknown {
+    const parts = pathText.split('.');
+    let current: unknown = value;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object' || Array.isArray(current)) {
+            return undefined;
+        }
+        current = (current as Record<string, unknown>)[part];
+    }
+    return current;
+}
+
+function getNameList(value: unknown, pathText: string): string[] {
+    const items = getAtPath(value, pathText);
+    if (!Array.isArray(items)) {
+        return [];
+    }
+    return items
+        .map((item) => (item && typeof item === 'object' ? (item as { name?: unknown }).name : undefined))
+        .filter((item): item is string => typeof item === 'string');
+}
+
+describe('curatedCatalog internal audit', () => {
+    it.each(CURATED_INSTANCE_SIZE_PRESET_ITEMS)(
+        'keeps instance-size preset $key internally consistent',
+        ({ key, sourceType, verificationLevel, values }) => {
+            const parsed = parseSpecText(values.spec_text);
+
+            expect(sourceType).toBe('curated');
+            expect(verificationLevel).toBe('verified');
+            expect(values.catalog_scope).toBe(key.includes('test') ? 'test' : 'prod');
+            expect(values.enabled).toBe(true);
+            expect(values.requires_sriov).toBe(false);
+            expect(getAtPath(parsed, 'spec.runStrategy')).toBe('Always');
+
+            // InstanceSize keeps capacity and overcommit data in top-level catalog fields.
+            expect(getAtPath(parsed, 'spec.template.spec.domain.cpu.cores')).toBeUndefined();
+            expect(getAtPath(parsed, 'spec.template.spec.domain.memory.guest')).toBeUndefined();
+            expect(getAtPath(parsed, 'spec.template.spec.domain.resources')).toBeUndefined();
+
+            expect(getNameList(parsed, 'spec.template.spec.domain.devices.disks')).toEqual(
+                expect.arrayContaining(['rootfs', 'cloudinitdisk']),
+            );
+            expect(getNameList(parsed, 'spec.template.spec.domain.devices.interfaces')).toContain('default');
+            expect(getNameList(parsed, 'spec.template.spec.networks')).toContain('default');
+
+            if (key.startsWith('linux')) {
+                expect(values.cpu_cores).toBe(4);
+                expect(values.memory_gi).toBe(8);
+                expect(values.disk_gb).toBe(60);
+            } else {
+                expect(values.cpu_cores).toBe(8);
+                expect(values.memory_gi).toBe(16);
+                expect(values.disk_gb).toBe(120);
+            }
+
+            if (key.endsWith('test')) {
+                expect(values.cpu_overcommit_enabled).toBe(true);
+                expect(values.cpu_request).toBeDefined();
+                expect(values.memory_overcommit_enabled).toBe(true);
+                expect(values.memory_request_gi).toBeDefined();
+                expect(values.dedicated_cpu).toBe(false);
+                expect(getAtPath(parsed, 'spec.template.spec.domain.cpu.dedicatedCpuPlacement')).not.toBe(true);
+            } else {
+                expect(values.cpu_overcommit_enabled).toBe(false);
+                expect(values.cpu_request).toBeUndefined();
+                expect(values.memory_overcommit_enabled).toBe(false);
+                expect(values.memory_request_gi).toBeUndefined();
+                expect(values.dedicated_cpu).toBe(true);
+                expect(getAtPath(parsed, 'spec.template.spec.domain.cpu.dedicatedCpuPlacement')).toBe(true);
+                expect(getAtPath(parsed, 'spec.template.spec.domain.cpu.numa.guestMappingPassthrough')).toEqual({});
+                expect(getAtPath(parsed, 'spec.template.spec.domain.memory.hugepages.pageSize')).toBe('2Mi');
+            }
+        },
+    );
+});

--- a/web/src/presets/catalog/curatedTemplateCatalog.audit.test.ts
+++ b/web/src/presets/catalog/curatedTemplateCatalog.audit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    CURATED_TEMPLATE_PRESET_ITEMS,
+    curatedLinuxCloudInitExample,
+    curatedWindowsCloudInitExample,
+} from './curatedCatalog';
+
+describe('curated template catalog internal audit', () => {
+    it.each(CURATED_TEMPLATE_PRESET_ITEMS)(
+        'keeps template preset $key internally consistent',
+        ({ key, sourceType, verificationLevel, osFamily, osVersion, pvcNamespace, pvcName, imageUrlExamples, values }) => {
+            expect(sourceType).toBe('curated');
+            expect(verificationLevel).toBe('verified');
+
+            expect(values.source_type).toBe('cdi_pvc_clone');
+            expect(values.pvc_namespace).toBe(pvcNamespace);
+            expect(values.pvc_name).toBe(pvcName);
+            expect(values.os_family).toBe(osFamily);
+            expect(values.os_version).toBe(osVersion);
+            expect(values.catalog_scope).toBe(key.includes('test') ? 'test' : 'prod');
+            expect(values.image_url).toBeUndefined();
+            expect(values.enabled).toBe(true);
+
+            expect(values.pvc_namespace).toBe('vm-muban');
+            expect(imageUrlExamples.length).toBeGreaterThan(0);
+            expect(imageUrlExamples.some((item) => item.startsWith('docker://') || item.startsWith('https://'))).toBe(true);
+
+            if (key.startsWith('linux')) {
+                expect(values.os_family).toBe('linux');
+                expect(values.cloud_init).toBe(curatedLinuxCloudInitExample);
+                expect(values.cloud_init?.startsWith('#cloud-config')).toBe(true);
+            } else {
+                expect(values.os_family).toBe('windows');
+                expect(values.cloud_init).toBe(curatedWindowsCloudInitExample);
+                expect(values.cloud_init?.startsWith('#ps1_sysnative')).toBe(true);
+            }
+        },
+    );
+});


### PR DESCRIPTION
## Summary

- add repository-local audit tests for curated instance-size preset catalog invariants
- add repository-local audit tests for curated template preset catalog invariants
- keep the checks self-contained so they validate shipped catalog data only

## Boundary

This PR is test-only. It intentionally does not include the preset picker UI slice from #386 or the later YAML bundle exchange utility PR.

## Validation

- `npm run test:run --prefix web -- src/presets/catalog/curatedCatalog.audit.test.ts src/presets/catalog/curatedTemplateCatalog.audit.test.ts`
- `npm run lint --prefix web -- src/presets/catalog/curatedCatalog.audit.test.ts src/presets/catalog/curatedTemplateCatalog.audit.test.ts`
- `npm run typecheck --prefix web`
- `bash docs/design/ci/scripts/check_changed_code_has_tests.sh`

Closes #384
Refs #357