### PR TITLE
feat(web): add preset catalog bundle exchange utilities

### DIFF
--- a/web/src/presets/exchange/bundle.test.ts
+++ b/web/src/presets/exchange/bundle.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    CURATED_INSTANCE_SIZE_PRESET_ITEMS,
+    CURATED_TEMPLATE_PRESET_ITEMS,
+    OFFICIAL_TEMPLATE_PRESET_ITEMS,
+} from '@/presets/catalog';
+
+import {
+    buildPresetCatalogBundle,
+    parsePresetCatalogBundleYAML,
+    serializePresetCatalogBundleToYAML,
+} from './bundle';
+
+describe('preset bundle exchange', () => {
+    it('builds and parses a curated bundle with templates and instance sizes', () => {
+        const bundle = buildPresetCatalogBundle({
+            name: 'curated-catalog',
+            sourceType: 'curated',
+            templateItems: CURATED_TEMPLATE_PRESET_ITEMS,
+            instanceSizeItems: CURATED_INSTANCE_SIZE_PRESET_ITEMS,
+            now: new Date('2026-03-12T00:00:00Z'),
+        });
+
+        const yamlText = serializePresetCatalogBundleToYAML(bundle);
+        const reparsed = parsePresetCatalogBundleYAML(yamlText);
+
+        expect(reparsed.metadata.name).toBe('curated-catalog');
+        expect(reparsed.items.templates).toHaveLength(CURATED_TEMPLATE_PRESET_ITEMS.length);
+        expect(reparsed.items.instance_sizes).toHaveLength(CURATED_INSTANCE_SIZE_PRESET_ITEMS.length);
+    });
+
+    it('preserves official template starter items in yaml bundles', () => {
+        const bundle = buildPresetCatalogBundle({
+            name: 'official-template-catalog',
+            sourceType: 'official',
+            templateItems: OFFICIAL_TEMPLATE_PRESET_ITEMS,
+            now: new Date('2026-03-12T00:00:00Z'),
+        });
+
+        const yamlText = serializePresetCatalogBundleToYAML(bundle);
+
+        expect(yamlText).toContain('kind: PresetCatalogBundle');
+        expect(yamlText).toContain('official-fedora-eval');
+        expect(yamlText).toContain('quay.io/containerdisks/fedora:latest');
+    });
+});

