### PR TITLE
docs(adr): add ADR-0048 as proposed

### DIFF
--- a/docs/adr/ADR-0048-directory-sync-capability.md
+++ b/docs/adr/ADR-0048-directory-sync-capability.md
@@ -1,0 +1,259 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-03-19
+deciders: ["@jindyzhao"]
+consulted: ["@jindyzhao"]
+informed: ["@jindyzhao"]
+---
+
+# ADR-0048: Directory Sync Capability for Auth Providers
+
+> **Status**: 🔍 Public Review — 48-hour minimum comment window<br>
+> **Review Open**: 2026-03-19<br>
+> **Review Closes**: 2026-03-21 (earliest merge date)<br>
+> **Discussion**: [Issue #396](https://github.com/kv-shepherd/shepherd/issues/396)<br>
+> **Extends**: `ADR-0035-auth-provider-plugin-boundary.md` *(adds optional directory-sync capability within the auth-provider plugin boundary)*<br>
+> **Extends**: `ADR-0024-provider-interface-capability-composition.md` *(keeps directory sync as a small optional capability, not a base-interface expansion)*
+>
+> 📝 **Design Note**: Implementation-facing details are in `docs/design/notes/ADR-0048-directory-sync-capability.md`. The implementation PR must follow the contract in this ADR, not the superseded process-first draft.
+
+---
+
+## Context and Problem Statement
+
+Enterprise deployments often need to import and synchronize users from external
+directories such as WeCom, Feishu, DingTalk, Azure AD, LDAP-backed org trees, or
+future SCIM-compatible systems.
+
+The platform already treats auth providers as plugins with a stable core
+contract. The open question is not whether directory sync should exist, but
+**what the core is allowed to standardize**.
+
+The project philosophy is strict:
+
+* Core defines canonical standards and invariant outcomes.
+* Peripheral adapters may keep provider-specific workflows and quirks.
+* Core must require result compatibility, but must not hardcode vendor process.
+
+The earlier process-first draft assumed all directory providers fit the same
+"department tree + attribute picker + preview + manual sync" flow. That is too
+prescriptive for this codebase's plugin boundary.
+
+**Core question**: How should the platform support directory-based user import
+while keeping provider-specific workflow at the edge and standardizing only the
+canonical import result in core?
+
+## Decision Drivers
+
+* **ADR-0035 plugin boundary**: Core auth/RBAC runtime must remain plugin-standard and provider-agnostic.
+* **ADR-0024 capability composition**: Directory sync must remain an optional capability, not a mandatory expansion of `AuthProviderAdminAdapter`.
+* **ADR-0026 standardized provider output**: Core must consume canonical identity fields, not vendor-specific field names or flow steps.
+* **Core philosophy**: Core only governs consistent results; provider-specific process belongs at the edge.
+* **Identity safety**: Sync must respect global `User` invariants such as username/email uniqueness and stable external identity linkage.
+* **ADR-0006 async model**: Bulk directory import remains an async job.
+* **Schema-driven UI reuse**: Core may render a generic form from plugin-supplied schema, but must not assume one universal directory workflow.
+
+## Considered Options
+
+* **Option 1**: Provider-specific sync modules with custom endpoints and UI
+* **Option 2**: Generic process contract with fixed steps (`ListDepartments`, `AvailableAttributes`, `Preview`, `Sync`)
+* **Option 3**: Generic normalized import contract with provider-owned request schema/workflow (chosen)
+
+## Decision Outcome
+
+**Chosen option**: **"Option 3: Generic normalized import contract with
+provider-owned request schema/workflow"**, because it matches the project's core
+philosophy: the core standardizes canonical user-import results and job
+semantics, while each provider keeps control of how it gathers, filters, and
+shapes source data before adaptation.
+
+### Normative Decisions
+
+#### 1. `DirectorySyncCapability` remains optional, but moves to the result boundary
+
+Auth-provider adapters that support directory import **MAY** implement
+`DirectorySyncCapability`.
+
+The capability contract must standardize:
+
+* provider-owned sync request schema
+* canonical preview/import result items
+* canonical sync job status and summary
+
+The capability contract must **not** standardize vendor workflow primitives such
+as "departments", "organizational units", "attribute picker", or any other
+provider-specific selection process as universal first-class core concepts.
+
+#### 2. Providers own sync workflow input; core accepts only opaque provider request payload
+
+Core APIs carry a `provider_request` JSON object whose structure is defined by
+the adapter's `request_schema`.
+
+Examples:
+
+* WeCom may use department IDs and field-selection options.
+* LDAP may use base DN, filters, and nested search flags.
+* Azure AD may use group selectors or delta tokens.
+* A future push-oriented bridge may use a minimal request or scheduled cursor.
+
+Core handlers, workers, and database schemas must treat `provider_request` as an
+opaque adapter-owned payload. Core must not inspect provider-specific keys.
+
+#### 3. Core standardizes canonical import result records
+
+All providers must normalize imported users into a canonical record shape before
+core persistence:
+
+| Field | Purpose |
+|-------|---------|
+| `external_id` | Stable provider-side identity key |
+| `username` | Canonical Shepherd username candidate |
+| `display_name` | Canonical Shepherd display name |
+| `email` | Canonical Shepherd email candidate |
+| `groups` | Normalized group list if provider can supply it |
+| `attributes` | Provider-specific raw attributes for display/audit only |
+
+Core auth/RBAC/approval/runtime logic must depend only on canonical fields and
+must not branch on provider-specific attribute keys.
+
+#### 4. Conflict classification is a core responsibility
+
+Directory sync must classify identity conflicts before persistence. At minimum,
+the contract must distinguish:
+
+* same `(auth_provider_id, external_id)` identity
+* username collision
+* email collision
+* ambiguous existing local user
+
+`conflict_resolution` policies apply only after classification. Core must not
+rely on database unique-constraint failures as the primary decision mechanism.
+
+#### 5. Provider-specific raw attributes must not be persisted on `User` core fields
+
+Canonical `User` fields remain authoritative for auth and governance. Raw
+directory attributes are stored in a dedicated provider-profile projection, not
+in `User.metadata`.
+
+This projection is informational only and must not drive:
+
+* authentication
+* RBAC
+* approval policy
+* runtime orchestration
+* validation rules
+
+#### 6. Async job contract remains core-owned
+
+Directory imports run asynchronously via River Queue. Core owns:
+
+* job enqueue semantics
+* job lifecycle/status
+* job summary counters
+* auditability of request snapshot and result summary
+
+Providers own only source-data acquisition and adaptation into canonical import
+records.
+
+#### 7. API surface is reduced to standardized result-oriented endpoints
+
+The approved API surface is:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/admin/auth-providers/{id}/directory/descriptor` | Return capability metadata and `request_schema` |
+| `POST` | `/admin/auth-providers/{id}/directory/preview` | Preview canonical import result for `provider_request` |
+| `POST` | `/admin/auth-providers/{id}/directory/sync` | Trigger async sync job using `provider_request` |
+| `GET` | `/admin/auth-providers/{id}/directory/sync-jobs` | List sync jobs |
+| `GET` | `/admin/auth-providers/{id}/directory/sync-jobs/{jobId}` | Get one sync job |
+
+The earlier dedicated `/departments` and `/attributes` endpoints are rejected as
+universal core concepts.
+
+### Consequences
+
+* ✅ Good, because core now standardizes only canonical results and job semantics.
+* ✅ Good, because WeCom/LDAP/Azure AD/Feishu can keep different request workflows without core API churn.
+* ✅ Good, because the existing schema-driven UI pattern can still render a generic request form from provider-supplied schema.
+* ✅ Good, because raw provider data is isolated from canonical `User` fields.
+* ✅ Good, because future providers with non-department-based selection models no longer require a new core abstraction.
+* 🟡 Neutral, because provider authors must define a request schema in addition to producing normalized records.
+* 🟡 Neutral, because the core preview table becomes canonical-field-first rather than vendor-workflow-first.
+* ❌ Bad, because this ADR rejects the earlier simpler process-first draft and requires rework of the proposed note/API/storage model before implementation.
+
+### Confirmation
+
+* Core directory-sync handlers and workers never inspect provider-specific request keys.
+* No runtime path hardcodes WeCom/LDAP/Azure/Feishu-specific workflow branches.
+* Preview/sync tests prove two materially different providers can use the same endpoints with different `provider_request` shapes.
+* Conflict-resolution tests cover `external_id`, `username`, and `email` collision paths.
+* Raw directory attributes are stored outside core `User` fields and are explicitly non-authoritative.
+* CI architecture checks continue to enforce auth-provider plugin boundary rules.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Provider-specific sync modules
+
+Each provider gets its own API endpoints, handlers, and UI flow.
+
+* ✅ Good, because every provider can model its own workflow perfectly.
+* ❌ Bad, because it breaks ADR-0035 by forcing core/API/frontend changes for every new provider.
+* ❌ Bad, because canonical identity conflict rules would drift across providers.
+
+### Option 2: Generic process contract with fixed workflow steps
+
+Assume every provider exposes the same department/attribute/preview workflow.
+
+* ✅ Good, because the first implementation feels straightforward.
+* ❌ Bad, because it standardizes process instead of standardizing result.
+* ❌ Bad, because it cannot cleanly represent providers that select by groups, filters, cursors, or non-browse flows.
+* ❌ Bad, because it pushes vendor workflow vocabulary into core API and UI.
+
+### Option 3: Generic normalized import contract with provider-owned workflow (Chosen)
+
+Providers define input shape and acquisition process; core persists only
+canonical import results.
+
+* ✅ Good, because it matches the project's "core defines standards, edge owns process" philosophy.
+* ✅ Good, because it keeps the auth-provider seam extensible without process leakage.
+* ✅ Good, because it reuses schema-driven UI without pretending all providers share the same workflow.
+* 🟡 Neutral, because adapters do more adaptation work.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* `ADR-0035-auth-provider-plugin-boundary.md` — Auth providers remain plugin-standard and discoverable.
+* `ADR-0024-provider-interface-capability-composition.md` — Optional capability composition pattern.
+* `ADR-0026-idp-config-naming.md` — Canonical provider output contract and adapter-only normalization.
+* `ADR-0041-power-operation-approval-requirement-service.md` — Parallel precedent: core keeps canonical semantics, provider routing stays peripheral.
+* `ADR-0006-unified-async-model.md` — Async execution model for sync jobs.
+
+### References
+
+* [SCIM 2.0 RFC 7644](https://tools.ietf.org/html/rfc7644)
+* [Go Specification - Interface Embedding](https://github.com/golang/go/blob/master/doc/go_spec.html)
+* [HashiCorp go-plugin tutorial](https://github.com/hashicorp/go-plugin/blob/main/docs/extensive-go-plugin-tutorial.md)
+* [Backstage external integrations](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/external-integrations.md)
+
+### Implementation Notes
+
+Revisit this ADR if:
+
+* frontend plugin surfaces become available and providers want custom admin UX beyond schema-driven forms
+* multi-provider user linking becomes a first-class identity model
+* push-based sync becomes a first-class runtime mode
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-19 | @jindyzhao | Initial process-first draft published for review |
+| 2026-03-19 | @jindyzhao | Reworked to result-first contract: provider-owned workflow, core-owned canonical import semantics |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@
 | [ADR-0045](./ADR-0045-cluster-resolved-root-volume-provisioning.md) | Cluster-Resolved Root Volume Provisioning Intent | **Accepted** | - |
 | [ADR-0046](./ADR-0046-schema-mask-field-visibility-tiers.md) | Schema Mask Field Visibility Tiers | **Accepted** | - |
 | [ADR-0047](./ADR-0047-vm-status-granular-lifecycle-states.md) | Granular VM Lifecycle States (STARTING / NOT_FOUND) | **Proposed** | - |
+| [ADR-0048](./ADR-0048-directory-sync-capability.md) | Directory Sync Capability for Auth Providers | **Proposed** | Result-first contract: provider-owned workflow, core-owned canonical import semantics |
 
 > ℹ️ **ADR-0037 Sync Notes**:
 >
@@ -128,6 +129,7 @@ For newcomers, we recommend reading ADRs in this order:
 19. **ADR-0045** (Cluster-Resolved Root Volume Provisioning, **Accepted**) → Clarifies where storage `auto` intent may exist and when approval must resolve explicit root-volume provisioning values
 20. **ADR-0046** (Schema Mask Field Visibility Tiers, **Accepted**) → Formalizes `professional_fields` as a UI-only expert-tier in SchemaMask
 21. **ADR-0047** (Granular VM Lifecycle States, **Proposed** 🔍 48-hr review window) → Adds `STARTING` and `NOT_FOUND` as first-class VM status values with polling/delete integration
+22. **ADR-0048** (Directory Sync Capability, **Proposed** 🔍 48-hr review window) → Adds provider-owned sync request schema with core-owned canonical user-import/result semantics
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/docs/design/notes/ADR-0048-directory-sync-capability.md
+++ b/docs/design/notes/ADR-0048-directory-sync-capability.md
@@ -1,0 +1,403 @@
+# Design Note: ADR-0048 — Directory Sync Capability for Auth Providers
+
+> **Status**: Proposed (ADR-0048 under review until 2026-03-21)
+> **Related ADR**: [ADR-0048](../../adr/ADR-0048-directory-sync-capability.md)
+> **Owner**: @jindyzhao
+> **Created**: 2026-03-19
+> **Last Updated**: 2026-03-19
+
+## Summary
+
+ADR-0048 no longer standardizes a universal vendor workflow such as "department
+tree + attribute picker + preview wizard".
+
+Instead:
+
+* the provider owns the sync request shape and acquisition workflow
+* the core owns canonical preview/import result shape, conflict classification,
+  async job semantics, and persistence invariants
+
+This note captures the implementation shape that follows that boundary.
+
+## Scope
+
+- In scope: optional `DirectorySyncCapability` contract on auth-provider adapters
+- In scope: provider-defined `request_schema`
+- In scope: canonical preview/sync result contract
+- In scope: conflict classification before persistence
+- In scope: async sync jobs and auditability
+- In scope: dedicated storage for provider-specific raw profile attributes
+- Out of scope: hardcoded department/attribute workflow as a core assumption
+- Out of scope: provider-specific frontend flows in core
+- Out of scope: using `User.metadata` for raw directory attributes
+
+---
+
+## 1. Capability Contract
+
+### 1.1 Go Interface
+
+File: `internal/provider/directory_sync.go`
+
+```go
+package provider
+
+import "context"
+
+// DirectorySyncDescriptor tells core how to collect provider-owned request input.
+type DirectorySyncDescriptor struct {
+    DisplayName     string                 `json:"display_name"`
+    Description     string                 `json:"description,omitempty"`
+    RequestSchema   map[string]interface{} `json:"request_schema,omitempty"`
+    SupportsPreview bool                   `json:"supports_preview"`
+}
+
+// DirectoryUserRecord is the canonical user-import contract consumed by core.
+type DirectoryUserRecord struct {
+    ExternalID  string                 `json:"external_id"`
+    Username    string                 `json:"username"`
+    DisplayName string                 `json:"display_name"`
+    Email       string                 `json:"email,omitempty"`
+    Groups      []string               `json:"groups,omitempty"`
+    Attributes  map[string]interface{} `json:"attributes,omitempty"` // raw provider attributes, non-authoritative
+}
+
+// DirectoryConflict represents a canonical classification result.
+type DirectoryConflict struct {
+    Code           string `json:"code"` // same_external_identity | username_conflict | email_conflict | ambiguous_existing_user
+    Field          string `json:"field,omitempty"`
+    ExistingUserID string `json:"existing_user_id,omitempty"`
+    Message        string `json:"message,omitempty"`
+}
+
+// DirectoryPreviewItem is what core shows in preview responses.
+type DirectoryPreviewItem struct {
+    Record    DirectoryUserRecord  `json:"record"`
+    Conflicts []DirectoryConflict  `json:"conflicts,omitempty"`
+    Warnings  []string             `json:"warnings,omitempty"`
+}
+
+type DirectorySyncPreview struct {
+    TotalCount int                    `json:"total_count"`
+    Items      []DirectoryPreviewItem `json:"items"`
+}
+
+type DirectorySyncCapability interface {
+    DescribeDirectorySync() DirectorySyncDescriptor
+    PreviewDirectorySync(ctx context.Context, config map[string]interface{}, providerRequest map[string]interface{}) (*DirectorySyncPreview, error)
+    ListDirectoryUsers(ctx context.Context, config map[string]interface{}, providerRequest map[string]interface{}) ([]DirectoryUserRecord, error)
+}
+```
+
+### 1.2 Boundary Rules
+
+Core is allowed to know:
+
+* `request_schema`
+* canonical user record fields
+* canonical conflict types
+* canonical job states
+
+Core is not allowed to know:
+
+* whether the provider selected departments, groups, OUs, tags, filters, or cursors
+* provider-specific request keys
+* provider-specific attribute names outside the raw `attributes` blob
+
+### 1.3 Why this shape
+
+This keeps the interface small and stable while avoiding the earlier mistake of
+turning vendor workflow vocabulary into core API shape.
+
+---
+
+## 2. Persistence Model
+
+### 2.1 `User` remains canonical
+
+Canonical imported identity fields continue to live on `User`:
+
+* `auth_provider_id`
+* `external_id`
+* `username`
+* `display_name`
+* `email`
+
+Do **not** add `User.metadata` for provider-specific directory attributes.
+
+### 2.2 New `UserDirectoryProfile` projection
+
+File: `ent/schema/user_directory_profile.go`
+
+```go
+package schema
+
+import (
+    "entgo.io/ent"
+    "entgo.io/ent/schema/edge"
+    "entgo.io/ent/schema/field"
+)
+
+// UserDirectoryProfile stores non-authoritative raw directory attributes.
+type UserDirectoryProfile struct {
+    ent.Schema
+}
+
+func (UserDirectoryProfile) Mixin() []ent.Mixin {
+    return []ent.Mixin{TimeMixin{}}
+}
+
+func (UserDirectoryProfile) Fields() []ent.Field {
+    return []ent.Field{
+        field.String("id").Unique().Immutable(),
+        field.JSON("attributes", map[string]interface{}{}).
+            Comment("Raw provider-specific directory attributes; informational only"),
+        field.Time("last_synced_at"),
+    }
+}
+
+func (UserDirectoryProfile) Edges() []ent.Edge {
+    return []ent.Edge{
+        edge.From("user", User.Type).Ref("directory_profile").Unique().Required(),
+    }
+}
+```
+
+Rule:
+
+* `UserDirectoryProfile.attributes` is display/audit data only.
+* Auth/RBAC/approval/policy/runtime code must not read it for authoritative
+  behavior.
+
+### 2.3 `DirectorySyncJob`
+
+File: `ent/schema/directory_sync_job.go`
+
+```go
+type DirectorySyncJob struct {
+    ent.Schema
+}
+
+func (DirectorySyncJob) Fields() []ent.Field {
+    return []ent.Field{
+        field.String("id").Unique().Immutable(),
+        field.String("auth_provider_id").NotEmpty(),
+        field.Enum("status").
+            Values("pending", "running", "completed", "failed").
+            Default("pending"),
+        field.JSON("request_snapshot", map[string]interface{}{}).
+            Comment("Opaque provider_request payload frozen at trigger time"),
+        field.String("conflict_resolution").Default("skip"),
+        field.Int("total_entries").Default(0),
+        field.Int("created_count").Default(0),
+        field.Int("updated_count").Default(0),
+        field.Int("skipped_count").Default(0),
+        field.Int("error_count").Default(0),
+        field.JSON("errors", []string{}).Optional(),
+        field.String("triggered_by").NotEmpty(),
+        field.Time("started_at").Optional().Nillable(),
+        field.Time("completed_at").Optional().Nillable(),
+    }
+}
+```
+
+---
+
+## 3. Conflict Classification
+
+Conflict classification happens before writes.
+
+### 3.1 Required classes
+
+| Code | Meaning | Typical action |
+|------|---------|----------------|
+| `same_external_identity` | Same `(auth_provider_id, external_id)` | update / skip |
+| `username_conflict` | `username` already belongs to another user | error or manual resolve |
+| `email_conflict` | `email` already belongs to another user | error or manual resolve |
+| `ambiguous_existing_user` | Existing local/imported user cannot be safely linked | error |
+
+### 3.2 Worker rule
+
+The worker must not treat a database unique violation as normal conflict
+classification. It must resolve conflicts first, then write.
+
+### 3.3 Preview rule
+
+Preview responses include canonical `conflicts` so administrators see how a sync
+will behave before enqueue.
+
+---
+
+## 4. API Shape
+
+### 4.1 `GET /admin/auth-providers/{id}/directory/descriptor`
+
+Returns capability metadata:
+
+```json
+{
+  "display_name": "WeCom Directory Sync",
+  "description": "Import users from enterprise contacts",
+  "supports_preview": true,
+  "request_schema": {
+    "type": "object",
+    "properties": {
+      "departments": { "type": "array", "items": { "type": "string" } },
+      "include_nested": { "type": "boolean", "default": true },
+      "selected_fields": { "type": "array", "items": { "type": "string" } }
+    }
+  }
+}
+```
+
+The same endpoint for another provider might expose a completely different
+schema. Core must not care.
+
+### 4.2 `POST /admin/auth-providers/{id}/directory/preview`
+
+Request:
+
+```json
+{
+  "provider_request": {
+    "departments": ["2", "3"],
+    "include_nested": true
+  },
+  "conflict_resolution": "skip"
+}
+```
+
+Response:
+
+```json
+{
+  "total_count": 2,
+  "items": [
+    {
+      "record": {
+        "external_id": "zhangsan",
+        "username": "zhangsan",
+        "display_name": "张三",
+        "email": "zhangsan@example.com",
+        "groups": ["tech"],
+        "attributes": { "department_name": "技术部" }
+      },
+      "conflicts": []
+    }
+  ]
+}
+```
+
+### 4.3 `POST /admin/auth-providers/{id}/directory/sync`
+
+Request:
+
+```json
+{
+  "provider_request": {
+    "departments": ["2", "3"],
+    "include_nested": true
+  },
+  "conflict_resolution": "skip"
+}
+```
+
+Response:
+
+```json
+{
+  "job_id": "dsj_abc123",
+  "status": "pending"
+}
+```
+
+### 4.4 `GET /admin/auth-providers/{id}/directory/sync-jobs`
+
+Standard paginated list response.
+
+### 4.5 `GET /admin/auth-providers/{id}/directory/sync-jobs/{jobId}`
+
+Returns job summary and counts only. It does not expose provider workflow
+internals as first-class fields.
+
+---
+
+## 5. Worker Flow
+
+File: `internal/jobs/directory_sync_worker.go`
+
+### 5.1 Job args
+
+```go
+type DirectorySyncArgs struct {
+    AuthProviderID string `json:"auth_provider_id"`
+    JobID          string `json:"job_id"`
+}
+```
+
+### 5.2 Execution steps
+
+1. Load auth provider and job row
+2. Resolve adapter from auth-provider registry
+3. Type-assert `DirectorySyncCapability`
+4. Load `request_snapshot` and `conflict_resolution`
+5. Call `ListDirectoryUsers(config, request_snapshot)`
+6. For each canonical `DirectoryUserRecord`:
+   - classify conflicts
+   - create/update canonical `User`
+   - upsert `UserDirectoryProfile.attributes`
+7. Update `DirectorySyncJob` counters
+
+### 5.3 Explicit non-goals
+
+The worker must not:
+
+* parse provider-specific request keys
+* branch on provider type
+* treat raw attributes as authoritative core data
+
+---
+
+## 6. Frontend Integration
+
+### 6.1 Reuse schema-driven form machinery
+
+The existing auth-provider admin UI already renders `config_schema` dynamically.
+Directory sync should follow the same pattern:
+
+* fetch `descriptor`
+* render `descriptor.request_schema`
+* send opaque `provider_request`
+* display canonical preview table and job list
+
+### 6.2 Default UI is generic, not prescriptive
+
+Core may ship a default request form and preview table, but that UI must be
+generic:
+
+* no hardcoded department tree assumption
+* no hardcoded attribute selector assumption
+* no provider-type `switch` in frontend
+
+### 6.3 Future extension
+
+If the platform later gains frontend plugin surfaces, providers may supply richer
+custom UX without changing the backend contract defined here.
+
+---
+
+## 7. Acceptance Criteria
+
+* Adapters without `DirectorySyncCapability` return `501` from directory-sync endpoints.
+* The request payload is always carried under `provider_request`; handlers/workers do not inspect provider-specific keys.
+* `go test ./internal/jobs/... -run TestDirectorySyncWorker` covers conflict classification for `external_id`, `username`, and `email`.
+* `go test ./internal/api/handlers/... -run TestDirectorySyncPreviewUsesOpaqueProviderRequest` proves handler code never parses vendor-specific request keys.
+* `UserDirectoryProfile.attributes` is never read by auth/RBAC/approval/runtime paths.
+* CI auth-provider boundary checks keep passing.
+
+## Revisit Conditions
+
+- frontend plugin/runtime extension becomes available
+- multi-provider identity linking is introduced
+- scheduled or push-based sync becomes first-class
+- raw profile data needs lifecycle separate from imported user linkage


### PR DESCRIPTION
## Summary
Atomic docs PR for ADR-0048 proposal only.

## Scope
- Add `docs/adr/ADR-0048-directory-sync-capability.md` (status: `proposed`)
- Add `docs/design/notes/ADR-0048-directory-sync-capability.md`
- Update `docs/adr/README.md` index for ADR-0048

## Governance
- ADR-0048 remains `proposed`
- This PR is limited to the ADR review package only
- No normative design-spec changes
- No implementation code
- No generated/runtime artifacts

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

## Tracking
- Refs #396