### PR TITLE
docs(adr): fix ADR-0047 review metadata

### DIFF
--- a/docs/adr/ADR-0047-vm-status-granular-lifecycle-states.md
+++ b/docs/adr/ADR-0047-vm-status-granular-lifecycle-states.md
@@ -12,7 +12,7 @@ informed: ["@jindyzhao"]
 > **Status**: 🔍 Public Review — 48-hour minimum comment window<br>
 > **Review Open**: 2026-03-18<br>
 > **Review Closes**: 2026-03-20 (earliest merge date)<br>
-> **Discussion**: [Code Review 2026-03-18](https://github.com/kv-shepherd/shepherd/issues/)<br>
+> **Discussion**: [Issue #389](https://github.com/kv-shepherd/shepherd/issues/389)<br>
 > **Amends**: `ADR-0038-adaptive-k8s-polling.md#§1-polling-frequency-tiers` *(adds two new states to tier classification)*
 >
 > 📝 **Design Note**: Implementation code (vm_status_sync.go, ent schema, migration) lands in a separate implementation PR **after** this ADR is accepted.


### PR DESCRIPTION
## Summary
Fix the `Discussion` link in the proposed ADR-0047 review package so it points to the actual public-review issue.

## Scope
- update `docs/adr/ADR-0047-vm-status-granular-lifecycle-states.md`

## Constraints
- ADR-0047 remains `proposed`
- docs only
- no normative design-spec changes
- no implementation code
- no generated/runtime artifacts

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

## Tracking
- Refs #389