### PR TITLE
docs(adr): publish ADR-0049 review package

### DIFF
--- a/docs/adr/ADR-0048-directory-sync-capability.md
+++ b/docs/adr/ADR-0048-directory-sync-capability.md
@@ -49,6 +49,7 @@ canonical import result in core?
 * **ADR-0035 plugin boundary**: Core auth/RBAC runtime must remain plugin-standard and provider-agnostic.
 * **ADR-0024 capability composition**: Directory sync must remain an optional capability, not a mandatory expansion of `AuthProviderAdminAdapter`.
 * **ADR-0026 standardized provider output**: Core must consume canonical identity fields, not vendor-specific field names or flow steps.
+* **ADR-0049 external auth/runtime standard**: normalized external cohorts may be carried for display and mapping input, but they are not direct permissions.
 * **ADR-0021 contract-first governance**: The directory-sync API must stay provider-agnostic at the HTTP contract boundary even when providers use different request shapes.
 * **Core philosophy**: Core only governs consistent results; provider-specific process belongs at the edge.
 * **Identity safety**: Sync must respect global `User` invariants such as username/email uniqueness and stable external identity linkage.
@@ -112,11 +113,13 @@ core persistence:
 | `username` | Canonical Shepherd username candidate |
 | `display_name` | Canonical Shepherd display name |
 | `email` | Canonical Shepherd email candidate |
-| `groups` | Normalized group list if provider can supply it |
+| `cohorts` | Normalized external cohort refs if provider can supply them |
 | `attributes` | Provider-specific raw attributes for display/audit only |
 
-Core auth/RBAC/approval/runtime logic must depend only on canonical fields and
-must not branch on provider-specific attribute keys.
+Core auth/RBAC/approval/runtime logic must depend only on canonical identity
+fields and must not branch on provider-specific attribute keys or cohort kinds.
+Normalized cohorts are informational and may be consumed only by explicit
+mapping or batch-management services that produce Shepherd RBAC records.
 
 #### 4. Conflict classification is a core responsibility
 
@@ -236,6 +239,7 @@ canonical import results.
 * `ADR-0024-provider-interface-capability-composition.md` — Optional capability composition pattern.
 * `ADR-0021-api-contract-first.md` — Contract-first governance for the standardized directory-sync API surface.
 * `ADR-0026-idp-config-naming.md` — Canonical provider output contract and adapter-only normalization.
+* `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` — JIT user-center rule and normalized external-cohort semantics.
 * `ADR-0041-power-operation-approval-requirement-service.md` — Parallel precedent: core keeps canonical semantics, provider routing stays peripheral.
 * `ADR-0006-unified-async-model.md` — Async execution model for sync jobs.
 
@@ -262,3 +266,4 @@ Revisit this ADR if:
 |------|--------|--------|
 | 2026-03-19 | @jindyzhao | Initial process-first draft published for review |
 | 2026-03-19 | @jindyzhao | Reworked to result-first contract: provider-owned workflow, core-owned canonical import semantics |
+| 2026-03-20 | @jindyzhao | Aligned canonical import wording with normalized external-cohort standard from ADR-0049 draft |

