### PR TITLE
fix(deploy): simplify release image defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,49 +129,39 @@ npm run dev
 ### Deployment From Release Images
 
 The default production path uses GitHub-published container images from GHCR
-and does not require a git checkout or `git pull` on the target host. It only
-requires Docker, Docker Compose v2, outbound access to `ghcr.io` and
-`raw.githubusercontent.com`, and a PostgreSQL 18 database.
-
-For production, use a PostgreSQL 18 instance you operate yourself and pass
-`DATABASE_URL` before `bash`. With `DEPLOY_BUNDLED_POSTGRES=false`, the deploy
-script will not start the bundled `postgres:18` compose service.
+and does not require a git checkout or `git pull` on the target host. The
+host needs Docker, Docker Compose v2, and outbound access to `ghcr.io` and
+`raw.githubusercontent.com`.
 
 ```bash
-mkdir -p shepherd-deploy
-cd shepherd-deploy
-
-# Set this to the GitHub Release you want to deploy.
-# GHCR image tags omit the leading "v".
-SHEPHERD_VERSION=0.1.1-alpha.5
-DEPLOY_SCRIPT_REF=main
-
-curl -fsSL "https://raw.githubusercontent.com/kv-shepherd/shepherd/${DEPLOY_SCRIPT_REF}/deploy/prod/deploy-prod.sh" | \
-  DEPLOY_ASSET_REF="${DEPLOY_SCRIPT_REF}" \
-  SERVER_IMAGE="ghcr.io/kv-shepherd/shepherd-server:${SHEPHERD_VERSION}" \
-  WEB_IMAGE="ghcr.io/kv-shepherd/shepherd-web:${SHEPHERD_VERSION}" \
-  SERVER_PUBLIC_BASE_URL="https://shepherd.example.com" \
-  DATABASE_URL="postgres://shepherd:replace-me"@"postgres.example.com:5432/shepherd_db?sslmode=require" \
-  DEPLOY_BUNDLED_POSTGRES=false \
-  bash -s -- --skip-build --with-seed
+mkdir -p shepherd-deploy && cd shepherd-deploy
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
 ```
 
-Notes for the first run:
+By default this starts the current pinned GHCR release images, bundled
+PostgreSQL 18, `https://localhost`, and a generated self-signed TLS certificate
+if no certificate files are present. The script writes generated secrets and
+bootstrap credentials to `.env.prod`; back up that file.
 
-- Image tags use the release version without the leading `v`.
-- `DEPLOY_SCRIPT_REF` selects the public deploy helper and compose/nginx assets;
-  `main` is the default path for the latest one-command deploy flow.
-- `SERVER_PUBLIC_BASE_URL` must be the external HTTPS URL users will open.
-- The script writes generated secrets and bootstrap credentials to `.env.prod`;
-  back up this file.
-- If TLS files are missing, a self-signed certificate is generated for initial
-  testing. Replace it with a CA-issued certificate for production.
-- The first deploy should use `--with-seed` to create built-in roles and the
-  initial `admin` account.
+All runtime overrides are optional and can be passed before `bash` only when
+needed:
 
-If you need a single-host evaluation install without an external database, omit
-`DATABASE_URL` and `DEPLOY_BUNDLED_POSTGRES=false`; the same script will start
-the bundled PostgreSQL 18 service.
+```bash
+# Use a real external URL when a domain or ingress is ready.
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  SERVER_PUBLIC_BASE_URL=https://shepherd.example.com bash -s -- --with-seed
+
+# Use an external PostgreSQL 18 service instead of the bundled container.
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  DATABASE_URL='<postgres-18-dsn>' DEPLOY_BUNDLED_POSTGRES=false bash -s -- --with-seed
+
+# Pin a different GitHub Release image version. GHCR tags omit the leading "v".
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  SHEPHERD_VERSION=0.1.1-alpha.5 bash -s -- --with-seed
+```
+
+The first deploy should use `--with-seed` to create built-in roles and the
+initial `admin` account.
 
 Useful production commands from the deployment directory:
 

--- a/deploy/prod/.env.prod.example
+++ b/deploy/prod/.env.prod.example
@@ -4,10 +4,9 @@
 #
 # Recommended first-run flow:
 #   1. Copy this file to .env.prod
