### PR TITLE
docs(adr): refine ADR-0048 review package

### DIFF
--- a/docs/adr/ADR-0048-directory-sync-capability.md
+++ b/docs/adr/ADR-0048-directory-sync-capability.md
@@ -49,6 +49,7 @@ canonical import result in core?
 * **ADR-0035 plugin boundary**: Core auth/RBAC runtime must remain plugin-standard and provider-agnostic.
 * **ADR-0024 capability composition**: Directory sync must remain an optional capability, not a mandatory expansion of `AuthProviderAdminAdapter`.
 * **ADR-0026 standardized provider output**: Core must consume canonical identity fields, not vendor-specific field names or flow steps.
+* **ADR-0021 contract-first governance**: The directory-sync API must stay provider-agnostic at the HTTP contract boundary even when providers use different request shapes.
 * **Core philosophy**: Core only governs consistent results; provider-specific process belongs at the edge.
 * **Identity safety**: Sync must respect global `User` invariants such as username/email uniqueness and stable external identity linkage.
 * **ADR-0006 async model**: Bulk directory import remains an async job.
@@ -168,6 +169,9 @@ The approved API surface is:
 | `GET` | `/admin/auth-providers/{id}/directory/sync-jobs` | List sync jobs |
 | `GET` | `/admin/auth-providers/{id}/directory/sync-jobs/{jobId}` | Get one sync job |
 
+`preview` is a synchronous read-only operation over provider-owned request
+input. `sync` enqueues an asynchronous import job per ADR-0006.
+
 The earlier dedicated `/departments` and `/attributes` endpoints are rejected as
 universal core concepts.
 
@@ -230,6 +234,7 @@ canonical import results.
 
 * `ADR-0035-auth-provider-plugin-boundary.md` — Auth providers remain plugin-standard and discoverable.
 * `ADR-0024-provider-interface-capability-composition.md` — Optional capability composition pattern.
+* `ADR-0021-api-contract-first.md` — Contract-first governance for the standardized directory-sync API surface.
 * `ADR-0026-idp-config-naming.md` — Canonical provider output contract and adapter-only normalization.
 * `ADR-0041-power-operation-approval-requirement-service.md` — Parallel precedent: core keeps canonical semantics, provider routing stays peripheral.
 * `ADR-0006-unified-async-model.md` — Async execution model for sync jobs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -161,6 +161,18 @@ For newcomers, we recommend reading ADRs in this order:
 4. Submit for review with a GitHub Issue
 5. After 48-hour review period, update status to `Accepted` or `Rejected`
 
+### ADR Relationship Markers
+
+Use relationship markers only when they communicate a real dependency between
+decisions:
+
+* `Supersedes`: the new ADR replaces an older decision.
+* `Amends`: the new ADR changes or clarifies a specific section of an accepted ADR.
+* `Extends`: the new ADR builds on an existing decision without changing its normative meaning, typically by adding an adjacent capability or applying the same boundary/pattern in a new area.
+
+`Extends` is not a substitute for `Amends` or `Supersedes`. If the old decision
+is being changed, use those markers instead.
+
 ### Proposed ADRs and Pending Changes
 
 When an ADR is **Proposed**, do NOT edit normative design specs.
@@ -205,6 +217,9 @@ Accepted ADRs are **immutable**. To change a decision:
 1. **Minor Clarification**: Create a new ADR with `Amends: ADR-XXXX §X`
 2. **Major Change**: Create a new ADR with `Supersedes: ADR-XXXX`
 3. **Append Only**: Add an "Amendments by Subsequent ADRs" block at the END of the original ADR
+
+If a new ADR only builds on an accepted decision without modifying it, use
+`Extends` and leave the original ADR unchanged.
 
 ---
 

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -12,7 +12,8 @@ informed: []  # Stakeholders kept up-to-date (one-way communication)
 > **Review Period**: Until YYYY-MM-DD (48-hour minimum)<br>
 > **Discussion**: [Issue #XX](https://github.com/kv-shepherd/shepherd/issues/XX)<br>
 > **Supersedes**: `ADR-XXXX-xxx.md` *(if applicable)*<br>
-> **Amends**: `ADR-XXXX-xxx.md#section-anchor` *(if applicable)*
+> **Amends**: `ADR-XXXX-xxx.md#section-anchor` *(if applicable)*<br>
+> **Extends**: `ADR-XXXX-xxx.md` *(if applicable; use only when building on a prior ADR without modifying it)*
 
 ---
 

--- a/docs/design/notes/ADR-0048-directory-sync-capability.md
+++ b/docs/design/notes/ADR-0048-directory-sync-capability.md
@@ -109,6 +109,21 @@ Core is not allowed to know:
 This keeps the interface small and stable while avoiding the earlier mistake of
 turning vendor workflow vocabulary into core API shape.
 
+### 1.4 Public plugin SDK exposure
+
+Implementation must expose the directory-sync capability through the public
+plugin SDK, not only through `internal/provider`.
+
+Required follow-up at implementation time:
+
+* re-export `DirectorySyncCapability` from `pkg/authproviderplugin`
+* re-export the canonical directory-sync DTOs used by plugin authors
+* keep third-party plugins from importing `internal/provider` directly
+
+This follows the shared-SDK pattern already used for admin auth-provider
+plugins and keeps the host/plugin contract small, stable, and importable by
+external plugin code.
+
 ---
 
 ## 2. Persistence Model
@@ -288,6 +303,10 @@ Response:
 }
 ```
 
+This endpoint is synchronous and read-only. It validates the opaque
+`provider_request`, asks the adapter for a canonical preview, and does not
+enqueue a River job.
+
 ### 4.3 `POST /admin/auth-providers/{id}/directory/sync`
 
 Request:
@@ -310,6 +329,9 @@ Response:
   "status": "pending"
 }
 ```
+
+This endpoint is asynchronous. It freezes `provider_request` into
+`DirectorySyncJob.request_snapshot` and enqueues the River worker.
 
 ### 4.4 `GET /admin/auth-providers/{id}/directory/sync-jobs`
 
@@ -392,6 +414,7 @@ custom UX without changing the backend contract defined here.
 * The request payload is always carried under `provider_request`; handlers/workers do not inspect provider-specific keys.
 * `go test ./internal/jobs/... -run TestDirectorySyncWorker` covers conflict classification for `external_id`, `username`, and `email`.
 * `go test ./internal/api/handlers/... -run TestDirectorySyncPreviewUsesOpaqueProviderRequest` proves handler code never parses vendor-specific request keys.
+* `pkg/authproviderplugin` re-exports the directory-sync capability and canonical DTOs needed by third-party auth-provider plugins.
 * `UserDirectoryProfile.attributes` is never read by auth/RBAC/approval/runtime paths.
 * CI auth-provider boundary checks keep passing.
 


### PR DESCRIPTION
## Summary
Refine the ADR-0048 public-review package with governance and contract clarifications.

## Scope
- update `docs/adr/README.md`
- update `docs/adr/TEMPLATE.md`
- refine `docs/adr/ADR-0048-directory-sync-capability.md`
- refine `docs/design/notes/ADR-0048-directory-sync-capability.md`

## Constraints
- ADR-0048 remains `proposed`
- docs only
- no normative implementation code
- no generated/runtime artifacts

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

## Tracking
- Refs #396