--- a/web/src/presets/exchange/bundle.ts
+++ b/web/src/presets/exchange/bundle.ts
@@ -1,0 +1,99 @@
+import { dump, load } from 'js-yaml';
+
+import type {
+    InstanceSizePresetCatalogItem,
+    PresetCatalogSourceType,
+    TemplatePresetCatalogItem,
+} from '@/presets/catalog';
+
+import {
+    presetCatalogBundleSchema,
+    type InstanceSizePresetBundleItem,
+    type PresetCatalogBundle,
+    type TemplatePresetBundleItem,
+} from './schema';
+
+interface BuildPresetCatalogBundleArgs<TTemplateValues, TInstanceSizeValues> {
+    name: string;
+    sourceType: PresetCatalogSourceType;
+    templateItems?: Array<TemplatePresetCatalogItem<TTemplateValues>>;
+    instanceSizeItems?: Array<InstanceSizePresetCatalogItem<TInstanceSizeValues>>;
+    now?: Date;
+}
+
+function toTemplateBundleItem<TValues>(
+    item: TemplatePresetCatalogItem<TValues>,
+): TemplatePresetBundleItem {
+    return {
+        key: item.key,
+        label: item.labelKey,
+        description: item.descriptionKey,
+        source_type: item.sourceType,
+        verification_level: item.verificationLevel,
+        os_family: item.osFamily,
+        os_version: item.osVersion,
+        values: item.values as Record<string, unknown>,
+    };
+}
+
+function toInstanceSizeBundleItem<TValues>(
+    item: InstanceSizePresetCatalogItem<TValues>,
+): InstanceSizePresetBundleItem {
+    return {
+        key: item.key,
+        label: item.labelKey,
+        description: item.descriptionKey,
+        source_type: item.sourceType,
+        verification_level: item.verificationLevel,
+        values: item.values as Record<string, unknown>,
+    };
+}
+
+export function buildPresetCatalogBundle<TTemplateValues, TInstanceSizeValues>({
+    name,
+    sourceType,
+    templateItems = [],
+    instanceSizeItems = [],
+    now = new Date(),
+}: BuildPresetCatalogBundleArgs<TTemplateValues, TInstanceSizeValues>): PresetCatalogBundle {
+    return {
+        apiVersion: 'shepherd.io/v1alpha1',
+        kind: 'PresetCatalogBundle',
+        metadata: {
+            name,
+            source_type: sourceType,
+            exported_at: now.toISOString(),
+        },
+        items: {
+            templates: templateItems.map((item) => toTemplateBundleItem(item)),
+            instance_sizes: instanceSizeItems.map((item) => toInstanceSizeBundleItem(item)),
+        },
+    };
+}
+
+export function serializePresetCatalogBundleToYAML(bundle: PresetCatalogBundle): string {
+    return dump(bundle, {
+        noRefs: true,
+        lineWidth: 120,
+        sortKeys: false,
+    });
+}
+
+export function parsePresetCatalogBundleYAML(yamlText: string): PresetCatalogBundle {
+    const parsed = load(yamlText);
+    return presetCatalogBundleSchema.parse(parsed);
+}
+
+export function downloadTextFile(
+    filename: string,
+    text: string,
+    mimeType = 'text/plain;charset=utf-8',
+) {
+    const blob = new Blob([text], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(url);
+}

--- a/web/src/presets/exchange/schema.ts
+++ b/web/src/presets/exchange/schema.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const presetCatalogSourceTypeSchema = z.enum(['curated', 'official', 'imported']);
+export const presetVerificationLevelSchema = z.enum(['verified', 'experimental', 'unverified']);
+
+export const templatePresetBundleItemSchema = z.object({
+    key: z.string().min(1),
+    label: z.string().min(1),
+    description: z.string().optional(),
+    source_type: presetCatalogSourceTypeSchema,
+    verification_level: presetVerificationLevelSchema,
+    os_family: z.enum(['linux', 'windows']),
+    os_version: z.string().min(1),
+    values: z.record(z.string(), z.unknown()),
+});
+
+export const instanceSizePresetBundleItemSchema = z.object({
+    key: z.string().min(1),
+    label: z.string().min(1),
+    description: z.string().optional(),
+    source_type: presetCatalogSourceTypeSchema,
+    verification_level: presetVerificationLevelSchema,
+    values: z.record(z.string(), z.unknown()),
+});
+
+export const presetCatalogBundleSchema = z.object({
+    apiVersion: z.literal('shepherd.io/v1alpha1'),
+    kind: z.literal('PresetCatalogBundle'),
+    metadata: z.object({
+        name: z.string().min(1),
+        source_type: presetCatalogSourceTypeSchema,
+        exported_at: z.string().min(1),
+    }),
+    items: z.object({
+        templates: z.array(templatePresetBundleItemSchema).default([]),
+        instance_sizes: z.array(instanceSizePresetBundleItemSchema).default([]),
+    }),
+});
+
+export type PresetCatalogBundle = z.infer<typeof presetCatalogBundleSchema>;
+export type TemplatePresetBundleItem = z.infer<typeof templatePresetBundleItemSchema>;
+export type InstanceSizePresetBundleItem = z.infer<typeof instanceSizePresetBundleItemSchema>;

--- a/web/src/types/js-yaml.d.ts
+++ b/web/src/types/js-yaml.d.ts
@@ -1,0 +1,4 @@
+declare module 'js-yaml' {
+    export function dump(value: unknown, options?: Record<string, unknown>): string;
+    export function load(value: string, options?: Record<string, unknown>): unknown;
+}


### PR DESCRIPTION
## Summary

- add a zod schema for preset catalog bundles
- add YAML serialize/parse helpers using `js-yaml`
- add focused tests for bundle round-trip behavior and official-template preservation
- keep the utility layer separate from the later admin UI import/export flow

## Boundary

This PR is the utility slice after the preset picker and catalog-audit PRs. It intentionally does not include admin UI wiring or backend/API changes.

## Validation

- `npm run lint --prefix web`
- `npm run typecheck --prefix web`
- `bash docs/design/ci/scripts/check_changed_code_has_tests.sh`
- `npm run test:run --prefix web`

Closes #385
Refs #357