### PR TITLE
fix(vm): carry live status resourceVersion

### DIFF
--- a/docs/adr/ADR-0015-governance-model-v2.md
+++ b/docs/adr/ADR-0015-governance-model-v2.md
@@ -2395,3 +2395,11 @@ DELETE /api/v1/systems/{id}?confirm_name=shop
 > - `professional_fields` is a presentation tier only; it must not change authorization, validation, approval, or runtime behavior.
 > - Admin UI must keep `professional_fields` hidden by default and require explicit opt-in before exposing expert-only paths.
 > - `mask.quick_fields` remains the required array in schema responses; `advanced_fields` and `professional_fields` stay optional mask lists.
+
+---
+
+## Historical Scope Note (2026-05-15)
+
+ADR-0015 is an accepted historical record from the pre-ADR-0030 governance phase. It intentionally remains broad and detailed because accepted ADRs are immutable; the project will not split or rewrite it retroactively. For current implementation review, use the amendment blocks above and later focused ADRs as the canonical source for superseded details such as VM request ownership, Template/InstanceSize boundaries, RBAC baseline roles, auth-provider naming, and schema-mask tiers.
+
+Do not treat this ADR's length or embedded implementation sketches as the current ADR authoring standard. New ADRs must follow the concise, decision-focused template and documentation layering rules introduced later in `ADR-0030` and `TEMPLATE.md`.