--- a/docs/adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
+++ b/docs/adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
@@ -1,0 +1,294 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-03-20
+deciders: ["@jindyzhao"]
+consulted: ["@jindyzhao"]
+informed: ["@jindyzhao"]
+---
+
+# ADR-0049: External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping
+
+> **Status**: 🔍 Public Review — 48-hour minimum comment window<br>
+> **Review Open**: 2026-03-20<br>
+> **Review Closes**: 2026-03-22 (earliest merge date)<br>
+> **Discussion**: [Issue #400](https://github.com/kv-shepherd/shepherd/issues/400)<br>
+> **Amends**: `ADR-0026-idp-config-naming.md#standard-provider-output-contract` *(clarifies runtime auth result shape, non-authoritative profile data, and cohort normalization)*<br>
+> **Amends**: `ADR-0035-auth-provider-plugin-boundary.md` *(extends the auth-provider boundary from admin/discovery into runtime login and callback execution)*<br>
+> **Amends**: `ADR-0015-governance-model-v2.md` *(clarifies that external identity data may drive RoleBinding automation, but permissions remain platform-owned)*<br>
+> **Extends**: `ADR-0048-directory-sync-capability.md` *(keeps directory sync optional/scoped instead of the default user-center construction path)*
+>
+> 📝 **Design Note**: implementation-facing details and the WeCom first-provider plan are captured in `docs/design/notes/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md`.
+
+---
+
+## Context and Problem Statement
+
+The project already treats auth-provider configuration and admin discovery as a
+plugin boundary, but runtime login is still not governed by the same standard.
+At the same time, enterprise providers such as WeCom, OIDC, LDAP, and future
+SSO adapters expose different login workflows and different organizational data
+shapes.
+
+The platform needs a stricter rule set before implementing the first external
+runtime provider:
+
+* external login workflow must stay at the provider edge
+* the core user center must remain canonical and minimal
+* platform permissions must remain owned by Shepherd RBAC, not by vendor claims
+* external organization data must help administrators batch-manage RBAC without
+  becoming direct runtime authority
+
+**Core question**: how should Shepherd standardize runtime external
+authentication, user-center provisioning, and external organization mapping so
+that WeCom can be the first provider implementation without pushing vendor
+workflow into core?
+
+## Decision Drivers
+
+* **ADR-0035 plugin boundary**: auth providers must remain plugin-standard and provider-agnostic at runtime, not only in admin CRUD.
+* **ADR-0026 normalized identity contract**: core must consume canonical identity data instead of provider-specific claims or callback fields.
+* **ADR-0015 platform RBAC**: authorization decisions must remain based on Shepherd roles and bindings.
+* **ADR-0048 optional sync capability**: directory import is optional and scoped, not the default user-center construction path.
+* **Core philosophy**: core only defines stable standards and outcomes; provider-specific processes stay at the edge.
+* **Operational fit**: storing a full enterprise directory by default is wasteful for V1 and creates avoidable sync/conflict overhead.
+* **Admin usability**: external groups/departments/tags should still help batch authorization workflows.
+* **Contract-first governance**: runtime auth endpoints and DTOs must be standardized before implementation.
+
+## Considered Options
+
+* **Option 1**: Keep runtime login hardcoded in core and add external providers case by case
+* **Option 2**: Standardize runtime auth plugins, JIT user provisioning, and platform-owned RBAC mapping from normalized external cohorts (chosen)
+* **Option 3**: Mirror full external directories into Shepherd and authorize directly from provider groups/departments
+
+## Decision Outcome
+
+**Chosen option**: **"Option 2: Standardize runtime auth plugins, JIT user
+provisioning, and platform-owned RBAC mapping from normalized external
+cohorts"**, because it keeps the core canonical and provider-agnostic while
+still letting external identity systems improve administrator workflows.
+
+### Normative Decisions
+
+#### 1. External auth runtime must use the auth-provider plugin boundary end to end
+
+For external auth providers, runtime login must resolve a provider adapter via
+the auth-provider registry and must not hardcode vendor branches in core.
+
+The provider owns:
+
+* login-mode specifics
+* redirect/callback parameter semantics
+* token exchange
+* remote user-info fetch
+* provider-specific validation quirks
+
+The core owns:
+
+* request routing
+* CSRF/state correlation primitives
+* canonical auth-result validation
+* JIT user upsert
+* Shepherd JWT/session issuance
+* auditability and error normalization
+
+#### 2. JIT provisioning is the default user-center rule for all external auth providers
+
+All external auth providers must default to **just-in-time provisioning**:
+
+* a user is created or updated when they successfully log in
+* the platform stores users who have logged in or who were explicitly imported
+  by an administrator
+* full-directory mirroring is not the default construction path for the user
+  center
+
+`DirectorySyncCapability` remains optional per ADR-0048 and is used only for
+scoped pre-provisioning or administrative import workflows.
+
+#### 3. Core user identity remains canonical and minimal
+
+The authoritative identity model remains the canonical Shepherd `User` plus the
+stable external link:
+
+| Field | Purpose |
+|-------|---------|
+| `auth_provider_id` | Which provider instance authenticated the user |
+| `external_id` | Stable provider-side identity key |
+| `username` | Canonical Shepherd username |
+| `display_name` | Canonical Shepherd display name |
+| `email` | Canonical Shepherd email candidate |
+| `enabled` | Whether the user is active in Shepherd |
+
+Provider-specific claims or profile blobs must not become authoritative user
+fields in core.
+
+#### 4. External organization data must be normalized as external cohorts
+
+Core must not standardize vendor terms such as "OIDC groups", "LDAP OUs",
+"WeCom departments", or "enterprise tags" as separate first-class core models.
+
+Instead, providers may normalize them into a common **external cohort** shape:
+
+| Field | Purpose |
+|-------|---------|
+| `kind` | Cohort type such as `group`, `department`, `ou`, `tag` |
+| `key` | Stable provider-scoped cohort identifier |
+| `display_name` | Human-readable label |
+
+External cohorts are **not permissions**. They are input for display, filtering,
+and explicit RBAC mapping only.
+
+#### 5. Platform RBAC remains the sole authorization authority
+
+Runtime authorization checks must read only Shepherd RBAC state such as:
+
+* `Role`
+* `RoleBinding`
+* `ResourceRoleBinding`
+
+Runtime authorization must not directly read:
+
+* OIDC claims/groups
+* LDAP groups/OUs
+* WeCom departments/tags
+* raw profile attributes
+
+External cohorts may only affect access after they are transformed into
+Shepherd-managed RBAC records through explicit mapping rules or administrator
+actions.
+
+#### 6. External cohort mapping is allowed, but it maps into Shepherd RBAC
+
+The platform may support mapping rules such as:
+
+* external cohort -> Shepherd role
+* external cohort -> allowed environments
+* external cohort -> scoped resource binding policy
+
+But the persisted runtime result must always be Shepherd RBAC records.
+
+This means:
+
+* external identity data may trigger or maintain auto-managed RoleBindings
+* administrators may batch-grant RBAC using cohort membership as a selector
+* removing or changing a mapping changes future Shepherd-managed bindings
+* permission evaluation still reads only Shepherd RBAC tables
+
+#### 7. Supplemental external profile data is display-only and stored outside authoritative core fields
+
+Providers may return supplemental profile data such as:
+
+* phone number
+* preferred name
+* localized name
+* job title
+* department label
+* avatar URL
+
+These values must be stored in a dedicated projection separate from
+authoritative `User` fields. They are informational only and must not drive:
+
+* authentication success
+* RBAC
+* approval policy
+* runtime orchestration
+* validation rules
+
+#### 8. One provider may expose multiple login modes without changing the core contract
+
+A provider may support multiple login modes under the same provider type.
+
+Example:
+
+* WeCom QR login for desktop/browser use
+* WeCom in-app web authorization for users already inside the WeCom client
+
+Core must see these only as provider-defined login modes behind one runtime
+contract. Core must not fork business logic per vendor login mode.
+
+### Consequences
+
+* ✅ Good, because WeCom/OIDC/LDAP can share one runtime auth standard without flattening their provider workflows into core.
+* ✅ Good, because the user center stores only users who matter to the platform by default.
+* ✅ Good, because administrators can still batch-manage permissions using external organization signals.
+* ✅ Good, because platform authorization remains auditable and deterministic in Shepherd RBAC.
+* ✅ Good, because directory sync remains optional and scoped instead of becoming a mandatory enterprise directory mirror.
+* 🟡 Neutral, because providers now need both runtime-auth adaptation and optional sync adaptation.
+* 🟡 Neutral, because existing group-only wording in older ADRs/design docs must be generalized to cohort wording over time.
+* ❌ Bad, because this ADR rejects the simpler but weaker "read provider claims directly during authorization" pattern.
+
+### Confirmation
+
+* Runtime external-auth handlers resolve providers via registry only.
+* No runtime path hardcodes WeCom/OIDC/LDAP vendor branches in core auth flow.
+* JIT login tests prove successful external login can create and update canonical users.
+* Authorization tests prove permission checks do not read external cohorts or raw profile attributes directly.
+* Mapping tests prove external cohorts only affect access through persisted Shepherd RBAC records.
+* Directory-sync tests continue to prove sync is optional and scoped, not the default user-center construction path.
+* CI architecture checks block provider-specific workflow leakage into runtime auth and directory-sync core paths.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Keep runtime login hardcoded in core
+
+Continue using provider-specific branches and special cases in runtime login.
+
+* ✅ Good, because the first provider can be added quickly.
+* ❌ Bad, because each new provider reopens core auth flow and increases drift.
+* ❌ Bad, because it conflicts with ADR-0035's plugin-standard direction.
+
+### Option 2: Runtime plugin standard + JIT + platform-owned RBAC mapping (Chosen)
+
+Providers own login workflow; core owns canonical user records and RBAC state.
+
+* ✅ Good, because it cleanly separates provider process from core standards.
+* ✅ Good, because it scales from WeCom to OIDC/LDAP without redefining the core user center.
+* ✅ Good, because it lets departments/groups/tags help admin workflows without becoming direct permissions.
+* 🟡 Neutral, because provider and mapping contracts must be defined carefully up front.
+
+### Option 3: Full mirrored directory + direct external authorization
+
+Mirror whole directories by default and treat external org data as runtime
+authority.
+
+* ✅ Good, because some enterprise admin operations appear convenient at first.
+* ❌ Bad, because it makes the core user center vendor-shaped and operationally heavy.
+* ❌ Bad, because runtime permissions become dependent on external provider semantics instead of Shepherd RBAC.
+* ❌ Bad, because it conflicts with the project's "core standard, edge process" philosophy.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* `ADR-0015-governance-model-v2.md` — Shepherd RBAC remains authoritative.
+* `ADR-0021-api-contract-first.md` — runtime auth APIs and DTOs must be standardized before implementation.
+* `ADR-0026-idp-config-naming.md` — normalized provider output remains the adapter contract.
+* `ADR-0035-auth-provider-plugin-boundary.md` — auth providers remain plugin-standard.
+* `ADR-0048-directory-sync-capability.md` — directory sync remains optional and result-first.
+
+### References
+
+* [HashiCorp go-plugin tutorial](https://github.com/hashicorp/go-plugin/blob/main/docs/extensive-go-plugin-tutorial.md)
+* [Backstage external integrations](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/external-integrations.md)
+* [SCIM Core Schema RFC 7643](https://www.rfc-editor.org/rfc/rfc7643.html)
+
+### Implementation Notes
+
+Revisit this ADR if:
+
+* Shepherd decides to support true multi-provider account linking as a first-class identity model
+* external providers need custom hosted login UIs beyond redirect/callback patterns
+* tenant boundaries require organization data to affect more than display, filtering, and mapping inputs
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-20 | @jindyzhao | Initial draft |
+| 2026-03-20 | @jindyzhao | Published for 48-hour public review |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,7 +57,8 @@
 | [ADR-0045](./ADR-0045-cluster-resolved-root-volume-provisioning.md) | Cluster-Resolved Root Volume Provisioning Intent | **Accepted** | - |
 | [ADR-0046](./ADR-0046-schema-mask-field-visibility-tiers.md) | Schema Mask Field Visibility Tiers | **Accepted** | - |
 | [ADR-0047](./ADR-0047-vm-status-granular-lifecycle-states.md) | Granular VM Lifecycle States (STARTING / NOT_FOUND) | **Proposed** | - |
-| [ADR-0048](./ADR-0048-directory-sync-capability.md) | Directory Sync Capability for Auth Providers | **Proposed** | Result-first contract: provider-owned workflow, core-owned canonical import semantics |
+| [ADR-0048](./ADR-0048-directory-sync-capability.md) | Directory Sync Capability for Auth Providers | **Proposed** | Result-first contract: provider-owned workflow, core-owned canonical user/cohort import semantics |
+| [ADR-0049](./ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md) | External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping | **Proposed** | Unified external-auth standard: JIT user center, provider-owned workflow, platform-owned RBAC |
 
 > ℹ️ **ADR-0037 Sync Notes**:
 >
@@ -129,7 +130,8 @@ For newcomers, we recommend reading ADRs in this order:
 19. **ADR-0045** (Cluster-Resolved Root Volume Provisioning, **Accepted**) → Clarifies where storage `auto` intent may exist and when approval must resolve explicit root-volume provisioning values
 20. **ADR-0046** (Schema Mask Field Visibility Tiers, **Accepted**) → Formalizes `professional_fields` as a UI-only expert-tier in SchemaMask
 21. **ADR-0047** (Granular VM Lifecycle States, **Proposed** 🔍 48-hr review window) → Adds `STARTING` and `NOT_FOUND` as first-class VM status values with polling/delete integration
-22. **ADR-0048** (Directory Sync Capability, **Proposed** 🔍 48-hr review window) → Adds provider-owned sync request schema with core-owned canonical user-import/result semantics
+22. **ADR-0048** (Directory Sync Capability, **Proposed** 🔍 48-hr review window) → Adds provider-owned sync request schema with core-owned canonical user/cohort import semantics
+23. **ADR-0049** (External Auth Runtime, **Proposed** 🔍 48-hr review window) → Defines unified external-auth runtime, JIT user-center provisioning, and external cohort to platform RBAC mapping
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/docs/design/notes/ADR-0048-directory-sync-capability.md
+++ b/docs/design/notes/ADR-0048-directory-sync-capability.md
@@ -4,7 +4,7 @@
 > **Related ADR**: [ADR-0048](../../adr/ADR-0048-directory-sync-capability.md)
 > **Owner**: @jindyzhao
 > **Created**: 2026-03-19
-> **Last Updated**: 2026-03-19
+> **Last Updated**: 2026-03-20
 
 ## Summary
 
@@ -18,6 +18,9 @@ Instead:
   async job semantics, and persistence invariants
 
 This note captures the implementation shape that follows that boundary.
+
+It also aligns the preview/import record wording with the normalized
+`external cohort` standard introduced in the ADR-0049 draft.
 
 ## Scope
 
@@ -52,13 +55,19 @@ type DirectorySyncDescriptor struct {
     SupportsPreview bool                   `json:"supports_preview"`
 }
 
+type DirectoryCohortRef struct {
+    Kind        string `json:"kind"`
+    Key         string `json:"key"`
+    DisplayName string `json:"display_name,omitempty"`
+}
+
 // DirectoryUserRecord is the canonical user-import contract consumed by core.
 type DirectoryUserRecord struct {
     ExternalID  string                 `json:"external_id"`
     Username    string                 `json:"username"`
     DisplayName string                 `json:"display_name"`
     Email       string                 `json:"email,omitempty"`
-    Groups      []string               `json:"groups,omitempty"`
+    Cohorts     []DirectoryCohortRef   `json:"cohorts,omitempty"`
     Attributes  map[string]interface{} `json:"attributes,omitempty"` // raw provider attributes, non-authoritative
 }
 
@@ -103,6 +112,10 @@ Core is not allowed to know:
 * whether the provider selected departments, groups, OUs, tags, filters, or cursors
 * provider-specific request keys
 * provider-specific attribute names outside the raw `attributes` blob
+
+Normalized cohorts are non-authoritative organizational references. They may be
+used later by explicit mapping/batch-management services, but they are not
+runtime permissions.
 
 ### 1.3 Why this shape
 
@@ -292,10 +305,13 @@ Response:
       "record": {
         "external_id": "zhangsan",
         "username": "zhangsan",
-        "display_name": "张三",
+        "display_name": "Zhang San",
         "email": "zhangsan@example.com",
-        "groups": ["tech"],
-        "attributes": { "department_name": "技术部" }
+        "cohorts": [
+          { "kind": "department", "key": "wecom:department:2", "display_name": "Engineering" },
+          { "kind": "tag", "key": "wecom:tag:tech", "display_name": "Tech" }
+        ],
+        "attributes": { "department_name": "Engineering" }
       },
       "conflicts": []
     }
@@ -416,6 +432,7 @@ custom UX without changing the backend contract defined here.
 * `go test ./internal/api/handlers/... -run TestDirectorySyncPreviewUsesOpaqueProviderRequest` proves handler code never parses vendor-specific request keys.
 * `pkg/authproviderplugin` re-exports the directory-sync capability and canonical DTOs needed by third-party auth-provider plugins.
 * `UserDirectoryProfile.attributes` is never read by auth/RBAC/approval/runtime paths.
+* provider results may expose normalized cohorts beyond plain groups without changing the core contract.
 * CI auth-provider boundary checks keep passing.
 
 ## Revisit Conditions

--- a/docs/design/notes/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
+++ b/docs/design/notes/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
@@ -1,0 +1,315 @@
+# Design Note: ADR-0049 — External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping
+
+> **Status**: Proposed (ADR-0049 under review until 2026-03-22)
+> **Related ADR**: [ADR-0049](../../adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md)
+> **Owner**: @jindyzhao
+> **Created**: 2026-03-20
+> **Last Updated**: 2026-03-20
+
+## Summary
+
+This note captures the intended implementation shape for a unified external-auth
+runtime standard:
+
+* external providers plug into runtime login/callback through a shared contract
+* successful external login uses JIT provisioning by default
+* the canonical user center stores only logged-in or explicitly imported users
+* external groups/departments/tags are normalized into `external cohorts`
+* external cohorts may drive Shepherd RBAC automation, but never become direct
+  runtime permissions
+
+WeCom is the first provider practice for this standard, not a special core
+exception.
+
+## Scope
+
+- In scope: runtime auth plugin seam for external providers
+- In scope: JIT user provisioning on successful external login
+- In scope: normalized external cohort projection and mapping into Shepherd RBAC
+- In scope: display-only supplemental profile projection
+- In scope: WeCom as the first provider implementation under the shared standard
+- Out of scope: provider-specific workflow branches in core auth handlers
+- Out of scope: default full-directory mirroring to construct the user center
+- Out of scope: using external claims/cohorts directly during runtime authorization
+
+---
+
+## 1. Runtime Contract
+
+### 1.1 Public plugin SDK
+
+Implementation should extend the public plugin SDK, not `internal/provider`,
+with a runtime contract similar to:
+
+* `pkg/authproviderplugin/runtime.go`
+* `internal/provider/auth_runtime.go`
+
+The shared contract should stay small and stable:
+
+```go
+package provider
+
+import "context"
+
+type ExternalCohort struct {
+    Kind        string `json:"kind"`
+    Key         string `json:"key"`
+    DisplayName string `json:"display_name,omitempty"`
+}
+
+type AuthProfileAttributes map[string]interface{}
+
+type AuthResult struct {
+    ExternalID        string                `json:"external_id"`
+    Username          string                `json:"username"`
+    DisplayName       string                `json:"display_name"`
+    Email             string                `json:"email,omitempty"`
+    Enabled           bool                  `json:"enabled"`
+    Cohorts           []ExternalCohort      `json:"cohorts,omitempty"`
+    ProfileAttributes AuthProfileAttributes `json:"profile_attributes,omitempty"`
+}
+
+type AuthStartRequest struct {
+    LoginMode string `json:"login_mode,omitempty"`
+    ReturnTo  string `json:"return_to,omitempty"`
+}
+
+type AuthStartResponse struct {
+    RedirectURL string `json:"redirect_url,omitempty"`
+}
+
+type AuthCallbackRequest struct {
+    Query  map[string][]string `json:"query,omitempty"`
+    Form   map[string][]string `json:"form,omitempty"`
+    Header map[string][]string `json:"header,omitempty"`
+}
+
+type AuthRuntimeCapability interface {
+    StartLogin(ctx context.Context, config map[string]interface{}, req AuthStartRequest) (*AuthStartResponse, error)
+    CompleteLogin(ctx context.Context, config map[string]interface{}, req AuthCallbackRequest) (*AuthResult, error)
+}
+```
+
+Core must validate the canonical result shape, but must not understand
+provider-specific callback fields.
+
+### 1.2 Core-owned runtime steps
+
+For external auth, the generic flow should be:
+
+1. list login-capable providers
+2. start provider login
+3. receive callback on a generic provider callback path
+4. pass callback envelope to provider
+5. receive canonical `AuthResult`
+6. perform JIT upsert
+7. refresh external cohorts/profile projection
+8. reconcile auto-managed RoleBindings when configured
+9. issue Shepherd JWT/session
+10. return a provider-agnostic frontend bridge response so browser-based login
+    UIs can receive the Shepherd session without exposing the JWT in a callback
+    query string
+
+### 1.3 Provider-owned runtime steps
+
+The provider owns:
+
+* redirect URL construction
+* provider callback parameter parsing
+* token exchange
+* remote userinfo lookup
+* provider-specific nonce/state quirks
+* provider-side retry/backoff rules
+
+Core should not branch on `wecom`, `oidc`, or `ldap` in this flow.
+
+---
+
+## 2. JIT User Center Model
+
+### 2.1 Default rule
+
+The user center should default to:
+
+* create/update user when external login succeeds
+* keep only users who have logged in or were explicitly imported
+* avoid full enterprise directory mirrors unless an admin explicitly uses
+  directory sync
+
+### 2.2 Canonical identity anchor
+
+The JIT upsert rule should use:
+
+* primary external identity: `(auth_provider_id, external_id)`
+* conflict checks: `username`, `email`
+
+This aligns with the existing `User` invariants and avoids relying on database
+unique failures as control flow.
+
+### 2.3 Supplemental profile projection
+
+Supplemental provider profile data should live in a dedicated projection such as
+`UserDirectoryProfile`, not in authoritative `User` fields.
+
+Preferred display-field whitelist:
+
+* `given_name`
+* `family_name`
+* `preferred_name`
+* `phone_number`
+* `job_title`
+* `organization`
+* `organization_unit`
+* `locale`
+* `avatar_url`
+
+Provider-specific raw attributes may still be retained in a raw blob, but
+public UI should render only allowlisted fields.
+
+---
+
+## 3. External Cohorts and RBAC Mapping
+
+### 3.1 Why `external cohort` instead of `group`
+
+`group` is too narrow once Shepherd needs to support:
+
+* OIDC groups
+* LDAP groups
+* LDAP OUs
+* WeCom departments
+* WeCom tags
+
+The implementation should standardize these as typed external cohorts.
+
+### 3.2 Mapping rule semantics
+
+A mapping rule should mean:
+
+* `external cohort selector` -> `Shepherd RBAC mutation policy`
+
+Examples:
+
+* cohort `group:ops` -> `viewer` in `test`
+* cohort `department:finance` -> `operator` on selected systems
+* cohort `tag:dba` -> database-management role
+
+The runtime authorization engine still reads only persisted Shepherd RBAC
+records.
+
+### 3.3 Storage direction
+
+The current group-specific naming is too narrow for this standard.
+Implementation should prefer a clean generic model such as:
+
+* `external_cohorts`
+* `external_cohort_mappings`
+* `external_cohort_grants`
+
+instead of extending group-only tables and names.
+
+Because the project is pre-launch, this should be done as a clean rename rather
+than by adding compatibility layers.
+
+### 3.4 Reconciliation model
+
+Auto-managed RBAC reconciliation should be explicit:
+
+* provider returns current normalized cohorts
+* successful external login upserts the observed cohort set into a
+  non-authoritative `external_cohorts` catalog for later admin mapping and
+  filtering
+* mapping service evaluates current cohort set
+* Shepherd groups matching mappings by target binding key
+* Shepherd updates persisted `RoleBinding` rows plus `external_cohort_grants`
+  metadata
+* manual bindings remain untouched
+
+Runtime permission evaluation does not call back into the provider.
+
+---
+
+## 4. WeCom as the First Provider Practice
+
+### 4.1 Positioning
+
+WeCom is the first implementation under the shared standard. It does not define
+the core contract.
+
+### 4.2 Login modes
+
+Recommended scope:
+
+* primary: desktop/browser QR login
+* secondary: in-WeCom web authorization when practical
+
+Both belong to one `wecom` provider type and should appear as provider-defined
+login modes, not separate core auth products.
+
+### 4.3 Canonical field mapping
+
+WeCom-specific user data should be adapted into the shared result:
+
+* stable WeCom user ID -> `external_id`
+* provider-configured username rule -> `username`
+* Chinese or preferred display label -> `display_name`
+* enterprise email if available -> `email`
+* department/tag membership -> `cohorts`
+* phone/localized names/department labels -> `profile_attributes`
+
+### 4.4 Directory sync relationship
+
+WeCom directory sync remains optional and scoped:
+
+* use it for pre-provisioning, batch review, or admin-driven imports
+* do not require it for successful login
+* do not make it the default user-center source
+
+This keeps WeCom aligned with the same standard as OIDC and LDAP.
+
+---
+
+## 5. API Direction
+
+Contract-first implementation should likely add a provider-agnostic runtime API
+surface similar to:
+
+* `GET /auth/providers`
+* `POST /auth/providers/{id}/login/start`
+* `GET /auth/providers/{id}/callback`
+* callback responses may be HTML bridge pages that `postMessage` the resulting
+  Shepherd session back to the initiating frontend window
+
+If additional endpoints are required, they should still preserve the rule that
+core endpoints remain provider-agnostic and provider-specific callback/query
+details stay inside the adapter.
+
+---
+
+## 6. Interaction with ADR-0048
+
+ADR-0048 remains valid, but should align with this note by using the same
+normalized `external cohort` terminology instead of a narrow `groups`-only
+shape when the provider can return organizational membership during preview/sync.
+
+Directory sync continues to be:
+
+* optional
+* scoped
+* result-first
+* non-authoritative for RBAC until mapped into Shepherd bindings
+
+---
+
+## 7. Acceptance Criteria
+
+* runtime external-auth core paths use only provider registry/capabilities
+* at least two different external providers can share the same start/callback
+  core flow with different provider-owned callback semantics
+* successful external login performs JIT create/update of canonical `User`
+* supplemental profile data is stored outside authoritative core user fields
+* runtime authorization code reads only Shepherd RBAC state
+* external cohort mapping produces persisted Shepherd bindings instead of direct
+  provider-driven authorization
+* WeCom QR login works as the first provider without adding WeCom-specific
+  branches to core auth runtime


### PR DESCRIPTION
## Summary
Publish ADR-0049 for 48-hour public review and align the still-proposed ADR-0048 wording with the same normalized external cohort standard.

## Scope
- add `docs/adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md`
- add `docs/design/notes/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md`
- update `docs/adr/ADR-0048-directory-sync-capability.md`
- update `docs/design/notes/ADR-0048-directory-sync-capability.md`
- update `docs/adr/README.md`

## Constraints
- ADR-0048 remains `proposed`
- ADR-0049 remains `proposed`
- docs only
- no normative design-spec changes
- no implementation code
- no generated/runtime artifacts

## Why ADR-0048 Is Included
ADR-0049 formalizes the normalized `external cohort` standard for external auth and RBAC mapping. ADR-0048 is still in proposed state, so its canonical import wording is aligned in the same review-package update to avoid leaving two active proposed ADRs with conflicting terminology (`groups` vs `cohorts`).

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

## Tracking
- Refs #400