### PR TITLE
[Draft] docs(adr): publish ADR-0050 and ADR-0051 review package

### DIFF
--- a/docs/adr/ADR-0050-upstream-identity-assertion-runtime-provider.md
+++ b/docs/adr/ADR-0050-upstream-identity-assertion-runtime-provider.md
@@ -1,0 +1,281 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-03-21
+deciders: ["@jindyzhao"]
+consulted: ["@jindyzhao"]
+informed: ["@jindyzhao"]
+---
+
+# ADR-0050: Upstream Identity Assertion Runtime Provider for Legacy Systems
+
+> **Status**: Proposed (public review)<br>
+> **Review Open**: 2026-03-21<br>
+> **Review Closes**: 2026-03-23 (>= 48h)<br>
+> **Discussion**: [Issue #402](https://github.com/kv-shepherd/shepherd/issues/402)<br>
+> **Extends**: `ADR-0035-auth-provider-plugin-boundary.md` *(applies the auth-provider plugin boundary to legacy upstream identity assertions as a runtime provider type)*<br>
+> **Extends**: `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` *(adds a generic non-OIDC external-auth path without changing core canonical identity/RBAC rules)*<br>
+> **Extends**: `ADR-0021-api-contract-first.md` *(requires contract-first runtime APIs for upstream assertion entry and callback/landing handling)*
+>
+> 📝 **Design Note**: implementation-facing details are in `docs/design/notes/ADR-0050-upstream-identity-assertion-runtime-provider.md`.
+
+---
+
+## Context and Problem Statement
+
+Some enterprise environments already have legacy portals or internal systems that
+authenticate users and expose some form of trusted identity assertion, but they
+do not speak modern OIDC/SAML end to end.
+
+Examples include:
+
+* opaque token plus `userinfo` endpoint
+* opaque token plus introspection endpoint
+* trusted reverse-proxy header assertion behind a gateway
+
+The project needs a way to integrate these systems without:
+
+* hardcoding one specific legacy application into core
+* trusting plain `username` query parameters
+* forcing every legacy system to implement a brand-new Shepherd-specific token protocol before integration is possible
+
+**Core question**: How should Shepherd support passwordless entry from legacy
+upstream systems that can present a trusted identity assertion, while preserving
+the existing auth-provider plugin boundary and canonical core identity model?
+
+## Decision Drivers
+
+* **ADR-0035 plugin boundary**: runtime auth must resolve providers via registry only and must not hardcode legacy-system branches in core.
+* **ADR-0049 external-auth standard**: external login must still end in canonical `AuthResult`, JIT provisioning, and platform-owned RBAC.
+* **Security boundary**: Shepherd must never trust unauthenticated `username` handoff from browser-controlled inputs.
+* **Real-world deployability**: requiring a legacy system to implement a brand-new Shepherd-specific handoff protocol is often unrealistic.
+* **Open-source generality**: the solution must be reusable for multiple legacy systems, not only one internal portal.
+* **Contract-first governance**: entry/callback/landing APIs must be standardized before implementation.
+
+## Considered Options
+
+* **Option 1**: Hardcode an application-specific bridge flow in core
+* **Option 2**: Introduce a generic upstream identity assertion runtime provider (chosen)
+* **Option 3**: Require all legacy systems to migrate to OIDC/Keycloak before Shepherd integration
+* **Option 4**: Trust browser-provided `username` or ad hoc headers directly
+
+## Decision Outcome
+
+**Chosen option**: **"Introduce a generic upstream identity assertion runtime
+provider"**, because it preserves the plugin-standard runtime contract while
+allowing Shepherd to consume already-existing enterprise trust signals without
+turning one legacy system into a core architectural concept.
+
+### Normative Decisions
+
+#### 1. Legacy upstream identity entry must be modeled as a runtime auth provider type
+
+Legacy-system integration must use the auth-provider registry and runtime auth
+seam defined by ADR-0035 and ADR-0049.
+
+Core must not add:
+
+* application-specific branches
+* one-off login handlers
+* one-off token-verification code paths
+
+Instead, a provider type may implement a generic upstream assertion pattern.
+
+#### 2. Core only accepts trusted upstream identity assertions, never plain usernames
+
+Shepherd must not authenticate users from:
+
+* `?username=alice`
+* arbitrary browser-supplied headers
+* inferred knowledge of another system's session
+
+An upstream identity assertion provider must verify identity through one of the
+following provider-owned mechanisms:
+
+* upstream token + `userinfo` endpoint
+* upstream token + introspection endpoint
+* trusted reverse-proxy headers from a deployment-controlled gateway
+
+The provider may use a different internal mechanism, but core must only receive
+a canonical `AuthResult` after verification succeeds.
+
+#### 3. The provider owns verification workflow; core owns canonical identity handling
+
+The provider owns:
+
+* how an upstream assertion is obtained
+* how the assertion is forwarded to upstream verification
+* which endpoint or trust source is used
+* how upstream response fields are mapped
+
+The core owns:
+
+* request routing
+* request origin/state handling where applicable
+* canonical `AuthResult` validation
+* JIT user upsert
+* Shepherd JWT/session issuance
+* auditability and error normalization
+
+#### 4. Upstream assertion providers must normalize into the ADR-0049 runtime contract
+
+After successful verification, the provider must emit the same canonical
+runtime auth result shape as any other external provider:
+
+* `external_id`
+* `username`
+* `display_name`
+* `email`
+* `enabled`
+* optional `cohorts`
+* optional display-only profile attributes
+
+This means legacy upstream systems are not a separate core identity model.
+
+#### 5. Authorization remains platform-owned
+
+Even if the upstream verification response contains groups, departments, or
+roles, runtime authorization must still remain owned by Shepherd RBAC per
+ADR-0049.
+
+Upstream claims may be normalized into external cohorts or profile attributes,
+but permission checks must not read them directly.
+
+#### 6. Deployment-controlled trust sources are allowed, but their semantics remain provider-local
+
+Some environments may use a gateway or reverse proxy that injects trusted user
+headers after upstream authentication. This is allowed only when:
+
+* the trust boundary is deployment-controlled
+* the provider implementation verifies that the request is arriving from that trusted boundary
+* the provider still normalizes the result into standard `AuthResult`
+
+Core must not treat reverse-proxy headers as a universal runtime contract.
+
+#### 7. This ADR does not require Shepherd to remove other runtime auth providers
+
+LDAP login, WeCom login, OIDC login, and future providers may coexist.
+
+The upstream assertion provider is an additional provider class for legacy
+environments, not a replacement for the broader runtime-auth standard.
+
+#### 8. Enterprise-specific secondary development may live in a separate private repository
+
+Enterprise-specific runtime providers, deployment glue, and adapters may be
+implemented in a separate private repository, as long as they implement the
+public provider contracts and shared SDK exposed by Shepherd.
+
+That private repository must not depend on Shepherd internal implementation
+packages.
+
+The open-source host repository should define:
+
+* the provider contract
+* the canonical auth-result boundary
+* the security and RBAC rules
+* the public SDK or common package that provider implementations import
+
+The private repository may define:
+
+* enterprise-specific upstream assertion transport
+* enterprise-specific mapping rules
+* deployment-specific trust integration
+
+Public ADRs and core implementation must not encode any one enterprise
+integration as a normative requirement.
+
+#### 9. Shared plugin contracts must live in public packages, not host internals
+
+If Shepherd supports private or external runtime provider implementations, the
+interfaces, DTOs, and helper glue required by those providers must live in
+public shared packages.
+
+Private repositories must not import:
+
+* `internal/...`
+* host-only handlers/services
+* host-only persistence packages as a substitute for provider contracts
+
+They should import only the public provider SDK surface intended for external
+implementation.
+
+### Consequences
+
+* ✅ Good, because legacy enterprise systems can be integrated without becoming core special cases.
+* ✅ Good, because Shepherd can reuse existing trust anchors such as userinfo/introspection flows.
+* ✅ Good, because security stays stronger than `username` passthrough or guessed sessions.
+* ✅ Good, because runtime auth still converges on one canonical user-center/RBAC model.
+* ✅ Good, because enterprise-specific secondary development can stay in a separate private repository without polluting the host core.
+* ✅ Good, because the host can expose a stable plugin SDK while keeping internals private.
+* 🟡 Neutral, because provider implementations may need deployment-specific configuration for how assertions arrive.
+* 🟡 Neutral, because some environments may still prefer a gateway or future IdP migration instead of this provider type.
+* ❌ Bad, because this does not magically solve environments where no trusted upstream assertion exists at all.
+
+### Confirmation
+
+* Runtime auth handlers resolve legacy upstream assertion providers via registry only.
+* No one-off legacy-system names appear in core runtime auth branches.
+* Tests prove Shepherd rejects plain username-only handoff.
+* Tests prove a verified upstream assertion can normalize into canonical `AuthResult` and create/update users through JIT provisioning.
+* Authorization tests prove upstream claims do not bypass Shepherd RBAC.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Hardcode an application-specific bridge in core
+
+* ✅ Good, because the first enterprise integration could be quick.
+* ❌ Bad, because it breaks ADR-0035 and turns one internal system into a core concept.
+* ❌ Bad, because the next legacy system would require another core exception.
+
+### Option 2: Generic upstream identity assertion runtime provider (Chosen)
+
+* ✅ Good, because it generalizes the legacy-integration pattern without hardcoding one system.
+* ✅ Good, because it still fits the existing auth-provider seam.
+* ✅ Good, because it keeps identity verification outside browser-controlled username passthrough.
+* 🟡 Neutral, because providers still need configuration for endpoint mappings and trust mode.
+
+### Option 3: Require all legacy systems to migrate to OIDC/Keycloak first
+
+* ✅ Good, because the long-term standards story is cleaner.
+* ❌ Bad, because it is often operationally or politically unrealistic as a prerequisite.
+* ❌ Bad, because it blocks incremental adoption of Shepherd.
+
+### Option 4: Trust browser-provided username or ad hoc headers directly
+
+* ✅ Good, because it looks easy.
+* ❌ Bad, because it is not a defensible trust model.
+* ❌ Bad, because it bypasses the runtime auth standard entirely.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* `ADR-0035-auth-provider-plugin-boundary.md` — provider registry and plugin-standard runtime boundary
+* `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` — canonical external auth result, JIT provisioning, and RBAC rules
+* `ADR-0026-idp-config-naming.md` — standardized provider output contract
+* `ADR-0021-api-contract-first.md` — runtime APIs must be standardized before implementation
+
+### References
+
+* OAuth2-Proxy integration docs (Context7 `/oauth2-proxy/oauth2-proxy`) — trusted upstream header patterns behind deployment-controlled gateways
+* Keycloak userinfo/introspection docs (Context7 `/keycloak/keycloak/26.5.2`) — standard identity assertion verification patterns
+* HashiCorp go-plugin tutorial (Context7 `/hashicorp/go-plugin`) — shared SDK/contracts should stay stable while plugin implementations can evolve independently, potentially in separate repositories
+
+### Implementation Notes
+
+Revisit this ADR if:
+
+* the project later standardizes a first-class shared-gateway mode across all deployments
+* a future accepted ADR defines a stronger common abstraction over token-userinfo and trusted-header modes
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-21 | @jindyzhao | Initial draft |

--- a/docs/adr/ADR-0051-scheduled-directory-enrichment.md
+++ b/docs/adr/ADR-0051-scheduled-directory-enrichment.md
@@ -1,0 +1,247 @@
+---
+# MADR 4.0 compatible metadata (YAML frontmatter)
+status: "proposed"
+date: 2026-03-21
+deciders: ["@jindyzhao"]
+consulted: ["@jindyzhao"]
+informed: ["@jindyzhao"]
+---
+
+# ADR-0051: Scheduled Directory Enrichment for Existing Users
+
+> **Status**: Proposed (public review)<br>
+> **Review Open**: 2026-03-21<br>
+> **Review Closes**: 2026-03-23 (>= 48h)<br>
+> **Discussion**: [Issue #402](https://github.com/kv-shepherd/shepherd/issues/402)<br>
+> **Extends**: `ADR-0048-directory-sync-capability.md` *(adds a scheduled enrichment mode on top of provider-owned directory sync without turning full mirroring into the default)*<br>
+> **Extends**: `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` *(keeps JIT user-center construction as the default while allowing scheduled profile/cohort enrichment for existing users)*
+>
+> 📝 **Design Note**: implementation-facing details are in `docs/design/notes/ADR-0051-scheduled-directory-enrichment.md`.
+
+---
+
+## Context and Problem Statement
+
+Some enterprise deployments authenticate users through one source, but need to
+enrich those same users from another source.
+
+Typical example:
+
+* users authenticate via LDAP or a legacy upstream system
+* directory metadata such as departments or phone numbers is more complete in
+  WeCom or another enterprise directory
+* usernames or another stable join key can link the records
+
+The project already decided that:
+
+* JIT provisioning is the default user-center construction rule
+* directory sync is optional and provider-owned
+* external organization data cannot become direct authorization authority
+
+The open question is how to support scheduled external directory enrichment
+without drifting into full mirrored-directory mode or vendor-specific core
+logic.
+
+## Decision Drivers
+
+* **ADR-0049 JIT rule**: the platform should not mirror full external directories by default.
+* **ADR-0048 sync boundary**: provider-specific directory workflows stay at the edge; core standardizes results.
+* **Practical usability**: administrators still need richer department/profile data than the primary auth source may provide.
+* **Identity safety**: enrichment should link to existing canonical users through explicit join rules, not silent heuristic takeover.
+* **RBAC safety**: external directory metadata must remain input to mapping workflows, not direct runtime authority.
+* **Operational efficiency**: the common case is to enrich existing users, not to precreate thousands of never-used accounts.
+
+## Considered Options
+
+* **Option 1**: Full scheduled mirror of external directory into canonical users
+* **Option 2**: Scheduled enrichment of existing users linked by explicit join key (chosen)
+* **Option 3**: Manual one-off imports only, no scheduler
+
+## Decision Outcome
+
+**Chosen option**: **"Scheduled enrichment of existing users linked by explicit
+join key"**, because it preserves the JIT user-center model while still solving
+the practical need to supplement user profiles and cohort catalogs from richer
+directory sources.
+
+### Normative Decisions
+
+#### 1. Scheduled enrichment is an optional directory-sync mode, not a new core identity model
+
+Providers that already support directory sync may also support scheduled
+enrichment.
+
+This does not introduce a second user-center authority. It remains an optional
+mode of provider-owned directory sync under ADR-0048.
+
+#### 2. The default scheduled mode is `enrich_existing_only`
+
+The default scheduled enrichment behavior must be:
+
+* fetch records from the external directory
+* match them to existing Shepherd users by explicit join rule
+* enrich matched users only
+
+The platform must not default to creating canonical users for every synced
+directory record.
+
+#### 3. Matching must use an explicit join key rule
+
+Scheduled enrichment must use a provider-configured join rule such as:
+
+* `username`
+* `employee_id`
+* another explicit stable key
+
+Implicit fuzzy matching is not allowed as the default.
+
+If multiple users match or no user matches, the result must be classified
+explicitly rather than silently attached.
+
+#### 4. Scheduled enrichment writes only to non-authoritative projections and cohort catalogs
+
+Scheduled enrichment may update:
+
+* display-only external profile projection
+* normalized external cohort catalog
+* admin-facing sample or sync-result surfaces
+
+Scheduled enrichment must not directly rewrite:
+
+* the runtime auth authority model
+* RBAC decisions
+* approval policy state
+* core resource state
+
+#### 5. External directory metadata remains non-authoritative for authorization
+
+Departments, tags, groups, OUs, and similar data synced on a schedule may help:
+
+* filtering
+* batch selection
+* explicit cohort-to-RBAC mapping
+
+They still must not become direct runtime permission inputs.
+
+#### 6. Runtime auth and scheduled enrichment are independent capabilities
+
+A provider such as WeCom may support:
+
+* runtime login
+* directory sync
+* scheduled enrichment
+
+These capabilities may coexist, but they are independent. Enabling scheduled
+enrichment does not require runtime login, and disabling runtime login does not
+disable enrichment.
+
+#### 7. Provider-owned scheduling inputs stay outside the core result model
+
+Provider-specific scheduling and selection inputs remain provider-owned, for
+example:
+
+* department selectors
+* nested-sync flags
+* field selection
+* schedule cadence or cursor semantics
+
+Core owns only:
+
+* job lifecycle
+* canonical match classification
+* canonical projection/cohort write rules
+* result summary and auditability
+
+#### 8. Enterprise-specific enrichment implementations may live in a separate private repository
+
+Enterprise-specific scheduled enrichment logic may be implemented in a separate
+private repository, as long as it targets the public directory-sync and
+enrichment contracts defined by Shepherd.
+
+That private repository must not depend on Shepherd internal implementation
+packages.
+
+The open-source host repository should own:
+
+* the canonical enrichment semantics
+* the join/match safety rules
+* the projection/cohort boundary
+* the public SDK or common packages for enrichment providers
+
+The private repository may own:
+
+* enterprise-specific directory source adapters
+* enterprise-specific field mapping and scheduling defaults
+* enterprise deployment wiring
+
+### Consequences
+
+* ✅ Good, because richer external directories can supplement canonical users without becoming the primary identity authority.
+* ✅ Good, because the platform can default to enriching real users instead of mirroring unused enterprise populations.
+* ✅ Good, because WeCom and similar sources remain provider-specific at workflow level while core stays provider-neutral.
+* ✅ Good, because this pattern is reusable beyond WeCom for HR or other directory sources.
+* ✅ Good, because enterprise-specific enrichment logic can evolve in a private repository without changing public core semantics.
+* ✅ Good, because public enrichment contracts can remain stable while private adapters change independently.
+* 🟡 Neutral, because administrators must configure explicit join keys and sync scope carefully.
+* 🟡 Neutral, because some organizations may later choose a more aggressive pre-provisioning mode, which should remain opt-in.
+* ❌ Bad, because environments lacking a stable cross-system join key may need manual review workflows before enrichment is safe.
+
+### Confirmation
+
+* Scheduled enrichment tests prove the default mode enriches existing users only.
+* Match-classification tests prove unmatched and ambiguous records are surfaced explicitly.
+* Projection/cohort tests prove scheduled enrichment does not directly change runtime RBAC evaluation.
+* CI architecture checks continue to block vendor workflow leakage into core handlers and services.
+
+---
+
+## Pros and Cons of the Options
+
+### Option 1: Full scheduled mirror of the external directory
+
+* ✅ Good, because administrators can see the whole directory immediately.
+* ❌ Bad, because it conflicts with ADR-0049's JIT-first user-center model.
+* ❌ Bad, because it creates unnecessary identity, sync, and conflict overhead.
+
+### Option 2: Scheduled enrichment of existing users linked by explicit join key (Chosen)
+
+* ✅ Good, because it solves the common "LDAP authenticates, WeCom enriches" case cleanly.
+* ✅ Good, because it keeps enrichment provider-specific and user-center authority canonical.
+* ✅ Good, because it scales to multiple directory sources without changing core identity rules.
+* 🟡 Neutral, because unmatched records still need explicit handling or admin review.
+
+### Option 3: Manual one-off imports only
+
+* ✅ Good, because it is simple.
+* ❌ Bad, because it does not solve the drift problem for changing departments/profile data.
+* ❌ Bad, because it increases admin toil in exactly the environments that need enrichment most.
+
+---
+
+## More Information
+
+### Related Decisions
+
+* `ADR-0048-directory-sync-capability.md` — result-first directory sync boundary
+* `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` — JIT user-center rule and external cohort semantics
+* `ADR-0026-idp-config-naming.md` — standardized provider output and adapter-only normalization
+
+### References
+
+* Keycloak userinfo docs (Context7 `/keycloak/keycloak/26.5.2`) — standard model for retrieving identity/profile data from an upstream identity source
+* HashiCorp go-plugin tutorial (Context7 `/hashicorp/go-plugin`) — stable host contracts and separate plugin implementation repositories
+
+### Implementation Notes
+
+Revisit this ADR if:
+
+* the project later accepts a first-class "preprovision missing users" mode as a separate, opt-in policy
+* manual review queues become necessary for ambiguous enrichment joins
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-21 | @jindyzhao | Initial draft |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,8 @@
 | [ADR-0047](./ADR-0047-vm-status-granular-lifecycle-states.md) | Granular VM Lifecycle States (STARTING / NOT_FOUND) | **Proposed** | - |
 | [ADR-0048](./ADR-0048-directory-sync-capability.md) | Directory Sync Capability for Auth Providers | **Proposed** | Result-first contract: provider-owned workflow, core-owned canonical user/cohort import semantics |
 | [ADR-0049](./ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md) | External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping | **Proposed** | Unified external-auth standard: JIT user center, provider-owned workflow, platform-owned RBAC |
+| [ADR-0050](./ADR-0050-upstream-identity-assertion-runtime-provider.md) | Upstream Identity Assertion Runtime Provider for Legacy Systems | **Proposed** | Generic legacy token/userinfo or trusted-gateway runtime provider without core special-casing |
+| [ADR-0051](./ADR-0051-scheduled-directory-enrichment.md) | Scheduled Directory Enrichment for Existing Users | **Proposed** | Optional scheduled enrichment of existing users via explicit join key, without abandoning JIT user-center construction |
 
 > ℹ️ **ADR-0037 Sync Notes**:
 >
@@ -132,6 +134,8 @@ For newcomers, we recommend reading ADRs in this order:
 21. **ADR-0047** (Granular VM Lifecycle States, **Proposed** 🔍 48-hr review window) → Adds `STARTING` and `NOT_FOUND` as first-class VM status values with polling/delete integration
 22. **ADR-0048** (Directory Sync Capability, **Proposed** 🔍 48-hr review window) → Adds provider-owned sync request schema with core-owned canonical user/cohort import semantics
 23. **ADR-0049** (External Auth Runtime, **Proposed** 🔍 48-hr review window) → Defines unified external-auth runtime, JIT user-center provisioning, and external cohort to platform RBAC mapping
+24. **ADR-0050** (Upstream Identity Assertion Runtime Provider, **Proposed** 🔍 local draft) → Generalizes legacy token/userinfo or trusted-gateway identity handoff as a provider type instead of a core special case
+25. **ADR-0051** (Scheduled Directory Enrichment, **Proposed** 🔍 local draft) → Adds enrich-existing-only scheduled profile/cohort sync while keeping JIT user-center construction as the default
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/docs/design/notes/ADR-0050-upstream-identity-assertion-runtime-provider.md
+++ b/docs/design/notes/ADR-0050-upstream-identity-assertion-runtime-provider.md
@@ -1,0 +1,204 @@
+# ADR-0050 Design Note: Upstream Identity Assertion Runtime Provider
+
+## Purpose
+
+This note captures implementation-facing details for a runtime auth provider
+that verifies identity from an upstream system without making that system a core
+concept.
+
+## Design Goals
+
+* Reuse the existing runtime auth provider seam from ADR-0049.
+* Support legacy upstream systems that already expose a usable trust signal.
+* Avoid unsafe username passthrough.
+* Keep platform authorization owned by Shepherd RBAC.
+
+## Supported Trust Modes
+
+The provider may support one or more of these provider-local trust modes:
+
+1. `token_userinfo`
+   - client presents an upstream token
+   - provider calls configured `userinfo` endpoint
+2. `token_introspection`
+   - client presents an upstream token
+   - provider calls configured introspection endpoint
+3. `trusted_gateway_headers`
+   - provider reads deployment-controlled upstream headers after gateway authentication
+
+These modes are provider-internal implementation details. Core sees only one
+runtime provider contract.
+
+## Recommended Provider Configuration Shape
+
+Provider-local config may include:
+
+* `login_entry_url`
+* `trust_mode`
+* `userinfo_endpoint`
+* `introspection_endpoint`
+* `token_transport`
+  - `authorization_bearer`
+  - `query`
+  - `cookie`
+  - `header`
+* `token_param_name`
+* `token_header_name`
+* `trusted_header_username`
+* `trusted_header_email`
+* `trusted_gateway_cidrs`
+* `username_path`
+* `display_name_path`
+* `email_path`
+* `external_id_path`
+* `cohort_paths`
+* `profile_attribute_paths`
+* `request_timeout_seconds`
+
+This config belongs to the provider, not to core runtime auth.
+
+## Runtime Flow
+
+### Flow A: token -> userinfo
+
+1. Browser arrives at a Shepherd landing/start endpoint with an upstream token already available through deployment-approved means.
+2. Core routes to the configured provider.
+3. Provider forwards the token to configured `userinfo` endpoint.
+4. Provider validates upstream response shape.
+5. Provider maps upstream fields into canonical `AuthResult`.
+6. Core applies canonical validation, JIT upsert, JWT issuance, and audit.
+
+### Flow B: token -> introspection
+
+1. Browser arrives with upstream token.
+2. Provider calls configured introspection endpoint.
+3. Provider requires `active == true` or equivalent upstream success contract.
+4. Provider maps identity fields into canonical `AuthResult`.
+5. Core continues with standard runtime flow.
+
+### Flow C: trusted gateway headers
+
+1. Gateway authenticates the request upstream.
+2. Gateway injects trusted headers.
+3. Provider verifies request origin is within configured trust boundary.
+4. Provider maps trusted header values into canonical `AuthResult`.
+5. Core continues with standard runtime flow.
+
+## Security Constraints
+
+The implementation must reject:
+
+* plain `?username=...` without verification
+* arbitrary browser headers
+* direct dependence on another system's private session store
+* legacy-system-specific code branches in core handlers/services
+
+For trusted gateway mode, the provider must never assume that all headers are
+trusted. It must verify the deployment trust boundary explicitly.
+
+## Core/Edge Boundary
+
+### Core-owned
+
+* runtime routing
+* CSRF/state handling when applicable
+* canonical auth result validation
+* JIT provisioning
+* Shepherd session/JWT issuance
+* RBAC enforcement
+
+### Provider-owned
+
+* assertion retrieval details
+* userinfo/introspection invocation
+* trusted-header parsing
+* upstream field mapping
+* provider-local validation quirks
+
+## Private Repository Support
+
+This provider class is explicitly intended to support enterprise-specific
+secondary development in a separate private repository.
+
+Recommended split:
+
+### Public host repository
+
+Owns:
+
+* runtime auth provider contract
+* canonical `AuthResult`
+* JIT user provisioning service
+* RBAC and security rules
+* public provider SDK/common package
+
+### Private integration repository
+
+Owns:
+
+* concrete upstream integration adapters
+* deployment-specific trust glue
+* enterprise mapping defaults
+* enterprise runbooks and deployment manifests
+
+The private repository should depend on the public shared SDK/contracts rather
+than copying or forking core runtime auth semantics.
+
+It must not import Shepherd `internal/...` packages.
+
+## Recommended Public SDK Surface
+
+At minimum, the public SDK surface for this provider class should expose:
+
+* runtime auth provider interface
+* canonical auth result DTOs
+* any public helper DTOs needed for provider registration or capability description
+
+If additional helper logic is needed for external implementations, it should be
+published through stable public packages rather than by widening host internals.
+
+### Current repository implication
+
+The current repository already exposes an initial public provider surface under:
+
+* `pkg/authproviderplugin`
+
+That package is the correct direction for external/private provider
+implementations. As private-repository support becomes formalized, the project
+should strengthen this surface so that it serves as the stable SDK for provider
+implementations, rather than requiring any direct dependency on host internals.
+
+### Current SDK gaps to close
+
+To make separate-repository runtime providers practical, the public SDK should
+be strengthened in these areas:
+
+1. clearly document that provider registration currently happens through the
+   public admin registration surface, while runtime capability is discovered via
+   optional interface implementation
+2. re-export provider-facing error types such as runtime-start validation
+   errors so external implementations do not need `internal/...`
+3. keep runtime capability DTOs and helper types stable under `pkg/...`
+4. document a single public import path for provider authors
+
+## Testing Requirements
+
+Minimum tests:
+
+* rejects plain username-only handoff
+* verifies token -> userinfo success path
+* verifies token -> introspection success path if supported
+* verifies trusted-header mode rejects untrusted origin
+* proves canonical `AuthResult` reaches JIT provisioning path
+* proves upstream roles/groups are not used directly in permission checks
+
+## First Implementation Guidance
+
+The first implementation may target a generic `upstream_token_userinfo`
+provider, because that fits the most common legacy-environment pattern best.
+
+Even in that first implementation:
+
+* naming must remain generic
+* config fields must remain provider-local
+* runtime core must never mention any concrete legacy system by name

--- a/docs/design/notes/ADR-0051-scheduled-directory-enrichment.md
+++ b/docs/design/notes/ADR-0051-scheduled-directory-enrichment.md
@@ -1,0 +1,210 @@
+# ADR-0051 Design Note: Scheduled Directory Enrichment
+
+## Purpose
+
+This note captures implementation-facing details for enriching existing Shepherd
+users from an external directory source on a schedule.
+
+The first expected deployment example is WeCom department sync used to enrich
+users whose primary identity is established through LDAP or a legacy upstream
+auth provider.
+
+## Design Goals
+
+* Keep JIT user-center construction as the default rule.
+* Avoid full directory mirroring by default.
+* Support richer profile and cohort data from external directory sources.
+* Keep provider workflow at the edge and canonical writes in core.
+
+## Default Mode
+
+The default scheduled mode is:
+
+* `enrich_existing_only`
+
+Behavior:
+
+1. fetch records from external directory
+2. match to existing canonical users by explicit join key
+3. update display-only projections and external cohorts
+4. do not create missing canonical users by default
+
+## Join Strategy
+
+Required provider/admin config:
+
+* `join_key_type`
+  - `username`
+  - `employee_id`
+  - future explicit stable keys
+* optional `source_attribute_path`
+
+Default first implementation:
+
+* `join_key_type = username`
+
+The implementation must classify:
+
+* matched existing user
+* no match
+* multiple matches / ambiguous match
+
+Ambiguous results must not be auto-attached silently.
+
+## Scheduled Job Inputs
+
+Provider-owned request/schedule inputs may include:
+
+* department selectors
+* nested department inclusion
+* selected fields
+* sync cadence / cron
+* manual trigger vs scheduled trigger
+* cursor or delta token
+
+These stay provider-local and must remain opaque to core.
+
+## Core-Owned Write Model
+
+Scheduled enrichment may write:
+
+* `UserDirectoryProfile`
+* normalized `ExternalCohort`
+* sync job records and summaries
+
+Scheduled enrichment must not directly write:
+
+* runtime RBAC decisions
+* approval policy
+* core resource state
+
+If cohort-based access is desired later, it must go through explicit
+`ExternalCohort -> Shepherd RBAC` mapping and persisted Shepherd-managed RBAC
+records.
+
+## Suggested Provider Config Additions
+
+For a directory-capable provider, schedule/enrichment config may include:
+
+* `enrichment_enabled`
+* `enrichment_mode`
+* `schedule_cron`
+* `schedule_timezone`
+* `join_key_type`
+* `department_selectors`
+* `selected_profile_fields`
+* `selected_cohort_kinds`
+* `write_profile_fields`
+* `write_cohorts`
+
+These are provider-local admin settings, not core identity fields.
+
+## WeCom First-Provider Guidance
+
+For WeCom, the likely first implementation shape is:
+
+* select one or more departments
+* fetch users under those departments on a schedule
+* match by `username`
+* write:
+  - phone
+  - localized name
+  - organization unit / department labels
+  - avatar URL
+  - department-based external cohorts
+
+WeCom login capability may remain enabled or disabled independently of this
+scheduled enrichment capability.
+
+## UI Guidance
+
+Admin UI should expose:
+
+* current join rule
+* current sync scope
+* last run / next run
+* matched / unmatched / ambiguous counts
+* sample enriched fields
+
+The UI should not imply that enrichment changes permissions directly.
+
+## Testing Requirements
+
+Minimum tests:
+
+* default `enrich_existing_only` mode does not create missing canonical users
+* explicit join-key matching updates projections for matched users
+* unmatched records are reported but not auto-created in default mode
+* ambiguous matches are classified and skipped
+* synced cohorts do not directly affect runtime authorization
+
+## Private Repository Support
+
+Scheduled enrichment is expected to support enterprise-specific secondary
+development in a separate private repository.
+
+Recommended split:
+
+### Public host repository
+
+Owns:
+
+* canonical enrichment semantics
+* match classification rules
+* projection/cohort persistence rules
+* admin-visible result contract
+* public enrichment SDK/common package if third-party or private adapters are supported
+
+### Private integration repository
+
+Owns:
+
+* concrete directory adapters
+* enterprise field mapping
+* enterprise scheduling presets
+* enterprise deployment wiring
+
+It must not import Shepherd `internal/...` packages.
+
+## Recommended Public SDK Surface
+
+If enrichment adapters are implemented outside the host repository, the public
+SDK surface should expose:
+
+* directory sync capability interfaces
+* canonical directory record/result DTOs
+* public descriptor/request-schema DTOs
+
+The host should not require private repositories to depend on internal core
+services in order to implement enrichment adapters.
+
+### Current repository implication
+
+The current repository already exposes an initial public provider surface under:
+
+* `pkg/authproviderplugin`
+
+That package is the natural seed for a stable enrichment SDK. As private
+repository support becomes formalized, the host should continue moving external
+provider-facing contracts into that public surface rather than leaving them
+defined only under `internal/...`.
+
+### Current SDK gaps to close
+
+To make separate-repository enrichment adapters practical, the public SDK
+should be strengthened in these areas:
+
+1. re-export provider-facing request-validation error types
+2. re-export canonical conflict code constants, not only the alias type
+3. keep descriptor, preview, and canonical record DTOs stable under `pkg/...`
+4. document the public package path and capability-composition model for
+   adapter authors
+
+## Future Extension Points
+
+Possible later extensions, still opt-in:
+
+* `create_missing_users`
+* manual review queue for ambiguous matches
+* multiple join-key strategies with precedence
+* more than one directory enrichment source per user


### PR DESCRIPTION
## Summary
Publish the proposed ADR-0050 and ADR-0051 review package with paired design notes and ADR index updates.

## Scope
- `docs/adr/ADR-0050-upstream-identity-assertion-runtime-provider.md`
- `docs/design/notes/ADR-0050-upstream-identity-assertion-runtime-provider.md`
- `docs/adr/ADR-0051-scheduled-directory-enrichment.md`
- `docs/design/notes/ADR-0051-scheduled-directory-enrichment.md`
- `docs/adr/README.md`

## Non-Goals
- no implementation code
- no generated artifacts
- no enterprise-specific private-integration code

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`

## Review Window
- Start: 2026-03-21
- End: 2026-03-23 (>= 48h)

Refs #402