--- a/docs/adr/ADR-0016-go-module-vanity-import.md
+++ b/docs/adr/ADR-0016-go-module-vanity-import.md
@@ -179,3 +179,9 @@ import (
 > Going forward, all ADRs should follow the standard `Proposed → Accepted` lifecycle
 > with a minimum 48-hour public comment period. See Issue #14 for governance process
 > documentation.
+
+---
+
+## Historical Scope Note (2026-05-15)
+
+ADR-0016 is an early migration-phase ADR. Its expedited approval and operational setup detail are preserved for traceability, not as a model for new ADR shape or review process. New ADRs must follow the later concise, decision-focused ADR template and the standard review lifecycle unless a subsequent accepted ADR explicitly grants an exception.

--- a/docs/adr/ADR-0017-vm-request-flow-clarification.md
+++ b/docs/adr/ADR-0017-vm-request-flow-clarification.md
@@ -368,3 +368,9 @@ func (Namespace) Fields() []ent.Field {
 | 2026-01-26 | Added: Pre-written "Amendments by Subsequent ADRs" block for ADR-0015 (to be appended upon ADR-0017 acceptance) |
 | 2026-01-26 | Added: Namespace Schema Correction section - clarifies that `namespace_registry` should NOT have `cluster_id` field (multi-cluster governance principle) |
 | 2026-01-27 | Added: Namespace JIT Creation with permission denied handling (graceful error with actionable hints) |
+
+---
+
+## Historical Scope Note (2026-05-15)
+
+ADR-0017 is an accepted historical clarification ADR from the same early governance period as ADR-0015. It keeps amendment text and detailed migration guidance inline because accepted ADRs are immutable and must remain auditable. Do not interpret its size as the current ADR authoring standard; later ADR governance requires concise, decision-focused records with detailed flows moved to design documents where appropriate.

--- a/docs/adr/ADR-0018-instance-size-abstraction.md
+++ b/docs/adr/ADR-0018-instance-size-abstraction.md
@@ -2348,3 +2348,11 @@ RUNNING/STOPPED → DELETING → DELETED (terminal)
 ---
 
 _End of ADR-0018_
+
+---
+
+## Historical Scope Note (2026-05-15)
+
+ADR-0018 is an accepted historical design ADR that predates the later documentation-layering standard. Its detailed examples, UI sketches, migration checklist, and pre-written amendment blocks are intentionally preserved for auditability and will not be split after acceptance. For current review, treat later amendment blocks and focused ADRs as the canonical source where they supersede or refine sections of this document.
+
+Do not use ADR-0018's length as evidence that current ADR governance allows broad specification documents. New ADRs must remain concise and decision-focused, with implementation flows and test matrices maintained in the appropriate `docs/design/` layer.

--- a/docs/adr/ADR-0020-frontend-technology-stack.md
+++ b/docs/adr/ADR-0020-frontend-technology-stack.md
@@ -917,3 +917,15 @@ _End of ADR-0020_
 > - **Vitest**: Configure with `coverage.thresholds` at 80% lines/functions/statements, 75% branches
 > - **Playwright**: Use for Server Component testing and critical E2E paths
 > - **CI**: Coverage below thresholds will **BLOCK** PR merging
+
+### Implementation Note: Next.js 16 / React 19 Runtime Update (2026-05-15)
+
+| Original Section | Status | Amendment Details | See Also |
+|------------------|--------|-------------------|----------|
+| §Complete Technology Stack: Next.js `15.x (App Router)` | **VERSION UPDATED** | The implemented frontend now uses Next.js `16.x` with the App Router. This is a framework-version update only; the architectural choice remains React + Next.js + Ant Design. | `web/package.json`; Next.js App Router docs |
+| §Complete Technology Stack: React `19.x` | **CONFIRMED** | The implemented frontend uses React `19.x`; this remains aligned with the original decision. | `web/package.json`; Next.js App Router docs |
+
+> **Implementation Guidance**:
+> - Treat the current implemented baseline as `next@16.x`, `react@19.x`, and `react-dom@19.x`.
+> - Continue to use the App Router model under `web/src/app/`; do not introduce Pages Router routes.
+> - Keep dependency updates as version amendments unless they change the architectural stack or routing model.

--- a/docs/adr/ADR-0031-concurrency-and-worker-pool-standard.md
+++ b/docs/adr/ADR-0031-concurrency-and-worker-pool-standard.md
@@ -117,6 +117,7 @@ We need a single, enforceable concurrency standard that keeps runtime behavior p
 
 * The reference Worker Pool example is maintained in `docs/design/examples/worker/pool.go`.
 * The reference CI gates live under `docs/design/ci/` and are required before coding-phase transition.
+* Entrypoint lifecycle bridges outside `internal/` may use a single bounded goroutine when the goroutine is only adapting a blocking runtime primitive into explicit shutdown/error handling. The current approved instance is `pkg/serverbootstrap.defaultServe`, which runs `http.Server.ListenAndServe`, reports at most one error through a buffered channel, and is terminated by `http.Server.Shutdown`. This is not an application-work concurrency escape hatch; new in-process work still belongs in the worker-pool or River model.
 
 ---
 

--- a/docs/adr/ADR-0038-adaptive-k8s-polling.md
+++ b/docs/adr/ADR-0038-adaptive-k8s-polling.md
@@ -156,9 +156,10 @@ Current: low-frequency
 * Code review confirms `last_k8s_rv` is persisted after every successful poll (including on 304 Not Modified responses).
 * DB schema review confirms `polling_tier`, `poll_interval_sec`, `last_k8s_rv`, `last_polled_at`, `high_tier_since` fields are added via Atlas migration.
 * Load test: with 1,000 stable VMs at 30-minute interval → ~0.5 req/s to K8s; with 100 transitional VMs at 15s interval → ~6.7 req/s. Total within acceptable bounds for governance platform scale.
-* CI gate: `k8spollingrv` analyzer verifies that polling-path `metav1.ListOptions`
-  and `metav1.GetOptions` struct literals include `ResourceVersion` using Go
-  type information, and rejects the explicit `"0"` sentinel in polling code.
+* CI gate: `k8spollingrv` analyzer verifies that polling-path `metav1.ListOptions`,
+  `metav1.GetOptions`, and Shepherd provider `infracontract.ListOptions` struct
+  literals include `ResourceVersion` using Go type information and polling-context
+  file/function detection, and rejects the explicit `"0"` sentinel in polling code.
 
 ---
 

--- a/docs/design/ci/scripts/check_auth_provider_plugin_boundary.go
+++ b/docs/design/ci/scripts/check_auth_provider_plugin_boundary.go
@@ -281,7 +281,7 @@ func main() {
 			path: "internal/api/handlers/vm_live_status.go",
 			required: []string{
 				`"kv-shepherd.io/shepherd/internal/provider/infracontract"`,
-				"infracontract.ListOptions{}",
+				"infracontract.ListOptions{",
 			},
 			forbiddenText: []string{
 				"provider.ListOptions{}",

--- a/internal/api/handlers/server_vm_test.go
+++ b/internal/api/handlers/server_vm_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"kv-shepherd.io/shepherd/ent"
 	entcluster "kv-shepherd.io/shepherd/ent/cluster"
@@ -52,6 +53,19 @@ func (p *failingVMLiveStatusProvider) ListVMs(ctx context.Context, _, namespace 
 		return nil, p.err
 	}
 	return p.MockProvider.ListVMs(ctx, "", namespace, provider.ListOptions{})
+}
+
+type resourceExpiredOnceVMProvider struct {
+	*provider.MockProvider
+	calls []provider.ListOptions
+}
+
+func (p *resourceExpiredOnceVMProvider) ListVMs(ctx context.Context, _, namespace string, opts provider.ListOptions) (*domain.VMList, error) {
+	p.calls = append(p.calls, opts)
+	if opts.ResourceVersion == "stale-rv" {
+		return nil, k8serrors.NewResourceExpired("stale resourceVersion")
+	}
+	return p.MockProvider.ListVMs(ctx, "", namespace, opts)
 }
 
 // ---- Pure unit tests for vmToAPI converter ------------------------------------------------
@@ -360,6 +374,70 @@ func TestListVMs_RefreshesStatusFromLiveCluster(t *testing.T) {
 	}
 	if stored.Status != entvm.StatusSTOPPED {
 		t.Fatalf("stored status = %q, want %q", stored.Status, entvm.StatusSTOPPED)
+	}
+}
+
+func TestListVMs_RetriesBaselineWhenCachedResourceVersionExpires(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.OpenEntPostgres(t, "list_vms_live_status_rv_expired")
+	_ = logger.Init("error", "json")
+
+	clusterID := "cluster-" + uuid.NewString()
+	mustCreateClusterWithEnv(t, client, clusterID, entcluster.EnvironmentProd)
+
+	vmID := "vm-" + uuid.NewString()
+	vmName := "vm" + vmID[len(vmID)-4:]
+	mustCreateVMWithCluster(t, client, vmID, clusterID, "prod-ns")
+	_, err := client.VM.UpdateOneID(vmID).
+		SetPollingTier(entvm.PollingTierLow).
+		SetPollIntervalSec(1800).
+		SetLastK8sRv("stale-rv").
+		Save(t.Context())
+	if err != nil {
+		t.Fatalf("seed stale resourceVersion: %v", err)
+	}
+
+	mock := provider.NewMockProvider()
+	mock.Seed([]*domain.VM{{
+		Name:            vmName,
+		Namespace:       "prod-ns",
+		Cluster:         clusterID,
+		Status:          domain.VMStatusStopped,
+		ResourceVersion: "rv-live-recovered",
+	}})
+	expiring := &resourceExpiredOnceVMProvider{MockProvider: mock}
+
+	srv := NewServer(ServerDeps{
+		EntClient: client,
+		VMService: service.NewVMService(expiring),
+	})
+
+	c, w := newAuthedGinContext(t, http.MethodGet, "/vms", "", "user-rv", []string{"vm:read", "platform:admin"})
+	srv.ListVMs(c, generated.ListVMsParams{})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if len(expiring.calls) < 2 {
+		t.Fatalf("ListVMs calls = %d, want at least 2", len(expiring.calls))
+	}
+	if got := expiring.calls[0].ResourceVersion; got != "stale-rv" {
+		t.Fatalf("first resourceVersion = %q, want stale-rv", got)
+	}
+	if got := expiring.calls[1].ResourceVersion; got != "" {
+		t.Fatalf("retry resourceVersion = %q, want empty baseline", got)
+	}
+
+	stored, err := client.VM.Get(t.Context(), vmID)
+	if err != nil {
+		t.Fatalf("reload vm: %v", err)
+	}
+	if stored.Status != entvm.StatusSTOPPED {
+		t.Fatalf("stored status = %q, want %q", stored.Status, entvm.StatusSTOPPED)
+	}
+	if stored.LastK8sRv == nil || *stored.LastK8sRv != "rv-live-recovered" {
+		t.Fatalf("stored last_k8s_rv = %v, want rv-live-recovered", stored.LastK8sRv)
 	}
 }
 

--- a/internal/api/handlers/vm_live_status.go
+++ b/internal/api/handlers/vm_live_status.go
@@ -64,7 +64,14 @@ func (s *Server) refreshVMLiveStates(ctx context.Context, vms []*ent.VM) []*ent.
 	}
 
 	for key, indexes := range groups {
-		liveList, err := s.vmService.ListVMs(ctx, key.clusterID, key.namespace, infracontract.ListOptions{})
+		groupRows := make([]*ent.VM, 0, len(indexes))
+		for _, idx := range indexes {
+			if vms[idx] != nil {
+				groupRows = append(groupRows, vms[idx])
+			}
+		}
+
+		liveList, err := s.listVMLiveStateGroup(ctx, key, groupRows)
 		observedAt := time.Now()
 		if err != nil {
 			// Scenario A: K8s API call failed — cluster unreachable → UNKNOWN
@@ -130,7 +137,7 @@ func (s *Server) loadObservedLiveVMsByID(ctx context.Context, vms []*ent.VM) map
 	}
 
 	for key, group := range groups {
-		liveList, err := s.vmService.ListVMs(ctx, key.clusterID, key.namespace, infracontract.ListOptions{})
+		liveList, err := s.listVMLiveStateGroup(ctx, key, group)
 		if err != nil {
 			logger.Warn("failed to load live vm details for namespace",
 				zap.String("cluster_id", key.clusterID),
@@ -161,6 +168,41 @@ func (s *Server) loadObservedLiveVMsByID(ctx context.Context, vms []*ent.VM) map
 	}
 
 	return liveByVMID
+}
+
+func (s *Server) listVMLiveStateGroup(ctx context.Context, key vmLiveGroupKey, group []*ent.VM) (*domain.VMList, error) {
+	resourceVersion := liveStateGroupResourceVersion(group)
+	liveList, err := s.vmService.ListVMs(ctx, key.clusterID, key.namespace, infracontract.ListOptions{
+		ResourceVersion: resourceVersion,
+	})
+	if err == nil || resourceVersion == "" {
+		return liveList, err
+	}
+	if !k8serrors.IsResourceExpired(err) && !k8serrors.IsGone(err) {
+		return liveList, err
+	}
+
+	logger.Warn("cached resourceVersion expired while refreshing live vm statuses, retrying baseline",
+		zap.String("cluster_id", key.clusterID),
+		zap.String("namespace", key.namespace),
+		zap.String("stale_rv", resourceVersion),
+		zap.Error(err),
+	)
+	return s.vmService.ListVMs(ctx, key.clusterID, key.namespace, infracontract.ListOptions{
+		ResourceVersion: "",
+	})
+}
+
+func liveStateGroupResourceVersion(group []*ent.VM) string {
+	for _, vmRow := range group {
+		if vmRow == nil || vmRow.LastK8sRv == nil {
+			continue
+		}
+		if resourceVersion := strings.TrimSpace(*vmRow.LastK8sRv); resourceVersion != "" {
+			return resourceVersion
+		}
+	}
+	return ""
 }
 
 func (s *Server) applyObservedVMState(ctx context.Context, vmRow *ent.VM, liveVM *domain.VM, observedAt time.Time) *ent.VM {

--- a/pkg/serverbootstrap/serverbootstrap.go
+++ b/pkg/serverbootstrap/serverbootstrap.go
@@ -123,6 +123,8 @@ func runWithConfig(
 }
 
 func defaultServe(srv *http.Server, errCh chan<- error) {
+	// ADR-0031 exception: this entrypoint-owned goroutine only bridges
+	// http.Server.ListenAndServe into shutdown-aware error handling.
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err

--- a/tools/shepherd-linter/README.md
+++ b/tools/shepherd-linter/README.md
@@ -98,6 +98,7 @@ Context7 best practices applied: `pass.Files` for comment scanning (not `os.Read
 |----------|----------|-----------------|
 | `openapirbaccontract` | Explicit `x-rbac` semantics, auth scheme alignment, and `401/403` response coverage on every OpenAPI operation | New analyzer-only enforcement |
 | `entquerysafety` | Raw `ent/dialect/sql` / `sqljson` usage is limited to reviewed `*_ent_predicates.go` helpers plus database/test integration | New analyzer-only enforcement |
+| `k8spollingrv` | ADR-0038: polling-path K8s and Shepherd provider options must carry `ResourceVersion`; rejects explicit `"0"` sentinel | New analyzer-only enforcement |
 
 **`ssacompliance` rules:**
 - Forbidden struct literals: `kubevirtv1.VirtualMachine{...}`, `kubevirtv1.VirtualMachineSpec{...}`, etc.
@@ -174,7 +175,7 @@ func (p *shepherdArchPlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 }
 
 func (p *shepherdArchPlugin) GetLoadMode() string {
-    return register.LoadModeTypesInfo  // k8spollingrv verifies real metav1 option types
+    return register.LoadModeTypesInfo  // k8spollingrv verifies real metav1/provider option types
 }
 ```
 

--- a/tools/shepherd-linter/analyzer/k8spollingrv/analyzer.go
+++ b/tools/shepherd-linter/analyzer/k8spollingrv/analyzer.go
@@ -5,16 +5,18 @@
 // resourceVersion from the previous API response. This routes the request
 // through the K8s watch cache instead of penetrating etcd.
 //
-// Violations detected:
-//   - k8smetav1.ListOptions{} without ResourceVersion in status-sync context
-//   - k8smetav1.GetOptions{} without ResourceVersion in status-sync context
+// Violations detected in polling contexts:
+//   - k8smetav1.ListOptions{} without ResourceVersion
+//   - k8smetav1.GetOptions{} without ResourceVersion
+//   - infracontract.ListOptions{} without ResourceVersion
 //
 // The analyzer uses AST inspection plus type information to find literal struct
-// initializations of metav1.ListOptions and metav1.GetOptions that do not set a
-// usable ResourceVersion field.
+// initializations of metav1.ListOptions, metav1.GetOptions, and Shepherd
+// provider ListOptions that do not set a usable ResourceVersion field.
 //
-// Scope: only files whose name matches polling/sync/health patterns are checked.
-// Test files (_test.go) are excluded to avoid false positives from test fixtures.
+// Scope: files or functions whose names match polling/sync/health/live-status
+// patterns are checked. Test files (_test.go) are excluded to avoid false
+// positives from test fixtures.
 package k8spollingrv
 
 import (
@@ -33,7 +35,7 @@ import (
 // Analyzer is the exported golangci-lint Analyzer for ADR-0038 ResourceVersion enforcement.
 var Analyzer = &analysis.Analyzer{
 	Name:     "k8spollingrv",
-	Doc:      "ADR-0038: enforces ResourceVersion field in K8s ListOptions/GetOptions struct literals to prevent etcd penetration",
+	Doc:      "ADR-0038: enforces ResourceVersion field in K8s and Shepherd provider ListOptions/GetOptions struct literals to prevent etcd penetration",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -45,8 +47,15 @@ var targetTypes = map[string]bool{
 	"GetOptions":  true,
 }
 
+type functionScope struct {
+	start token.Pos
+	end   token.Pos
+	name  string
+}
+
 func run(pass *analysis.Pass) (interface{}, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	scopes := collectFunctionScopes(pass.Files)
 
 	nodeFilter := []ast.Node{
 		(*ast.CompositeLit)(nil),
@@ -58,15 +67,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
-		typeName := resolveMetav1OptionsType(pass, lit.Type)
+		typeName := resolveOptionsType(pass, lit.Type)
 		if typeName == "" {
 			return
 		}
 
-		// Check if this file is in a provider/polling/sync context.
-		// We only flag files that are clearly part of the K8s polling path.
-		fileName := pass.Fset.File(lit.Pos()).Name()
-		if !isPollingRelatedFile(fileName) {
+		if !isPollingRelatedContext(pass, scopes, lit.Pos()) {
 			return
 		}
 
@@ -96,26 +102,48 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
-// resolveMetav1OptionsType returns the K8s options type name for real
-// k8s.io/apimachinery/pkg/apis/meta/v1 ListOptions/GetOptions literals.
-func resolveMetav1OptionsType(pass *analysis.Pass, expr ast.Expr) string {
+// resolveOptionsType returns the relevant options type name for real Kubernetes
+// metav1 options or Shepherd provider contract ListOptions literals.
+func resolveOptionsType(pass *analysis.Pass, expr ast.Expr) string {
 	if pass.TypesInfo == nil {
 		return ""
 	}
 	typ := pass.TypesInfo.TypeOf(expr)
-	named, ok := typ.(*types.Named)
-	if !ok {
+	return resolveOptionsTypeFromType(typ)
+}
+
+func resolveOptionsTypeFromType(typ types.Type) string {
+	switch t := typ.(type) {
+	case *types.Named:
+		return resolveOptionsTypeName(t.Obj())
+	case *types.Alias:
+		if name := resolveOptionsTypeName(t.Obj()); name != "" {
+			return name
+		}
+		return resolveOptionsTypeFromType(types.Unalias(t))
+	default:
 		return ""
 	}
-	obj := named.Obj()
+}
+
+func resolveOptionsTypeName(obj *types.TypeName) string {
 	if obj == nil || obj.Pkg() == nil {
 		return ""
 	}
-	if obj.Pkg().Path() != "k8s.io/apimachinery/pkg/apis/meta/v1" {
-		return ""
-	}
+
+	pkgPath := obj.Pkg().Path()
 	name := obj.Name()
-	if !targetTypes[name] {
+	switch pkgPath {
+	case "k8s.io/apimachinery/pkg/apis/meta/v1":
+		if !targetTypes[name] {
+			return ""
+		}
+	case "kv-shepherd.io/shepherd/internal/provider/infracontract",
+		"kv-shepherd.io/shepherd/internal/provider":
+		if name != "ListOptions" {
+			return ""
+		}
+	default:
 		return ""
 	}
 	return name
@@ -158,6 +186,61 @@ func isZeroResourceVersion(pass *analysis.Pass, expr ast.Expr) bool {
 	return err == nil && value == "0"
 }
 
+func collectFunctionScopes(files []*ast.File) []functionScope {
+	var scopes []functionScope
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			scopes = append(scopes, functionScope{
+				start: fn.Pos(),
+				end:   fn.End(),
+				name:  functionScopeName(fn),
+			})
+		}
+	}
+	return scopes
+}
+
+func functionScopeName(fn *ast.FuncDecl) string {
+	name := fn.Name.Name
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return name
+	}
+	return receiverTypeName(fn.Recv.List[0].Type) + "." + name
+}
+
+func receiverTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.StarExpr:
+		return receiverTypeName(t.X)
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func isPollingRelatedContext(pass *analysis.Pass, scopes []functionScope, pos token.Pos) bool {
+	fileName := pass.Fset.File(pos).Name()
+	if isGoTestFile(fileName) {
+		return false
+	}
+	if isPollingRelatedFile(fileName) {
+		return true
+	}
+	for _, scope := range scopes {
+		if pos >= scope.start && pos <= scope.end && isPollingRelatedIdentifier(scope.name) {
+			return true
+		}
+	}
+	return false
+}
+
 // isPollingRelatedFile returns true if the **filename** (not full path) suggests
 // it is part of the K8s VM polling/sync infrastructure where ResourceVersion
 // is mandatory. Only the base filename is checked to avoid false positives from
@@ -178,17 +261,29 @@ func isPollingRelatedFile(path string) bool {
 	}
 
 	lower := strings.ToLower(base)
+	return isPollingRelatedIdentifier(lower)
+}
 
-	// Files explicitly in the polling/sync/health-check path.
-	// Maintenance: add new patterns if the project introduces new polling-related
-	// file naming conventions. Prefer over-matching here — the analyzer's error
-	// message clearly explains what to fix.
+func isGoTestFile(path string) bool {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		path = path[idx+1:]
+	}
+	return strings.HasSuffix(path, "_test.go")
+}
+
+func isPollingRelatedIdentifier(value string) bool {
+	lower := strings.ToLower(value)
 	pollingPatterns := []string{
+		"live_status",
+		"livestatus",
+		"observed_live",
 		"status_sync",
+		"statussync",
 		"polling",
 		"poll_",
 		"_poll",
 		"sync_status",
+		"syncstatus",
 		"health_check",
 		"healthcheck",
 		"reconcile",

--- a/tools/shepherd-linter/analyzer/k8spollingrv/analyzer_test.go
+++ b/tools/shepherd-linter/analyzer/k8spollingrv/analyzer_test.go
@@ -16,5 +16,6 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.Run(t, testdata, k8spollingrv.Analyzer,
 		"example.com/project/internal/provider",
 		"example.com/project/internal/handlers",
+		"kv-shepherd.io/shepherd/internal/api/handlers",
 	)
 }

--- a/tools/shepherd-linter/analyzer/k8spollingrv/testdata/src/kv-shepherd.io/shepherd/internal/api/handlers/server_vm.go
+++ b/tools/shepherd-linter/analyzer/k8spollingrv/testdata/src/kv-shepherd.io/shepherd/internal/api/handlers/server_vm.go
@@ -1,0 +1,20 @@
+// Package handlers is a test fixture for project provider ListOptions.
+// File name intentionally does not match polling patterns; function names do.
+package handlers
+
+import (
+	"kv-shepherd.io/shepherd/internal/provider"
+	infracontract "kv-shepherd.io/shepherd/internal/provider/infracontract"
+)
+
+func refreshVMLiveStates() {
+	_ = infracontract.ListOptions{} // want `ADR-0038: ListOptions literal missing ResourceVersion field`
+	_ = infracontract.ListOptions{ResourceVersion: "12345"}
+	_ = provider.ListOptions{} // want `ADR-0038: ListOptions literal missing ResourceVersion field`
+	_ = provider.ListOptions{ResourceVersion: ""}
+}
+
+func listVMs() {
+	_ = infracontract.ListOptions{}
+	_ = provider.ListOptions{}
+}

--- a/tools/shepherd-linter/analyzer/k8spollingrv/testdata/src/kv-shepherd.io/shepherd/internal/provider/infracontract/contract.go
+++ b/tools/shepherd-linter/analyzer/k8spollingrv/testdata/src/kv-shepherd.io/shepherd/internal/provider/infracontract/contract.go
@@ -1,0 +1,7 @@
+// Package infracontract is a minimal stub for k8spollingrv analyzer tests.
+package infracontract
+
+type ListOptions struct {
+	ResourceVersion string
+	Limit           int
+}

--- a/tools/shepherd-linter/analyzer/k8spollingrv/testdata/src/kv-shepherd.io/shepherd/internal/provider/interface.go
+++ b/tools/shepherd-linter/analyzer/k8spollingrv/testdata/src/kv-shepherd.io/shepherd/internal/provider/interface.go
@@ -1,0 +1,6 @@
+// Package provider is a minimal stub for k8spollingrv analyzer tests.
+package provider
+
+import infracontract "kv-shepherd.io/shepherd/internal/provider/infracontract"
+
+type ListOptions = infracontract.ListOptions


### PR DESCRIPTION
## Summary

- Carry cached VM `last_k8s_rv` through live status group refresh and retry with an empty baseline when Kubernetes reports an expired resourceVersion.
- Extend `k8spollingrv` so polling/live-status helper functions using Shepherd provider `ListOptions` are covered by the architecture gate.
- Align the related governance script and docs with the new gate shape, ADR historical notes, Next.js 16 / React 19 implementation state, and the approved server bootstrap goroutine exception.

## Context7 Checks

- Kubernetes docs confirm `resourceVersion` constrains list/get serving, `resourceVersionMatch` is recommended when a list sets `resourceVersion`, and `410 Gone` / `ResourceExpired` recovery should clear cached state and relist from a fresh baseline.
- Next.js 16 docs confirm the App Router model remains under the `app` directory, uses React Server Components, and requires the `next`, `react`, and `react-dom` runtime package set.

## Validation

- `make pr` PASS
- `go test ./internal/api/handlers -run 'TestListVMs_' -count=1` PASS
- `(cd tools/shepherd-linter && go test ./...)` PASS
- `make shepherd-lint` PASS
- `git diff --check` PASS
- DCO sign-off verified on the commit

## Release Impact

release impact: bugfix/patch

Closes #672