-#   2. Set SERVER_PUBLIC_BASE_URL
-#   3. If you use an external PostgreSQL service, set DATABASE_URL and
+#   2. If you use an external PostgreSQL service, set DATABASE_URL and
 #      DEPLOY_BUNDLED_POSTGRES=false
-#   4. Run: bash deploy/prod/deploy-prod.sh --with-seed
+#   3. Run: bash deploy/prod/deploy-prod.sh --with-seed
 #
 # Blank values below are intentional. The deploy script can generate the
 # missing first-run credentials and production security secrets, then persist
@@ -44,7 +43,9 @@ SECURITY_ENCRYPTION_KEY=
 
 # ---- Server ----
 SERVER_PORT=8080
-SERVER_PUBLIC_BASE_URL=https://replace-me.example.com
+# Blank defaults to https://localhost on first deploy. Set this to the
+# external HTTPS URL users will open when you have a real domain or ingress.
+SERVER_PUBLIC_BASE_URL=
 # Leave empty to automatically allow the SERVER_PUBLIC_BASE_URL origin only.
 SERVER_ALLOWED_ORIGINS=
 SERVER_ALLOW_CREDENTIALS=true

--- a/deploy/prod/deploy-prod.sh
+++ b/deploy/prod/deploy-prod.sh
@@ -18,10 +18,17 @@ if [[ -n "${BASH_SOURCE[0]:-}" && -f "${BASH_SOURCE[0]}" ]]; then
 else
     SCRIPT_DIR="${DEPLOY_DIR:-$(pwd)}"
 fi
-if ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." 2>/dev/null && pwd)"; then
+if [[ -f "${SCRIPT_DIR}/Dockerfile" && -f "${SCRIPT_DIR}/web/package.json" ]]; then
+    ROOT_DIR="${SCRIPT_DIR}"
+elif ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." 2>/dev/null && pwd)" \
+    && [[ -f "${ROOT_DIR}/Dockerfile" && -f "${ROOT_DIR}/web/package.json" ]]; then
     :
 else
     ROOT_DIR="$(pwd)"
+fi
+SOURCE_TREE_AVAILABLE=0
+if [[ -f "${ROOT_DIR}/Dockerfile" && -f "${ROOT_DIR}/web/package.json" ]]; then
+    SOURCE_TREE_AVAILABLE=1
 fi
 COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-${SCRIPT_DIR}/docker-compose.prod.yml}"
 ENV_FILE="${DEPLOY_ENV_FILE:-${SCRIPT_DIR}/.env.prod}"
@@ -32,6 +39,19 @@ TLS_KEY_FILE="${TLS_KEY_FILE:-${TLS_DIR}/key.pem}"
 COMPOSE_PROJECT_NAME="${DEPLOY_COMPOSE_PROJECT_NAME:-shepherd-prod}"
 DEPLOY_ASSET_REF="${DEPLOY_ASSET_REF:-main}"
 DEPLOY_RAW_BASE="${DEPLOY_RAW_BASE:-https://raw.githubusercontent.com/kv-shepherd/shepherd/${DEPLOY_ASSET_REF}}"
