### PR TITLE
fix(auth): clear stale session cookies

### DIFF
--- a/internal/api/middleware/jwt.go
+++ b/internal/api/middleware/jwt.go
@@ -211,6 +211,9 @@ func JWTAuthWithConfig(cfg JWTConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenString, source, err := extractJWTToken(c.Request, cfg.CookieName)
 		if err != nil {
+			if source == tokenSourceCookie {
+				clearJWTSessionCookie(c.Writer, cfg.CookieName)
+			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"code":    "UNAUTHORIZED",
 				"message": err.Error(),
@@ -220,6 +223,9 @@ func JWTAuthWithConfig(cfg JWTConfig) gin.HandlerFunc {
 		claims, err := cfg.ValidateToken(c.Request.Context(), tokenString)
 
 		if err != nil {
+			if source == tokenSourceCookie {
+				clearJWTSessionCookie(c.Writer, cfg.CookieName)
+			}
 			code := "UNAUTHORIZED"
 			msg := "invalid token"
 			switch {
@@ -260,6 +266,23 @@ func JWTAuthWithConfig(cfg JWTConfig) gin.HandlerFunc {
 	}
 }
 
+func clearJWTSessionCookie(w http.ResponseWriter, cookieName string) {
+	cookieName = strings.TrimSpace(cookieName)
+	if w == nil || cookieName == "" {
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0).UTC(),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 // JWTAuth is a compatibility wrapper for legacy call sites.
 func JWTAuth(signingKey []byte) gin.HandlerFunc {
 	return JWTAuthWithConfig(JWTConfig{SigningKey: signingKey})
@@ -289,7 +312,7 @@ func extractJWTToken(r *http.Request, cookieName string) (token, source string, 
 		if err == nil {
 			token := strings.TrimSpace(cookie.Value)
 			if token == "" {
-				return "", "", fmt.Errorf("missing auth session cookie")
+				return "", tokenSourceCookie, fmt.Errorf("missing auth session cookie")
 			}
 			return token, tokenSourceCookie, nil
 		}

--- a/internal/api/middleware/jwt_auth_cookie_test.go
+++ b/internal/api/middleware/jwt_auth_cookie_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,5 +59,78 @@ func TestJWTAuthWithConfig_BackfillsAuthorizationHeaderFromCookie(t *testing.T) 
 	}
 	if got, want := rec.Body.String(), "Bearer "+token; got != want {
 		t.Fatalf("authorization header = %q, want %q", got, want)
+	}
+}
+
+func TestJWTAuthWithConfig_ClearsCookieOnInvalidCookieToken(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	issueCfg := JWTConfig{
+		SigningKey: []byte("expired-cookie-token-signing-key-1234567890"),
+		Issuer:     "shepherd",
+		ExpiresIn:  -time.Hour,
+		CookieName: "shepherd_session",
+	}
+	token, _, err := GenerateToken(issueCfg, "u-1", "alice", nil, nil)
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+
+	router := gin.New()
+	router.Use(JWTAuthWithConfig(JWTConfig{
+		SigningKey: issueCfg.SigningKey,
+		Issuer:     issueCfg.Issuer,
+		CookieName: issueCfg.CookieName,
+	}))
+	router.GET("/auth/me", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: "shepherd_session", Value: token})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	cookieHeader := rec.Header().Get("Set-Cookie")
+	if !strings.Contains(cookieHeader, "shepherd_session=") {
+		t.Fatalf("Set-Cookie missing session name: %s", cookieHeader)
+	}
+	if !strings.Contains(cookieHeader, "Max-Age=0") {
+		t.Fatalf("Set-Cookie should expire the session cookie: %s", cookieHeader)
+	}
+}
+
+func TestJWTAuthWithConfig_ClearsEmptyCookie(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(JWTAuthWithConfig(JWTConfig{
+		SigningKey: []byte("empty-cookie-token-signing-key-1234567890"),
+		Issuer:     "shepherd",
+		CookieName: "shepherd_session",
+	}))
+	router.GET("/auth/me", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: "shepherd_session", Value: ""})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	cookieHeader := rec.Header().Get("Set-Cookie")
+	if !strings.Contains(cookieHeader, "shepherd_session=") {
+		t.Fatalf("Set-Cookie missing session name: %s", cookieHeader)
+	}
+	if !strings.Contains(cookieHeader, "Max-Age=0") {
+		t.Fatalf("Set-Cookie should expire the session cookie: %s", cookieHeader)
 	}
 }

--- a/web/src/proxy.test.ts
+++ b/web/src/proxy.test.ts
@@ -42,13 +42,12 @@ describe("proxy", () => {
     expect(response.headers.get("location")).toBeNull();
   });
 
-  it("redirects authenticated users away from the login page", () => {
+  it("allows the login page to validate a session cookie client-side", () => {
     const response = proxy(
       makeRequest("https://shepherd.example.com/login", "shepherd_session=session-token"),
     );
 
-    expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe("https://shepherd.example.com/dashboard");
+    expect(response.headers.get("location")).toBeNull();
   });
 
   it("treats the password change page as protected", () => {
@@ -65,10 +64,15 @@ describe("proxy", () => {
     const protectedResponse = proxy(makeRequest("https://shepherd.example.com/dashboard"));
     expect(protectedResponse.headers.get("location")).toBe("https://shepherd.example.com/signin");
 
+    const protectedCookieResponse = proxy(
+      makeRequest("https://shepherd.example.com/dashboard", "custom_session=session-token"),
+    );
+    expect(protectedCookieResponse.headers.get("location")).toBeNull();
+
     const loginResponse = proxy(
       makeRequest("https://shepherd.example.com/signin", "custom_session=session-token"),
     );
-    expect(loginResponse.headers.get("location")).toBe("https://shepherd.example.com/dashboard");
+    expect(loginResponse.headers.get("location")).toBeNull();
   });
 
   it("emits nonce-based CSP in production", () => {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -121,10 +121,6 @@ export function proxy(request: NextRequest) {
     return applyCspToResponse(NextResponse.redirect(new URL(loginPath, request.url)), nonce);
   }
 
-  if (pathname === loginPath && hasSession) {
-    return applyCspToResponse(NextResponse.redirect(new URL("/dashboard", request.url)), nonce);
-  }
-
   const requestHeaders = buildForwardedRequestHeaders(request.headers, nonce);
 
   const response = NextResponse.next({


### PR DESCRIPTION
## Summary

- Expire invalid cookie-backed JWT sessions on 401 responses.
- Let the login page validate any existing session client-side instead of redirecting from proxy based only on cookie presence.
- Add backend and frontend regression coverage for stale session cookie behavior.

## Issue

Closes #668

## Validation

- make pr
- make secrets-scan
- go test ./internal/api/middleware
- npm run lint --prefix web
- npm run typecheck --prefix web
- npm run test:run -- --run src/proxy.test.ts

## Release impact

bugfix/patch