### PR TITLE
docs(adr): accept ADR-0048 to ADR-0051

### DIFF
--- a/docs/adr/ADR-0048-directory-sync-capability.md
+++ b/docs/adr/ADR-0048-directory-sync-capability.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-03-19
 deciders: ["@jindyzhao"]
 consulted: ["@jindyzhao"]
@@ -9,9 +9,8 @@ informed: ["@jindyzhao"]
 
 # ADR-0048: Directory Sync Capability for Auth Providers
 
-> **Status**: 🔍 Public Review — 48-hour minimum comment window<br>
-> **Review Open**: 2026-03-19<br>
-> **Review Closes**: 2026-03-21 (earliest merge date)<br>
+> **Status**: Accepted<br>
+> **Accepted On**: 2026-03-23<br>
 > **Discussion**: [Issue #396](https://github.com/kv-shepherd/shepherd/issues/396)<br>
 > **Extends**: `ADR-0035-auth-provider-plugin-boundary.md` *(adds optional directory-sync capability within the auth-provider plugin boundary)*<br>
 > **Extends**: `ADR-0024-provider-interface-capability-composition.md` *(keeps directory sync as a small optional capability, not a base-interface expansion)*
@@ -267,3 +266,4 @@ Revisit this ADR if:
 | 2026-03-19 | @jindyzhao | Initial process-first draft published for review |
 | 2026-03-19 | @jindyzhao | Reworked to result-first contract: provider-owned workflow, core-owned canonical import semantics |
 | 2026-03-20 | @jindyzhao | Aligned canonical import wording with normalized external-cohort standard from ADR-0049 draft |
+| 2026-03-23 | @jindyzhao | Marked accepted after the 48-hour review window closed |

--- a/docs/adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
+++ b/docs/adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-03-20
 deciders: ["@jindyzhao"]
 consulted: ["@jindyzhao"]
@@ -9,9 +9,8 @@ informed: ["@jindyzhao"]
 
 # ADR-0049: External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping
 
-> **Status**: 🔍 Public Review — 48-hour minimum comment window<br>
-> **Review Open**: 2026-03-20<br>
-> **Review Closes**: 2026-03-22 (earliest merge date)<br>
+> **Status**: Accepted<br>
+> **Accepted On**: 2026-03-23<br>
 > **Discussion**: [Issue #400](https://github.com/kv-shepherd/shepherd/issues/400)<br>
 > **Amends**: `ADR-0026-idp-config-naming.md#standard-provider-output-contract` *(clarifies runtime auth result shape, non-authoritative profile data, and cohort normalization)*<br>
 > **Amends**: `ADR-0035-auth-provider-plugin-boundary.md` *(extends the auth-provider boundary from admin/discovery into runtime login and callback execution)*<br>
@@ -79,6 +78,7 @@ The provider owns:
 
 * login-mode specifics
 * redirect/callback parameter semantics
+* direct credential request semantics when the provider exposes a non-redirect login mode
 * token exchange
 * remote user-info fetch
 * provider-specific validation quirks
@@ -202,9 +202,33 @@ Example:
 
 * WeCom QR login for desktop/browser use
 * WeCom in-app web authorization for users already inside the WeCom client
+* LDAP username/password login submitted directly to Shepherd
 
 Core must see these only as provider-defined login modes behind one runtime
 contract. Core must not fork business logic per vendor login mode.
+
+Runtime login modes may use one of two standard interaction styles:
+
+* `redirect`: core starts provider login, then later forwards a callback envelope
+* `credentials`: core forwards a validated credential envelope and receives a canonical auth result directly
+
+Both interaction styles must still terminate in the same canonical `AuthResult`,
+JIT provisioning, cohort reconciliation, and Shepherd-issued session.
+
+#### 9. External-auth callback base URL is platform-wide configuration, not provider configuration
+
+Runtime callback generation for external auth must use a platform-level public
+base URL owned by Shepherd deployment/system settings.
+
+This value:
+
+* is shared by WeCom, OIDC, and other external runtime providers
+* defines Shepherd's public callback origin
+* must not be duplicated inside per-provider config blobs
+
+Provider config continues to own only provider-specific credentials and remote
+protocol parameters such as `corp_id`, `agent_id`, `client_id`, `issuer`, or
+provider scopes.
 
 ### Consequences
 
@@ -223,9 +247,11 @@ contract. Core must not fork business logic per vendor login mode.
 * No runtime path hardcodes WeCom/OIDC/LDAP vendor branches in core auth flow.
 * JIT login tests prove successful external login can create and update canonical users.
 * Authorization tests prove permission checks do not read external cohorts or raw profile attributes directly.
+* Providers may expose either `redirect` or `credentials` interaction styles without changing core-owned post-auth behavior.
 * Mapping tests prove external cohorts only affect access through persisted Shepherd RBAC records.
 * Directory-sync tests continue to prove sync is optional and scoped, not the default user-center construction path.
 * CI architecture checks block provider-specific workflow leakage into runtime auth and directory-sync core paths.
+* Runtime callback URL generation proves the public base URL is platform-wide and reused across external providers.
 
 ---
 
@@ -292,3 +318,4 @@ Revisit this ADR if:
 |------|--------|--------|
 | 2026-03-20 | @jindyzhao | Initial draft |
 | 2026-03-20 | @jindyzhao | Published for 48-hour public review |
+| 2026-03-23 | @jindyzhao | Marked accepted after the 48-hour review window closed |

--- a/docs/adr/ADR-0050-upstream-identity-assertion-runtime-provider.md
+++ b/docs/adr/ADR-0050-upstream-identity-assertion-runtime-provider.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-03-21
 deciders: ["@jindyzhao"]
 consulted: ["@jindyzhao"]
@@ -9,9 +9,8 @@ informed: ["@jindyzhao"]
 
 # ADR-0050: Upstream Identity Assertion Runtime Provider for Legacy Systems
 
-> **Status**: Proposed (public review)<br>
-> **Review Open**: 2026-03-21<br>
-> **Review Closes**: 2026-03-23 (>= 48h)<br>
+> **Status**: Accepted<br>
+> **Accepted On**: 2026-03-23<br>
 > **Discussion**: [Issue #402](https://github.com/kv-shepherd/shepherd/issues/402)<br>
 > **Extends**: `ADR-0035-auth-provider-plugin-boundary.md` *(applies the auth-provider plugin boundary to legacy upstream identity assertions as a runtime provider type)*<br>
 > **Extends**: `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` *(adds a generic non-OIDC external-auth path without changing core canonical identity/RBAC rules)*<br>
@@ -279,3 +278,4 @@ Revisit this ADR if:
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-21 | @jindyzhao | Initial draft |
+| 2026-03-23 | @jindyzhao | Marked accepted after the 48-hour review window closed |

--- a/docs/adr/ADR-0051-scheduled-directory-enrichment.md
+++ b/docs/adr/ADR-0051-scheduled-directory-enrichment.md
@@ -1,6 +1,6 @@
 ---
 # MADR 4.0 compatible metadata (YAML frontmatter)
-status: "proposed"
+status: "accepted"
 date: 2026-03-21
 deciders: ["@jindyzhao"]
 consulted: ["@jindyzhao"]
@@ -9,9 +9,8 @@ informed: ["@jindyzhao"]
 
 # ADR-0051: Scheduled Directory Enrichment for Existing Users
 
-> **Status**: Proposed (public review)<br>
-> **Review Open**: 2026-03-21<br>
-> **Review Closes**: 2026-03-23 (>= 48h)<br>
+> **Status**: Accepted<br>
+> **Accepted On**: 2026-03-23<br>
 > **Discussion**: [Issue #402](https://github.com/kv-shepherd/shepherd/issues/402)<br>
 > **Extends**: `ADR-0048-directory-sync-capability.md` *(adds a scheduled enrichment mode on top of provider-owned directory sync without turning full mirroring into the default)*<br>
 > **Extends**: `ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md` *(keeps JIT user-center construction as the default while allowing scheduled profile/cohort enrichment for existing users)*
@@ -245,3 +244,4 @@ Revisit this ADR if:
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-21 | @jindyzhao | Initial draft |
+| 2026-03-23 | @jindyzhao | Marked accepted after the 48-hour review window closed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,10 +57,10 @@
 | [ADR-0045](./ADR-0045-cluster-resolved-root-volume-provisioning.md) | Cluster-Resolved Root Volume Provisioning Intent | **Accepted** | - |
 | [ADR-0046](./ADR-0046-schema-mask-field-visibility-tiers.md) | Schema Mask Field Visibility Tiers | **Accepted** | - |
 | [ADR-0047](./ADR-0047-vm-status-granular-lifecycle-states.md) | Granular VM Lifecycle States (STARTING / NOT_FOUND) | **Proposed** | - |
-| [ADR-0048](./ADR-0048-directory-sync-capability.md) | Directory Sync Capability for Auth Providers | **Proposed** | Result-first contract: provider-owned workflow, core-owned canonical user/cohort import semantics |
-| [ADR-0049](./ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md) | External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping | **Proposed** | Unified external-auth standard: JIT user center, provider-owned workflow, platform-owned RBAC |
-| [ADR-0050](./ADR-0050-upstream-identity-assertion-runtime-provider.md) | Upstream Identity Assertion Runtime Provider for Legacy Systems | **Proposed** | Generic legacy token/userinfo or trusted-gateway runtime provider without core special-casing |
-| [ADR-0051](./ADR-0051-scheduled-directory-enrichment.md) | Scheduled Directory Enrichment for Existing Users | **Proposed** | Optional scheduled enrichment of existing users via explicit join key, without abandoning JIT user-center construction |
+| [ADR-0048](./ADR-0048-directory-sync-capability.md) | Directory Sync Capability for Auth Providers | **Accepted** | Result-first contract: provider-owned workflow, core-owned canonical user/cohort import semantics |
+| [ADR-0049](./ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md) | External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping | **Accepted** | Unified external-auth standard: JIT user center, provider-owned workflow, platform-owned RBAC |
+| [ADR-0050](./ADR-0050-upstream-identity-assertion-runtime-provider.md) | Upstream Identity Assertion Runtime Provider for Legacy Systems | **Accepted** | Generic legacy token/userinfo or trusted-gateway runtime provider without core special-casing |
+| [ADR-0051](./ADR-0051-scheduled-directory-enrichment.md) | Scheduled Directory Enrichment for Existing Users | **Accepted** | Optional scheduled enrichment of existing users via explicit join key, without abandoning JIT user-center construction |
 
 > ℹ️ **ADR-0037 Sync Notes**:
 >
@@ -132,10 +132,10 @@ For newcomers, we recommend reading ADRs in this order:
 19. **ADR-0045** (Cluster-Resolved Root Volume Provisioning, **Accepted**) → Clarifies where storage `auto` intent may exist and when approval must resolve explicit root-volume provisioning values
 20. **ADR-0046** (Schema Mask Field Visibility Tiers, **Accepted**) → Formalizes `professional_fields` as a UI-only expert-tier in SchemaMask
 21. **ADR-0047** (Granular VM Lifecycle States, **Proposed** 🔍 48-hr review window) → Adds `STARTING` and `NOT_FOUND` as first-class VM status values with polling/delete integration
-22. **ADR-0048** (Directory Sync Capability, **Proposed** 🔍 48-hr review window) → Adds provider-owned sync request schema with core-owned canonical user/cohort import semantics
-23. **ADR-0049** (External Auth Runtime, **Proposed** 🔍 48-hr review window) → Defines unified external-auth runtime, JIT user-center provisioning, and external cohort to platform RBAC mapping
-24. **ADR-0050** (Upstream Identity Assertion Runtime Provider, **Proposed** 🔍 local draft) → Generalizes legacy token/userinfo or trusted-gateway identity handoff as a provider type instead of a core special case
-25. **ADR-0051** (Scheduled Directory Enrichment, **Proposed** 🔍 local draft) → Adds enrich-existing-only scheduled profile/cohort sync while keeping JIT user-center construction as the default
+22. **ADR-0048** (Directory Sync Capability, **Accepted**) → Adds provider-owned sync request schema with core-owned canonical user/cohort import semantics
+23. **ADR-0049** (External Auth Runtime, **Accepted**) → Defines unified external-auth runtime, JIT user-center provisioning, and external cohort to platform RBAC mapping
+24. **ADR-0050** (Upstream Identity Assertion Runtime Provider, **Accepted**) → Generalizes legacy token/userinfo or trusted-gateway identity handoff as a provider type instead of a core special case
+25. **ADR-0051** (Scheduled Directory Enrichment, **Accepted**) → Adds enrich-existing-only scheduled profile/cohort sync while keeping JIT user-center construction as the default
 
 ### Historical Context
 - **ADR-0002** → Why we moved from Git storage to DB (Superseded by ADR-0007)

--- a/docs/design/notes/ADR-0048-directory-sync-capability.md
+++ b/docs/design/notes/ADR-0048-directory-sync-capability.md
@@ -1,6 +1,6 @@
 # Design Note: ADR-0048 — Directory Sync Capability for Auth Providers
 
-> **Status**: Proposed (ADR-0048 under review until 2026-03-21)
+> **Status**: Accepted (ADR-0048 accepted on 2026-03-23)
 > **Related ADR**: [ADR-0048](../../adr/ADR-0048-directory-sync-capability.md)
 > **Owner**: @jindyzhao
 > **Created**: 2026-03-19
@@ -22,6 +22,13 @@ This note captures the implementation shape that follows that boundary.
 It also aligns the preview/import record wording with the normalized
 `external cohort` standard introduced in the ADR-0049 draft.
 
+Admin-only read models for this workspace may live under
+`internal/edge/authworkspace/...`, split into narrower subpackages such as
+`runtimeview` and `directoryview`, so that HTTP handlers stay thin while core
+and provider code remain isolated. `runtimeview` owns runtime/login-mode DTO
+construction; `directoryview` owns preview/job/schedule DTO construction,
+including list pagination and unsupported schedule-state DTOs.
+
 ## Scope
 
 - In scope: optional `DirectorySyncCapability` contract on auth-provider adapters
@@ -40,7 +47,10 @@ It also aligns the preview/import record wording with the normalized
 
 ### 1.1 Go Interface
 
-File: `internal/provider/directory_sync.go`
+Primary contract file: `internal/provider/directorycontract/contract.go`
+
+`internal/provider/directory_sync.go` may remain as a thin re-export layer while
+the broader provider package is reduced.
 
 ```go
 package provider
@@ -80,8 +90,15 @@ type DirectoryConflict struct {
 }
 
 // DirectoryPreviewItem is what core shows in preview responses.
+type DirectoryPreviewMatch struct {
+    Action         string `json:"action"` // create | update | blocked
+    ExistingUserID string `json:"existing_user_id,omitempty"`
+    MatchedBy      string `json:"matched_by,omitempty"` // external_id
+}
+
 type DirectoryPreviewItem struct {
     Record    DirectoryUserRecord  `json:"record"`
+    Match     DirectoryPreviewMatch `json:"match"`
     Conflicts []DirectoryConflict  `json:"conflicts,omitempty"`
     Warnings  []string             `json:"warnings,omitempty"`
 }
@@ -217,9 +234,9 @@ func (DirectorySyncJob) Fields() []ent.Field {
             Comment("Opaque provider_request payload frozen at trigger time"),
         field.String("conflict_resolution").Default("skip"),
         field.Int("total_entries").Default(0),
-        field.Int("created_count").Default(0),
-        field.Int("updated_count").Default(0),
-        field.Int("skipped_count").Default(0),
+        field.Int("create_count").Default(0),
+        field.Int("update_count").Default(0),
+        field.Int("blocked_count").Default(0),
         field.Int("error_count").Default(0),
         field.JSON("errors", []string{}).Optional(),
         field.String("triggered_by").NotEmpty(),
@@ -253,6 +270,18 @@ classification. It must resolve conflicts first, then write.
 
 Preview responses include canonical `conflicts` so administrators see how a sync
 will behave before enqueue.
+
+### 3.4 Execution summary rule
+
+Async job results must reuse the same canonical action vocabulary as preview:
+
+- `create`
+- `update`
+- `blocked`
+
+`manual_import` and `scheduled_enrichment` may differ in source flow, but their
+persisted job summary must expose the same action buckets so admin UI and
+automation do not reintroduce provider-specific reasoning.
 
 ---
 
@@ -355,8 +384,78 @@ Standard paginated list response.
 
 ### 4.5 `GET /admin/auth-providers/{id}/directory/sync-jobs/{jobId}`
 
-Returns job summary and counts only. It does not expose provider workflow
-internals as first-class fields.
+Returns canonical job detail:
+
+* standard execution metadata
+* standard `result_summary` buckets using the same `create / update / blocked`
+  vocabulary as preview
+* opaque `request_snapshot` for debugging/replay
+
+It still does not expose provider workflow internals as first-class fields.
+
+### 4.6 Current admin workbench baseline
+
+The current host implementation already exposes a minimal provider-agnostic
+directory workbench around these APIs:
+
+* runtime/schedule/jobs state remains visible in the same admin surface
+* the provider-owned `request_schema` is rendered as a schema-driven request
+  form
+* preview shows canonical rows, normalized conflicts, and warnings
+* preview also exposes a result-first summary split into `ready`,
+  `warning`, and `conflict` buckets so administrators can understand match
+  quality before reading the detailed table
+* preview now carries a canonical `match` object so the host can distinguish
+  `create`, safe `update`, and `blocked` rows without guessing from raw
+  conflict arrays
+* preview can be filtered by those same standard result buckets and surfaces
+  aggregated conflict codes without introducing provider-specific navigation
+* preview summary cards may link to the latest relevant sync job detail using
+  the same canonical action vocabulary, for example jumping from a blocked
+  summary card to the latest job whose `result_summary.blocked_count > 0`
+* conflict-heavy previews may also render grouped summaries for canonical
+  conflict codes such as `username_conflict` or `ambiguous_existing_user`,
+  but that grouping remains derived from the existing canonical result shape
+* grouped conflict summaries may expand into per-code detail sections, but
+  those sections still reuse the same canonical preview rows instead of
+  introducing provider-owned sub-workflows
+* warning-heavy previews may apply the same pattern, grouping repeated warning
+  messages into expandable detail sections derived from the canonical preview
+  rows
+* manual sync launches an async job and relies on the standard jobs list for
+  follow-up
+* jobs list can be filtered by the same canonical action vocabulary
+  (`create / update / blocked`) instead of provider-specific outcome labels
+* a job detail surface may show result-summary tags, execution metadata,
+  errors, and opaque request snapshot, but should continue to avoid
+  provider-specific workflow widgets
+* handler-local view-model shaping for this admin workbench may be extracted
+  into an `internal/edge/...` package so HTTP handlers keep orchestration
+  concerns while edge workspace code owns provider-neutral admin DTO mapping
+* the same pattern can cover schedule status shaping as well: handlers load the
+  latest/pending job rows, while `internal/edge/...` code computes the standard
+  `supported/enabled/next_run` view model from the normalized plan
+* runtime descriptor construction and directory-capability resolution may also
+  move into `internal/edge/...` helpers so admin handlers stay focused on HTTP
+  flow, permission gates, and error mapping
+
+This is intentionally a result-first workbench. It must not grow
+provider-specific navigation models such as department trees, OU explorers, or
+vendor wizards into the shared UI/API.
+
+### 4.7 Schema-driven object field handling
+
+Provider-owned request payloads may legitimately contain nested objects. The
+schema-driven form layer should therefore treat `type: object` fields as local
+JSON editing surfaces:
+
+* edit-time defaults should be rendered as formatted JSON text
+* submit-time values should be parsed back into JSON objects before request
+  transmission
+* invalid JSON must be surfaced to administrators as a request-form error
+
+This keeps the shared workbench generic while still supporting provider-owned
+nested request structures.
 
 ---
 
@@ -384,7 +483,8 @@ type DirectorySyncArgs struct {
    - classify conflicts
    - create/update canonical `User`
    - upsert `UserDirectoryProfile.attributes`
-7. Update `DirectorySyncJob` counters
+7. Update `DirectorySyncJob` result summary using canonical action buckets
+   (`create / update / blocked`)
 
 ### 5.3 Explicit non-goals
 

--- a/docs/design/notes/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
+++ b/docs/design/notes/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md
@@ -1,6 +1,6 @@
 # Design Note: ADR-0049 — External Auth Runtime, JIT User Provisioning, and External Cohort-to-RBAC Mapping
 
-> **Status**: Proposed (ADR-0049 under review until 2026-03-22)
+> **Status**: Accepted (ADR-0049 accepted on 2026-03-23)
 > **Related ADR**: [ADR-0049](../../adr/ADR-0049-external-auth-runtime-jit-provisioning-and-external-cohort-rbac-mapping.md)
 > **Owner**: @jindyzhao
 > **Created**: 2026-03-20
@@ -42,7 +42,7 @@ Implementation should extend the public plugin SDK, not `internal/provider`,
 with a runtime contract similar to:
 
 * `pkg/authproviderplugin/runtime.go`
-* `internal/provider/auth_runtime.go`
+* `internal/provider/runtimecontract/contract.go`
 
 The shared contract should stay small and stable:
 
@@ -74,39 +74,105 @@ type AuthStartRequest struct {
     ReturnTo  string `json:"return_to,omitempty"`
 }
 
+type AuthCredentialRequest struct {
+    LoginMode   string                 `json:"login_mode,omitempty"`
+    Credentials map[string]interface{} `json:"credentials,omitempty"`
+    UserAgent   string                 `json:"user_agent,omitempty"`
+}
+
 type AuthStartResponse struct {
     RedirectURL string `json:"redirect_url,omitempty"`
 }
 
 type AuthCallbackRequest struct {
-    Query  map[string][]string `json:"query,omitempty"`
-    Form   map[string][]string `json:"form,omitempty"`
-    Header map[string][]string `json:"header,omitempty"`
+    Method     string              `json:"method,omitempty"`
+    Query      map[string][]string `json:"query,omitempty"`
+    Form       map[string][]string `json:"form,omitempty"`
+    Header     map[string][]string `json:"header,omitempty"`
+    RemoteAddr string              `json:"remote_addr,omitempty"`
 }
 
 type AuthRuntimeCapability interface {
     StartLogin(ctx context.Context, config map[string]interface{}, req AuthStartRequest) (*AuthStartResponse, error)
     CompleteLogin(ctx context.Context, config map[string]interface{}, req AuthCallbackRequest) (*AuthResult, error)
 }
+
+type AuthCredentialCapability interface {
+    AuthenticateCredentials(ctx context.Context, config map[string]interface{}, req AuthCredentialRequest) (*AuthResult, error)
+}
 ```
 
 Core must validate the canonical result shape, but must not understand
-provider-specific callback fields.
+provider-specific callback fields or provider-specific credential payload
+semantics.
+
+Implementation note:
+
+* prefer `internal/provider/admincontract/contract.go` as the narrow internal
+  home for admin-side auth-provider metadata/contracts
+* prefer `internal/provider/adminregistry/registry.go` as the narrow internal
+  home for auth-provider admin registry mechanics
+* prefer `internal/provider/adminglobal/global.go` as the narrow internal home
+  for the process-global admin registry entrypoints; keep
+  `internal/provider/auth_provider_admin_global.go` focused on built-in
+  registration and root-package re-export only
+* prefer `internal/provider/configcodec/codec.go` as the narrow internal home
+  for auth-provider config encryption/masking; keep
+  `internal/provider/auth_provider_config_codec.go` as a thin re-export layer
+  so jobs and handlers can depend on the utility without widening back to the
+  root `provider` package
+* keep `internal/provider/auth.go` focused on runtime auth contract only
+* prefer `internal/provider/runtimecontract/contract.go` as the narrow internal
+  home for runtime auth types; keep `internal/provider/auth.go` as a thin
+  re-export layer while the wider `provider` package is being reduced
+* prefer `internal/provider/approvalcontract/contract.go` and
+  `internal/provider/notificationcontract/contract.go` as the narrow internal
+  homes for approval and notification seams; keep
+  `internal/provider/approval.go` and `internal/provider/notification.go` as
+  thin re-export layers so future public-SDK extraction does not drag unrelated
+  provider concerns into the runtime surface
+* approval callers that only need canonical request/decision types should
+  depend on `approvalcontract` directly instead of routing pure type references
+  through the wider `internal/provider` root package
+* provider-neutral capability helpers such as `HasAllCapabilities` should live
+  in a narrow utility package when handlers only need feature-set checks; avoid
+  pulling the wider `internal/provider` root package into admin/read-only paths
+* VM infrastructure interfaces such as `InfrastructureProvider`,
+  `ProvisioningQueryProvider`, `PVCClonePreflightProvider`, and `ListOptions`
+  should live in a narrow `infracontract` package; keep
+  `internal/provider/interface.go` as a thin re-export layer
+
+### 1.4 Platform-wide public callback base URL
+
+Runtime external-auth callback URLs should be generated from a platform-wide
+public base URL, not from per-provider config.
+
+Implementation guidance:
+
+* keep a deployment default such as `server.public_base_url`
+* optionally expose a platform-level system setting override for administrators
+* reuse the same effective value across WeCom, OIDC, and future external auth
+  providers
+* do not add `public_base_url` or equivalent fields to provider config schemas
+
+This keeps deployment topology concerns in Shepherd core/system settings rather
+than leaking them into provider-specific config.
 
 ### 1.2 Core-owned runtime steps
 
 For external auth, the generic flow should be:
 
 1. list login-capable providers
-2. start provider login
-3. receive callback on a generic provider callback path
-4. pass callback envelope to provider
-5. receive canonical `AuthResult`
-6. perform JIT upsert
-7. refresh external cohorts/profile projection
-8. reconcile auto-managed RoleBindings when configured
-9. issue Shepherd JWT/session
-10. return a provider-agnostic frontend bridge response so browser-based login
+2. either start provider login or submit a standard credential envelope,
+   depending on the provider-defined interaction style
+3. when using redirect flows, receive callback on a generic provider callback
+   path and pass the callback envelope to the provider
+4. receive canonical `AuthResult`
+5. perform JIT upsert
+6. refresh external cohorts/profile projection
+7. reconcile auto-managed RoleBindings when configured
+8. issue Shepherd JWT/session
+9. return a provider-agnostic frontend bridge response so browser-based login
     UIs can receive the Shepherd session without exposing the JWT in a callback
     query string
 
@@ -115,6 +181,7 @@ For external auth, the generic flow should be:
 The provider owns:
 
 * redirect URL construction
+* credential payload interpretation for direct credential login modes
 * provider callback parameter parsing
 * token exchange
 * remote userinfo lookup
@@ -246,6 +313,14 @@ Recommended scope:
 Both belong to one `wecom` provider type and should appear as provider-defined
 login modes, not separate core auth products.
 
+LDAP is the first standard provider practice for a non-redirect interaction
+style:
+
+* provider advertises a `credentials` login mode
+* core collects the credential envelope without understanding LDAP bind/search details
+* provider performs service bind, search, and user bind internally
+* provider returns canonical `AuthResult`
+
 ### 4.3 Canonical field mapping
 
 WeCom-specific user data should be adapted into the shared result:
@@ -276,6 +351,7 @@ surface similar to:
 
 * `GET /auth/providers`
 * `POST /auth/providers/{id}/login/start`
+* `POST /auth/providers/{id}/login/submit`
 * `GET /auth/providers/{id}/callback`
 * callback responses may be HTML bridge pages that `postMessage` the resulting
   Shepherd session back to the initiating frontend window
@@ -283,6 +359,38 @@ surface similar to:
 If additional endpoints are required, they should still preserve the rule that
 core endpoints remain provider-agnostic and provider-specific callback/query
 details stay inside the adapter.
+
+### 5.1 Current admin runtime descriptor baseline
+
+The current host implementation also exposes a provider-agnostic admin
+descriptor for runtime login capability:
+
+* `GET /admin/auth-providers/{id}/runtime`
+
+This descriptor is intended to answer only standard questions:
+
+* does this provider support runtime login at all
+* does it expose `redirect`, `credentials`, or both interaction styles
+* does any login mode require the platform-wide public callback base URL
+* which provider-defined login modes are currently visible
+
+It must not expose vendor workflow internals such as WeCom callback quirks or
+LDAP bind/search details. Those remain adapter-owned.
+
+### 5.2 Current login-page/admin contract alignment
+
+The shared runtime contract now supports two interaction styles:
+
+* `redirect`
+* `credentials`
+
+The current host implementation uses this to keep the login page and the admin
+surface aligned:
+
+* login page renders the provider-defined interaction without vendor branching
+* admin page shows runtime readiness using the same normalized descriptor
+* browser-based flows rely on the platform-wide public base URL only when the
+  provider exposes redirect-based runtime login
 
 ---
 

--- a/docs/design/notes/ADR-0050-upstream-identity-assertion-runtime-provider.md
+++ b/docs/design/notes/ADR-0050-upstream-identity-assertion-runtime-provider.md
@@ -1,5 +1,8 @@
 # ADR-0050 Design Note: Upstream Identity Assertion Runtime Provider
 
+> **Status**: Accepted (ADR-0050 accepted on 2026-03-23)
+> **Related ADR**: [ADR-0050](../../adr/ADR-0050-upstream-identity-assertion-runtime-provider.md)
+
 ## Purpose
 
 This note captures implementation-facing details for a runtime auth provider
@@ -34,24 +37,40 @@ runtime provider contract.
 Provider-local config may include:
 
 * `login_entry_url`
+* `callback_param_name`
+* `state_param_name`
+* `return_to_param_name`
 * `trust_mode`
 * `userinfo_endpoint`
 * `introspection_endpoint`
-* `token_transport`
+* `incoming_token_transport`
   - `authorization_bearer`
   - `query`
   - `cookie`
   - `header`
-* `token_param_name`
-* `token_header_name`
+* `incoming_token_name`
+* `upstream_token_transport`
+  - `authorization_bearer`
+  - `query`
+  - `header`
+  - `form`
+* `upstream_token_name`
 * `trusted_header_username`
 * `trusted_header_email`
+* `trusted_header_external_id`
+* `trusted_header_display_name`
+* `trusted_header_enabled`
+* `trusted_header_cohorts`
+* `trusted_header_cohort_kind`
 * `trusted_gateway_cidrs`
 * `username_path`
 * `display_name_path`
 * `email_path`
 * `external_id_path`
-* `cohort_paths`
+* `enabled_path`
+* `active_path`
+* `cohort_path`
+* `cohort_kind`
 * `profile_attribute_paths`
 * `request_timeout_seconds`
 
@@ -83,6 +102,12 @@ This config belongs to the provider, not to core runtime auth.
 3. Provider verifies request origin is within configured trust boundary.
 4. Provider maps trusted header values into canonical `AuthResult`.
 5. Core continues with standard runtime flow.
+
+Current implementation note:
+
+* trusted-header mode relies on the callback/runtime request envelope carrying
+  the request `RemoteAddr`, so provider-local CIDR checks can be performed
+  without pushing gateway trust logic into core auth semantics
 
 ## Security Constraints
 

--- a/docs/design/notes/ADR-0051-scheduled-directory-enrichment.md
+++ b/docs/design/notes/ADR-0051-scheduled-directory-enrichment.md
@@ -1,5 +1,8 @@
 # ADR-0051 Design Note: Scheduled Directory Enrichment
 
+> **Status**: Accepted (ADR-0051 accepted on 2026-03-23)
+> **Related ADR**: [ADR-0051](../../adr/ADR-0051-scheduled-directory-enrichment.md)
+
 ## Purpose
 
 This note captures implementation-facing details for enriching existing Shepherd
@@ -64,6 +67,30 @@ Provider-owned request/schedule inputs may include:
 
 These stay provider-local and must remain opaque to core.
 
+### Current implementation shape
+
+The current host implementation models scheduled enrichment as an optional
+provider capability:
+
+* `BuildScheduledDirectoryEnrichmentPlan(ctx, config)`
+
+The returned plan currently carries:
+
+* `enabled`
+* `mode`
+* `join_key_type`
+* `schedule_cron`
+* `schedule_timezone`
+* `provider_request`
+
+Core persists explicit job metadata for:
+
+* `sync_mode`
+* `join_key_type`
+
+This keeps manual imports and scheduled enrichment distinct in audit/job
+history without introducing a second identity model.
+
 ## Core-Owned Write Model
 
 Scheduled enrichment may write:
@@ -96,8 +123,29 @@ For a directory-capable provider, schedule/enrichment config may include:
 * `selected_cohort_kinds`
 * `write_profile_fields`
 * `write_cohorts`
+* `scheduled_provider_request`
 
 These are provider-local admin settings, not core identity fields.
+
+### Generic provider baseline
+
+The current generic provider exposes a minimal baseline for exercising the
+common contract:
+
+* `enrichment_enabled`
+* `enrichment_mode`
+* `schedule_cron`
+* `schedule_timezone`
+* `join_key_type`
+* `scheduled_provider_request`
+
+The first supported mode is:
+
+* `enrich_existing_only`
+
+The first supported join rule is:
+
+* `username`
 
 ## WeCom First-Provider Guidance
 
@@ -128,6 +176,27 @@ Admin UI should expose:
 
 The UI should not imply that enrichment changes permissions directly.
 
+### Current admin workbench baseline
+
+The current host implementation already exposes a shared admin workbench around
+scheduled enrichment and manual directory execution:
+
+* runtime capability descriptor
+* directory preview form/result
+* schedule status
+* recent sync jobs
+* sample fields and discovered cohorts
+
+This gives administrators one provider-agnostic place to understand:
+
+* how records will be normalized
+* whether runtime login is available
+* whether scheduled enrichment is enabled
+* what the latest manual or scheduled jobs did
+
+The current workbench is intentionally conservative. It does not yet implement
+a full manual-review queue for ambiguous matches.
+
 ## Testing Requirements
 
 Minimum tests:
@@ -137,6 +206,21 @@ Minimum tests:
 * unmatched records are reported but not auto-created in default mode
 * ambiguous matches are classified and skipped
 * synced cohorts do not directly affect runtime authorization
+
+### Current scheduler baseline
+
+The current host scheduler runs as a periodic River job scanner:
+
+* interval: every 5 minutes
+* startup behavior: `RunOnStart`
+
+This scanner does not own provider workflow. It only:
+
+1. asks each capable provider for a normalized plan
+2. evaluates whether the plan is due
+3. creates a canonical scheduled enrichment job
+4. lets the existing directory worker execute the provider-owned fetch and
+   core-owned write rules
 
 ## Private Repository Support
 


### PR DESCRIPTION
## Summary
Record acceptance for ADR-0048, ADR-0049, ADR-0050, and ADR-0051 after their public review windows closed.

## Scope
- mark `ADR-0048` / `ADR-0049` / `ADR-0050` / `ADR-0051` as `accepted`
- update related design-note status markers
- update `docs/adr/README.md` status table and reading order

## Constraints
- docs only
- no implementation code
- no generated/runtime artifacts
- no normative design-spec changes beyond ADR acceptance metadata/indexing

## Review Window Check
- ADR-0048 review issue `#396`: review closed on 2026-03-21
- ADR-0049 review issue `#400`: review closed on 2026-03-22
- ADR-0050/0051 review issue `#402`: review closed on 2026-03-23
- current preparation time: 2026-03-23 11:16 UTC

## Validation
- `bash docs/design/ci/scripts/check_design_doc_governance.sh`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`
- `go run docs/design/ci/scripts/check_auth_provider_plugin_boundary.go`

Closes #404
Refs #396
Refs #400
Refs #402