+DEPLOY_RELEASE_VERSION="${DEPLOY_RELEASE_VERSION:-${SHEPHERD_VERSION:-0.1.1-alpha.5}}"
+
+resolve_image_defaults() {
+    if [[ "${SOURCE_TREE_AVAILABLE}" == "1" ]]; then
+        SERVER_IMAGE="${SERVER_IMAGE:-shepherd-server:latest}"
+        WEB_IMAGE="${WEB_IMAGE:-shepherd-web:latest}"
+    else
+        SERVER_IMAGE="${SERVER_IMAGE:-ghcr.io/kv-shepherd/shepherd-server:${DEPLOY_RELEASE_VERSION}}"
+        WEB_IMAGE="${WEB_IMAGE:-ghcr.io/kv-shepherd/shepherd-web:${DEPLOY_RELEASE_VERSION}}"
+    fi
+    export SERVER_IMAGE WEB_IMAGE
+}
+
 CONFIG_ENV_KEYS=(
     POSTGRES_USER
     POSTGRES_PASSWORD
@@ -66,9 +86,8 @@ for key in "${CONFIG_ENV_KEYS[@]}"; do
         CONFIG_ENV_OVERRIDES["${key}"]="${!key}"
     fi
 done
-SERVER_IMAGE="${SERVER_IMAGE:-shepherd-server:latest}"
-WEB_IMAGE="${WEB_IMAGE:-shepherd-web:latest}"
-export SERVER_IMAGE WEB_IMAGE TLS_CERT_FILE TLS_KEY_FILE
+resolve_image_defaults
+export TLS_CERT_FILE TLS_KEY_FILE
 ENTERPRISE_MODE=0
 BUILD_ONLY=0
 SEED_ONLY=0
@@ -99,6 +118,7 @@ Environment overrides:
   DEPLOY_ENV_FILE              Alternate .env.prod path
   DEPLOY_DIR                   Directory used when running this script via stdin
   DEPLOY_ASSET_REF             Git ref used for auto-downloaded deploy assets
+  SHEPHERD_VERSION             GHCR release image version for stdin/raw deploys
   DEPLOY_TLS_DIR               Alternate TLS cert/key directory
   DEPLOY_COMPOSE_PROJECT_NAME  Alternate docker compose project name
   SERVER_IMAGE                 Server image tag to build/run
@@ -158,13 +178,12 @@ ensure_deploy_assets() {
 }
 
 ensure_source_tree_for_build() {
-    if [[ -f "${ROOT_DIR}/Dockerfile" && -f "${ROOT_DIR}/web/package.json" ]]; then
+    if [[ "${SOURCE_TREE_AVAILABLE}" == "1" ]]; then
         return
     fi
 
     echo "ERROR: source tree not found for local image build."
-    echo "  Run with --skip-build and SERVER_IMAGE/WEB_IMAGE for release-image deployment,"
-    echo "  or run this script from a full repository checkout."
+    echo "  Run this script from a full repository checkout for source-build deployment."
     exit 1
 }
 
@@ -409,6 +428,15 @@ sync_bundled_database_url() {
     fi
 }
 
+ensure_public_base_url() {
+    local current
+    current="$(read_env_value SERVER_PUBLIC_BASE_URL)"
+    if is_placeholder_value "${current}"; then
+        write_env_value SERVER_PUBLIC_BASE_URL "https://localhost"
+        echo "INFO: defaulted SERVER_PUBLIC_BASE_URL to https://localhost in ${ENV_FILE}."
+    fi
+}
+
 should_prepare_bundled_postgres_values() {
     local mode current host
     mode="$(read_env_value DEPLOY_BUNDLED_POSTGRES)"
@@ -431,6 +459,7 @@ should_prepare_bundled_postgres_values() {
 }
 
 prepare_runtime_values() {
+    ensure_public_base_url
     if should_prepare_bundled_postgres_values; then
         ensure_generated_secret POSTGRES_PASSWORD 16
     fi
@@ -527,6 +556,7 @@ set -a
 # shellcheck source=/dev/null
 source "${ENV_FILE}"
 set +a
+resolve_image_defaults
 
 prepare_runtime_values
 
@@ -535,6 +565,7 @@ set -a
 # shellcheck source=/dev/null
 source "${ENV_FILE}"
 set +a
+resolve_image_defaults
 
 # Validate required variables
 for var in DATABASE_URL SERVER_PUBLIC_BASE_URL; do
@@ -584,6 +615,24 @@ if [[ "${SEED_ONLY}" == "1" ]]; then
     echo "Skipping build phase (--seed-only)."
 elif [[ "${SKIP_BUILD}" == "1" ]]; then
     echo "Skipping build phase (--skip-build)."
+    if [[ "${BUILD_ONLY}" == "1" ]]; then
+        echo ""
+        echo "Build phase skipped. Images selected:"
+        echo "  - ${SERVER_IMAGE}"
+        echo "  - ${WEB_IMAGE}"
+        echo "  - nginx:1.27-alpine"
+        exit 0
+    fi
+elif [[ "${SOURCE_TREE_AVAILABLE}" != "1" ]]; then
+    echo "Skipping build phase (release-image deployment; no source tree found)."
+    if [[ "${BUILD_ONLY}" == "1" ]]; then
+        echo ""
+        echo "Release images selected:"
+        echo "  - ${SERVER_IMAGE}"
+        echo "  - ${WEB_IMAGE}"
+        echo "  - nginx:1.27-alpine"
+        exit 0
+    fi
 else
     ensure_source_tree_for_build
 

--- a/deploy/prod/docker-compose.prod.yml
+++ b/deploy/prod/docker-compose.prod.yml
@@ -5,11 +5,9 @@
 #   docker compose -f deploy/prod/docker-compose.prod.yml --env-file deploy/prod/.env.prod up -d
 #
 # Prerequisites:
-#   1. Build images first:
-#      docker build --target runtime -t shepherd-server:latest .
-#      docker build -t shepherd-web:latest -f deploy/prod/web.Dockerfile web/
-#   2. Prepare .env.prod from .env.prod.example
-#   3. Place TLS cert/key in deploy/prod/tls/
+#   1. Prepare .env.prod from .env.prod.example or run deploy-prod.sh.
+#   2. Place TLS cert/key in deploy/prod/tls/ or let deploy-prod.sh generate
+#      an initial self-signed certificate for testing.
 # =============================================================================
 
 services:
@@ -42,7 +40,7 @@ services:
 
   # ---------- Go Backend (Shepherd API Server) ----------
   server:
-    image: ${SERVER_IMAGE:-shepherd-server:latest}
+    image: ${SERVER_IMAGE:-ghcr.io/kv-shepherd/shepherd-server:0.1.1-alpha.5}
     restart: unless-stopped
     environment:
       DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
@@ -51,7 +49,7 @@ services:
       SECURITY_SESSION_SECRET: ${SECURITY_SESSION_SECRET:-}
       SECURITY_ENCRYPTION_KEY: ${SECURITY_ENCRYPTION_KEY:-}
       SERVER_PORT: ${SERVER_PORT:-8080}
-      SERVER_PUBLIC_BASE_URL: ${SERVER_PUBLIC_BASE_URL:?SERVER_PUBLIC_BASE_URL is required}
+      SERVER_PUBLIC_BASE_URL: ${SERVER_PUBLIC_BASE_URL:-https://localhost}
       SERVER_READ_HEADER_TIMEOUT: ${SERVER_READ_HEADER_TIMEOUT:-10s}
       SERVER_IDLE_TIMEOUT: ${SERVER_IDLE_TIMEOUT:-2m}
       SERVER_MAX_REQUEST_BODY_BYTES: ${SERVER_MAX_REQUEST_BODY_BYTES:-10485760}
@@ -78,7 +76,7 @@ services:
 
   # ---------- Next.js Frontend (Production SSR) ----------
   web:
-    image: ${WEB_IMAGE:-shepherd-web:latest}
+    image: ${WEB_IMAGE:-ghcr.io/kv-shepherd/shepherd-web:0.1.1-alpha.5}
     restart: unless-stopped
     environment:
       NODE_ENV: production

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -9,8 +9,8 @@ you do not point `DATABASE_URL` at an external database.
 | Service | Image | Role |
 |---------|-------|------|
 | **db** | `postgres:18` | Optional bundled data persistence service |
-| **server** | `shepherd-server` | Go API backend (distroless runtime) |
-| **web** | `shepherd-web` | Next.js SSR frontend |
+| **server** | `ghcr.io/kv-shepherd/shepherd-server` by default | Go API backend (distroless runtime) |
+| **web** | `ghcr.io/kv-shepherd/shepherd-web` by default | Next.js SSR frontend |
 | **nginx** | `nginx:1.27-alpine` | TLS termination, reverse proxy, rate limiting |
 
 ## Deploying from Source
@@ -18,14 +18,15 @@ you do not point `DATABASE_URL` at an external database.
 ### Recommended First Deploy
 
 Use the deploy script unless you specifically need raw `docker compose`
-control. For the default bundled PostgreSQL topology, the only required edit is
-the public URL.
+control. For the default bundled PostgreSQL topology, the script can generate a
+complete first-run `.env.prod` without required edits. Set
+`SERVER_PUBLIC_BASE_URL` when you have a real external URL.
 
 ```bash
 # 1. Prepare the environment file
 cp deploy/prod/.env.prod.example deploy/prod/.env.prod
 #    Edit .env.prod:
-#      - required: SERVER_PUBLIC_BASE_URL
+#      - optional: SERVER_PUBLIC_BASE_URL for a real domain or ingress
 #      - optional: DATABASE_URL + DEPLOY_BUNDLED_POSTGRES=false for external PostgreSQL
 
 # 2. Provide TLS certificates
@@ -39,6 +40,7 @@ bash deploy/prod/deploy-prod.sh --with-seed
 
 On the default bundled PostgreSQL path, `deploy-prod.sh` will automatically:
 
+- default `SERVER_PUBLIC_BASE_URL` to `https://localhost` when it is empty
 - generate `POSTGRES_PASSWORD` if it is empty and persist it back to `.env.prod`
 - generate `DEV_ADMIN_PASSWORD` if it is empty and persist it back to `.env.prod`
 - generate `SECURITY_SESSION_SECRET` and `SECURITY_ENCRYPTION_KEY` if they are
@@ -79,9 +81,11 @@ docker build -t shepherd-web:latest -f deploy/prod/web.Dockerfile web/
 # 2. Fill .env.prod manually
 cp deploy/prod/.env.prod.example deploy/prod/.env.prod
 #    Set at least:
+#      - SERVER_IMAGE=shepherd-server:latest
+#      - WEB_IMAGE=shepherd-web:latest
 #      - POSTGRES_PASSWORD (or a full external DATABASE_URL)
 #      - DATABASE_URL
-#      - SERVER_PUBLIC_BASE_URL
+#    SERVER_PUBLIC_BASE_URL defaults to https://localhost when blank.
 
 # 3. Launch
 docker compose -f deploy/prod/docker-compose.prod.yml \
@@ -125,11 +129,11 @@ cluster, export `E2E_KUBECONFIG_PATH=/path/to/kubeconfig` (or
 
 | Variable | Description |
 |----------|-------------|
-| `DATABASE_URL` | PostgreSQL connection string |
+| `DATABASE_URL` | PostgreSQL connection string; `deploy-prod.sh` creates a bundled PostgreSQL DSN when blank |
 | `DEPLOY_BUNDLED_POSTGRES` | `auto`, `true`, or `false` to control bundled vs external PostgreSQL topology |
 | `SECURITY_SESSION_SECRET` | Session-signing secret; `deploy-prod.sh` generates and persists one when blank |
 | `SECURITY_ENCRYPTION_KEY` | Hex-encoded AES-256 data-encryption key; `deploy-prod.sh` generates and persists one when blank |
-| `SERVER_PUBLIC_BASE_URL` | External URL (e.g. `https://shepherd.example.com`) |
+| `SERVER_PUBLIC_BASE_URL` | External URL; defaults to `https://localhost` when blank |
 | `SERVER_ALLOWED_ORIGINS` | CORS origins (comma-separated) |
 | `DATABASE_AUTO_APPLY_VERSIONED_MIGRATIONS` | Apply reviewed Atlas migrations before the server starts (`true` / `false`) |
 | `DATABASE_AUTO_MIGRATE` | Ent schema auto-migrate fallback (`true` / `false`, dev-only) |


### PR DESCRIPTION
## Summary

- simplify the README release-image quick start to a no-required-variable curl-to-bash flow
- make stdin/raw deploys default to pinned GHCR release images and skip local builds when no source tree is present
- default blank SERVER_PUBLIC_BASE_URL to https://localhost while keeping bundled PostgreSQL 18 as the no-input database path
- keep source checkout deployments on local image tags and align the full deployment guide

## Validation

- bash -n deploy/prod/deploy-prod.sh
- ShellCheck via koalaman/shellcheck:stable
- raw/stdin deploy smoke with generated bundled PostgreSQL config and docker compose config
- SHEPHERD_VERSION override smoke
- source checkout image default smoke
- make public-hygiene-scan
- make secrets-scan
- make pr on wip/implementation
- make pr on pr/676-release-image-defaults

release impact: bugfix/patch

Closes #676