### PR TITLE
fix(auth): keep standard login route local

### DIFF
--- a/web/src/lib/api/authPolicy.test.ts
+++ b/web/src/lib/api/authPolicy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
     getRequestPath,
@@ -10,6 +10,12 @@ import {
 } from './authPolicy';
 
 describe('authPolicy', () => {
+    const originalLoginEntryPath = process.env.NEXT_PUBLIC_LOGIN_ENTRY_PATH;
+
+    afterEach(() => {
+        process.env.NEXT_PUBLIC_LOGIN_ENTRY_PATH = originalLoginEntryPath;
+    });
+
     it('treats public auth endpoints as unauthenticated request paths', () => {
         expect(isPublicAuthRequestPath('/api/v1/auth/login')).toBe(true);
         expect(isPublicAuthRequestPath('/api/v1/auth/providers')).toBe(true);
@@ -40,6 +46,14 @@ describe('authPolicy', () => {
         expect(shouldRedirectToLoginOnUnauthorized('/api/v1/auth/login', '/login')).toBe(false);
         expect(shouldRedirectToLoginOnUnauthorized('/api/v1/vms', '/login')).toBe(false);
         expect(shouldRedirectToLoginOnUnauthorized('/api/v1/vms', '/dashboard')).toBe(true);
+    });
+
+    it('keeps the standard login page local when a custom login entry is configured', () => {
+        process.env.NEXT_PUBLIC_LOGIN_ENTRY_PATH = '/custom-login';
+
+        expect(shouldRedirectToLoginOnUnauthorized('/api/v1/auth/me', '/login')).toBe(false);
+        expect(shouldRedirectToLoginOnUnauthorized('/api/v1/auth/me', '/custom-login')).toBe(false);
+        expect(shouldRedirectToLoginOnUnauthorized('/api/v1/auth/me', '/dashboard')).toBe(true);
     });
 
     it('extracts request path safely', () => {

--- a/web/src/lib/api/authPolicy.ts
+++ b/web/src/lib/api/authPolicy.ts
@@ -1,4 +1,4 @@
-import { getLoginEntryPath } from "@/lib/auth/loginEntry";
+import { getLoginEntryPath, getStandardLoginPath } from "@/lib/auth/loginEntry";
 
 export function getRequestPath(request: Request, origin = 'http://localhost'): string {
     try {
@@ -42,5 +42,5 @@ export function shouldRedirectToLoginOnUnauthorized(
     if (!shouldLogoutOnUnauthorized(requestPath)) {
         return false;
     }
-    return currentPathname !== getLoginEntryPath();
+    return currentPathname !== getLoginEntryPath() && currentPathname !== getStandardLoginPath();
 }


### PR DESCRIPTION
## Summary

- Treat the standard `/login` route as a login page even when a custom login entry path is configured.
- Keep protected-route 401 handling pointed at the configured login entry.
- Add regression coverage for custom login entry behavior.

## Issue

Closes #670

## Validation

- npm run test:run -- --run src/lib/api/authPolicy.test.ts
- npm run test:run -- --run src/lib/api/authPolicy.test.ts src/lib/api/client.test.ts src/features/auth-login/components/LoginPageContent.test.tsx
- npm run lint --prefix web
- npm run typecheck --prefix web

## Scope

Generic frontend auth redirect behavior only; no deployment-specific routes, domains, or provider names are included.