### PR TITLE
fix(deploy): resolve release image defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,101 +75,47 @@ See [CHANGELOG.md](CHANGELOG.md) for release details and
 
 ## Quick Start
 
-### Local Development
+### Deploy From Release Images
 
-Use this path when you want to modify Shepherd or run the full stack from the
-current source tree.
+Use this path for production or VPS installs. It uses GHCR release images and
+does not require a git checkout on the target host.
 
-Prerequisites:
-
-- Git
-- Go 1.25.10 or newer
-- Node.js 22 or newer with npm
-- Docker 24 or newer with Docker Compose v2
-- A Kubernetes/KubeVirt cluster is optional for development, but required for
-  real VM lifecycle operations
-
-```bash
-git clone https://github.com/kv-shepherd/shepherd.git
-cd shepherd
-git pull --ff-only origin main
-
-# Start frontend, backend, nginx, and a local PostgreSQL 18 container.
-./start-dev.sh
-
-# Start from a clean local database when you intentionally want a reset.
-./start-dev.sh --clean-all
-```
-
-| Endpoint | URL |
-|----------|-----|
-| Web UI | `http://localhost:3000` |
-| HTTPS dev ingress | `https://localhost:3443` |
-| API, through ingress | `http://localhost:3000/api/v1` |
-| API, direct backend | `http://localhost:8080/api/v1` |
-
-Local development seeds only the platform bootstrap baseline:
-
-- built-in roles
-- default admin account: `admin / admin`
-- first sign-in requires a password change
-
-Common development commands:
-
-```bash
-make generate   # Ent ORM + OpenAPI + sqlc code generation
-make build      # Go server binary -> bin/shepherd
-make test       # Go tests; PostgreSQL packages use postgres:18 test containers
-
-cd web
-npm ci
-npm run dev
-```
-
-### Deployment From Release Images
-
-The default production path uses GitHub-published container images from GHCR
-and does not require a git checkout or `git pull` on the target host. The
-host needs Docker, Docker Compose v2, and outbound access to `ghcr.io` and
-`raw.githubusercontent.com`.
+Prerequisites: Docker, Docker Compose v2, and outbound access to GHCR and
+GitHub release assets.
 
 ```bash
 mkdir -p shepherd-deploy && cd shepherd-deploy
 curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
 ```
 
-By default this starts the current pinned GHCR release images, bundled
-PostgreSQL 18, `https://localhost`, and a generated self-signed TLS certificate
-if no certificate files are present. The script writes generated secrets and
-bootstrap credentials to `.env.prod`; back up that file.
+This starts the latest published GHCR images with bundled PostgreSQL 18 and a
+local TLS endpoint. Generated secrets, bootstrap credentials, and resolved image
+refs are persisted to `.env.prod`; back up that file.
 
-All runtime overrides are optional and can be passed before `bash` only when
-needed:
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for external PostgreSQL 18,
+domain/TLS configuration, image version pinning, manual compose commands, and
+the security checklist.
 
-```bash
-# Use a real external URL when a domain or ingress is ready.
-curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
-  SERVER_PUBLIC_BASE_URL=https://shepherd.example.com bash -s -- --with-seed
+### Local Development
 
-# Use an external PostgreSQL 18 service instead of the bundled container.
-curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
-  DATABASE_URL='<postgres-18-dsn>' DEPLOY_BUNDLED_POSTGRES=false bash -s -- --with-seed
-
-# Pin a different GitHub Release image version. GHCR tags omit the leading "v".
-curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
-  SHEPHERD_VERSION=0.1.1-alpha.5 bash -s -- --with-seed
-```
-
-The first deploy should use `--with-seed` to create built-in roles and the
-initial `admin` account.
-
-Useful production commands from the deployment directory:
+Use this path when you want to modify Shepherd or run the full stack from the
+current source tree.
 
 ```bash
-docker compose -f docker-compose.prod.yml -p shepherd-prod ps
-docker compose -f docker-compose.prod.yml -p shepherd-prod logs -f
-docker compose -f docker-compose.prod.yml -p shepherd-prod down
+git clone https://github.com/kv-shepherd/shepherd.git
+cd shepherd
+git pull --ff-only origin main
+./start-dev.sh
 ```
+
+Prerequisites: Git, Go 1.25.10 or newer, Node.js 22 or newer with npm, and
+Docker 24 or newer with Docker Compose v2.
+
+Default local endpoints:
+
+- Web UI: `http://localhost:3000`
+- HTTPS dev ingress: `https://localhost:3443`
+- API: `http://localhost:3000/api/v1`
 
 ### Source Build Deployment
 
@@ -184,19 +130,13 @@ bash deploy/prod/deploy-prod.sh --with-seed
 ```
 
 See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full deployment guide,
-configuration reference, security checklist, manual compose flow, and VPS
-experience seed setup.
+configuration reference, security checklist, and VPS experience seed setup.
 
 ### Helm Deployment
 
-A Helm chart is the next Kubernetes-native deployment target. It is not shipped
-in this repository yet. The chart should use the same GHCR release images,
-prefer an external PostgreSQL 18 database, and map the current compose
-configuration into Kubernetes Secrets, Deployments, Services, Ingress, and
-health probes.
-
-Until the chart lands, use the release-image Docker Compose deployment above
-for production and VPS installs.
+Helm charts are maintained separately from the application source tree. Until
+the public chart repository is published, use the release-image Docker Compose
+deployment above for production and VPS installs.
 
 ## Documentation
 

--- a/deploy/prod/.env.prod.example
+++ b/deploy/prod/.env.prod.example
@@ -13,6 +13,13 @@
 # them back to .env.prod before starting release-mode services.
 # =============================================================================
 
+# ---- Release images ----
+# Leave empty when using deploy-prod.sh; it resolves and persists the image refs.
+# For manual docker compose, set full image references explicitly.
+# Example: ghcr.io/kv-shepherd/shepherd-server:<version>
+SERVER_IMAGE=
+WEB_IMAGE=
+
 # ---- Bundled PostgreSQL (ignored when using an external database) ----
 POSTGRES_USER=shepherd
 # Leave empty to auto-generate a strong password on first deploy and persist it

--- a/deploy/prod/deploy-prod.sh
+++ b/deploy/prod/deploy-prod.sh
@@ -39,17 +39,91 @@ TLS_KEY_FILE="${TLS_KEY_FILE:-${TLS_DIR}/key.pem}"
 COMPOSE_PROJECT_NAME="${DEPLOY_COMPOSE_PROJECT_NAME:-shepherd-prod}"
 DEPLOY_ASSET_REF="${DEPLOY_ASSET_REF:-main}"
 DEPLOY_RAW_BASE="${DEPLOY_RAW_BASE:-https://raw.githubusercontent.com/kv-shepherd/shepherd/${DEPLOY_ASSET_REF}}"
-DEPLOY_RELEASE_VERSION="${DEPLOY_RELEASE_VERSION:-${SHEPHERD_VERSION:-0.1.1-alpha.5}}"
+DEPLOY_RELEASE_VERSION="${DEPLOY_RELEASE_VERSION:-${SHEPHERD_VERSION:-}}"
+RESOLVED_RELEASE_VERSION=""
+
+strip_release_prefix() {
+    local version="$1"
+    version="${version#refs/tags/}"
+    version="${version#v}"
+    printf "%s" "${version}"
+}
+
+fetch_latest_release_tag() {
+    local url="https://api.github.com/repos/kv-shepherd/shepherd/releases?per_page=1"
+    local body
+    if command -v curl >/dev/null 2>&1; then
+        body="$(curl -fsSL "${url}")"
+    elif command -v wget >/dev/null 2>&1; then
+        body="$(wget -qO- "${url}")"
+    else
+        return 1
+    fi
+    printf "%s\n" "${body}" | sed -nE 's/^[[:space:]]*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1
+}
+
+resolve_release_version() {
+    if [[ -n "${RESOLVED_RELEASE_VERSION}" ]]; then
+        printf "%s" "${RESOLVED_RELEASE_VERSION}"
+        return 0
+    fi
+
+    local raw="${DEPLOY_RELEASE_VERSION:-${SHEPHERD_VERSION:-}}"
+    if [[ -z "${raw}" && "${DEPLOY_ASSET_REF}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        raw="${DEPLOY_ASSET_REF}"
+    fi
+    if [[ -z "${raw}" ]]; then
+        raw="$(fetch_latest_release_tag || true)"
+    fi
+
+    raw="$(strip_release_prefix "${raw}")"
+    if [[ -z "${raw}" ]]; then
+        echo "ERROR: could not resolve a Shepherd release image version." >&2
+        echo "  Set SHEPHERD_VERSION=<version> or SERVER_IMAGE/WEB_IMAGE explicitly." >&2
+        exit 1
+    fi
+
+    RESOLVED_RELEASE_VERSION="${raw}"
+    printf "%s" "${RESOLVED_RELEASE_VERSION}"
+}
 
 resolve_image_defaults() {
-    if [[ "${SOURCE_TREE_AVAILABLE}" == "1" ]]; then
+    local release_version_requested=0
+    if [[ -n "${DEPLOY_RELEASE_VERSION:-${SHEPHERD_VERSION:-}}" ]]; then
+        release_version_requested=1
+    fi
+
+    if [[ "${SOURCE_TREE_AVAILABLE}" == "1" && "${release_version_requested}" == "0" ]]; then
         SERVER_IMAGE="${SERVER_IMAGE:-shepherd-server:latest}"
         WEB_IMAGE="${WEB_IMAGE:-shepherd-web:latest}"
     else
-        SERVER_IMAGE="${SERVER_IMAGE:-ghcr.io/kv-shepherd/shepherd-server:${DEPLOY_RELEASE_VERSION}}"
-        WEB_IMAGE="${WEB_IMAGE:-ghcr.io/kv-shepherd/shepherd-web:${DEPLOY_RELEASE_VERSION}}"
+        local need_server_image=0
+        local need_web_image=0
+        local version=""
+
+        if [[ -z "${SERVER_IMAGE:-}" ]] || { [[ "${release_version_requested}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[SERVER_IMAGE]+x}" ]]; }; then
+            need_server_image=1
+        fi
+        if [[ -z "${WEB_IMAGE:-}" ]] || { [[ "${release_version_requested}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[WEB_IMAGE]+x}" ]]; }; then
+            need_web_image=1
+        fi
+
+        if [[ "${need_server_image}" == "1" || "${need_web_image}" == "1" ]]; then
+            version="$(resolve_release_version)"
+        fi
+        if [[ "${need_server_image}" == "1" ]]; then
+            SERVER_IMAGE="ghcr.io/kv-shepherd/shepherd-server:${version}"
+        fi
+        if [[ "${need_web_image}" == "1" ]]; then
+            WEB_IMAGE="ghcr.io/kv-shepherd/shepherd-web:${version}"
+        fi
     fi
     export SERVER_IMAGE WEB_IMAGE
+}
+
+persist_resolved_images() {
+    write_env_value SERVER_IMAGE "${SERVER_IMAGE}"
+    write_env_value WEB_IMAGE "${WEB_IMAGE}"
 }
 
 CONFIG_ENV_KEYS=(
@@ -86,7 +160,6 @@ for key in "${CONFIG_ENV_KEYS[@]}"; do
         CONFIG_ENV_OVERRIDES["${key}"]="${!key}"
     fi
 done
-resolve_image_defaults
 export TLS_CERT_FILE TLS_KEY_FILE
 ENTERPRISE_MODE=0
 BUILD_ONLY=0
@@ -118,7 +191,9 @@ Environment overrides:
   DEPLOY_ENV_FILE              Alternate .env.prod path
   DEPLOY_DIR                   Directory used when running this script via stdin
   DEPLOY_ASSET_REF             Git ref used for auto-downloaded deploy assets
-  SHEPHERD_VERSION             GHCR release image version for stdin/raw deploys
+  SHEPHERD_VERSION             GHCR release image version for stdin/raw deploys.
+                               If unset, deploy-prod.sh resolves the latest
+                               GitHub Release tag.
   DEPLOY_TLS_DIR               Alternate TLS cert/key directory
   DEPLOY_COMPOSE_PROJECT_NAME  Alternate docker compose project name
   SERVER_IMAGE                 Server image tag to build/run
@@ -557,6 +632,7 @@ set -a
 source "${ENV_FILE}"
 set +a
 resolve_image_defaults
+persist_resolved_images
 
 prepare_runtime_values
 
@@ -566,9 +642,10 @@ set -a
 source "${ENV_FILE}"
 set +a
 resolve_image_defaults
+persist_resolved_images
 
 # Validate required variables
-for var in DATABASE_URL SERVER_PUBLIC_BASE_URL; do
+for var in DATABASE_URL SERVER_PUBLIC_BASE_URL SERVER_IMAGE WEB_IMAGE; do
     val="${!var:-}"
     if is_placeholder_value "${val}"; then
         echo "ERROR: ${var} is not set or still has a placeholder value in ${ENV_FILE}"

--- a/deploy/prod/docker-compose.prod.yml
+++ b/deploy/prod/docker-compose.prod.yml
@@ -40,7 +40,7 @@ services:
 
   # ---------- Go Backend (Shepherd API Server) ----------
   server:
-    image: ${SERVER_IMAGE:-ghcr.io/kv-shepherd/shepherd-server:0.1.1-alpha.5}
+    image: ${SERVER_IMAGE:?SERVER_IMAGE is required. Run deploy-prod.sh or set SERVER_IMAGE in .env.prod}
     restart: unless-stopped
     environment:
       DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
@@ -76,7 +76,7 @@ services:
 
   # ---------- Next.js Frontend (Production SSR) ----------
   web:
-    image: ${WEB_IMAGE:-ghcr.io/kv-shepherd/shepherd-web:0.1.1-alpha.5}
+    image: ${WEB_IMAGE:?WEB_IMAGE is required. Run deploy-prod.sh or set WEB_IMAGE in .env.prod}
     restart: unless-stopped
     environment:
       NODE_ENV: production

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,30 +13,78 @@ you do not point `DATABASE_URL` at an external database.
 | **web** | `ghcr.io/kv-shepherd/shepherd-web` by default | Next.js SSR frontend |
 | **nginx** | `nginx:1.27-alpine` | TLS termination, reverse proxy, rate limiting |
 
-## Deploying from Source
+## Deploying from Release Images
 
-### Recommended First Deploy
+Use this path for production or VPS hosts that should run published GHCR images
+without a git checkout.
 
-Use the deploy script unless you specifically need raw `docker compose`
-control. For the default bundled PostgreSQL topology, the script can generate a
-complete first-run `.env.prod` without required edits. Set
-`SERVER_PUBLIC_BASE_URL` when you have a real external URL.
+Required host tools:
+
+- Docker with Docker Compose v2
+- `curl` or `wget`
+- outbound access to GHCR, GitHub raw files, and GitHub release metadata
+
+The shortest first deploy uses bundled PostgreSQL 18, `https://localhost`, and
+a generated self-signed TLS certificate:
 
 ```bash
-# 1. Prepare the environment file
-cp deploy/prod/.env.prod.example deploy/prod/.env.prod
-#    Edit .env.prod:
-#      - optional: SERVER_PUBLIC_BASE_URL for a real domain or ingress
-#      - optional: DATABASE_URL + DEPLOY_BUNDLED_POSTGRES=false for external PostgreSQL
+mkdir -p shepherd-deploy && cd shepherd-deploy
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
+```
 
-# 2. Provide TLS certificates
-mkdir -p deploy/prod/tls
-cp /path/to/cert.pem deploy/prod/tls/cert.pem
-cp /path/to/key.pem  deploy/prod/tls/key.pem
+`wget` works too:
 
-# 3. Build, deploy, and seed the initial admin/bootstrap data
+```bash
+wget -qO- https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
+```
+
+All runtime inputs are optional. Pass them before `bash` only when you need to
+override the default topology:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  SERVER_PUBLIC_BASE_URL=https://shepherd.example.com bash -s -- --with-seed
+
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  DATABASE_URL='<postgres-18-dsn>' DEPLOY_BUNDLED_POSTGRES=false bash -s -- --with-seed
+
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  SHEPHERD_VERSION='vX.Y.Z' bash -s -- --with-seed
+```
+
+Use PostgreSQL 18 for external databases. The bundled `postgres:18` container
+is convenient for evaluation and VPS installs, but an operator-managed
+PostgreSQL 18 service is recommended for production. When `DATABASE_URL` points
+to an external PostgreSQL host, `deploy-prod.sh` auto-detects that topology and
+does not start the bundled database. Override with
+`DEPLOY_BUNDLED_POSTGRES=true|false` only when you need to force the topology.
+
+`deploy-prod.sh` resolves release images in this order:
+
+1. explicit `SERVER_IMAGE` and `WEB_IMAGE`
+2. explicit `SHEPHERD_VERSION` or `DEPLOY_RELEASE_VERSION`
+3. version-like `DEPLOY_ASSET_REF`, such as `vX.Y.Z`
+4. the latest published GitHub Release
+
+Resolved image refs and generated secrets are persisted to `.env.prod` in the
+deployment directory.
+
+## Deploying from Source Build
+
+Use source-build deployment only when you intentionally want the target host to
+build local backend and frontend images from a checkout.
+
+```bash
+git clone https://github.com/kv-shepherd/shepherd.git
+cd shepherd
+git pull --ff-only origin main
 bash deploy/prod/deploy-prod.sh --with-seed
 ```
+
+For source builds, `deploy-prod.sh` uses local image tags by default unless you
+set `SHEPHERD_VERSION`, `SERVER_IMAGE`, or `WEB_IMAGE`.
+
+## Deployment Script Behavior
 
 On the default bundled PostgreSQL path, `deploy-prod.sh` will automatically:
 
@@ -46,32 +94,24 @@ On the default bundled PostgreSQL path, `deploy-prod.sh` will automatically:
 - generate `SECURITY_SESSION_SECRET` and `SECURITY_ENCRYPTION_KEY` if they are
   empty and persist them back to `.env.prod`
 - build `DATABASE_URL` for the bundled `db` service when it is empty
-- generate a self-signed TLS certificate when `deploy/prod/tls/cert.pem` and
-  `deploy/prod/tls/key.pem` are missing
+- generate a self-signed TLS certificate when `tls/cert.pem` and `tls/key.pem`
+  are missing
 
 Additional script entry points:
 
 ```bash
-bash deploy/prod/deploy-prod.sh              # builds + deploys
-bash deploy/prod/deploy-prod.sh --with-seed  # first deploy/bootstrap
-bash deploy/prod/deploy-prod.sh --with-seed --with-experience-seed
-bash deploy/prod/deploy-prod.sh --help       # all options
+bash deploy-prod.sh              # deploy using release images
+bash deploy-prod.sh --with-seed  # first deploy/bootstrap
+bash deploy-prod.sh --with-seed --with-experience-seed
+bash deploy-prod.sh --help       # all options
 ```
-
-On first run, `deploy-prod.sh` will generate `deploy/prod/.env.prod` from
-`deploy/prod/.env.prod.example` if the file is missing. The generated template
-stays local to the deployment host; it is not copied into container images.
-
-When `DATABASE_URL` points to an external PostgreSQL host, `deploy-prod.sh`
-auto-detects that topology and does not start the bundled `postgres:18`
-service. Override with `DEPLOY_BUNDLED_POSTGRES=true|false` only when you need
-to force the topology.
 
 ### Manual Docker Compose Path
 
 If you prefer plain `docker compose` without `deploy-prod.sh`, fill the blank
-credential fields in `.env.prod` yourself first, then run the compose commands
-manually.
+credential and image fields in `.env.prod` yourself first, then run the compose
+commands manually. `deploy-prod.sh` resolves and persists image references for
+you; raw compose requires `SERVER_IMAGE` and `WEB_IMAGE` to be set explicitly.
 
 ```bash
 # 1. Build images


### PR DESCRIPTION
Closes #678

## Summary

- Keep the README quick start centered on the shortest GHCR release-image deployment path, with local development and source-build deployment as separate follow-up paths.
- Move detailed production guidance into `docs/DEPLOYMENT.md`, including curl/wget raw-script deployment, optional PostgreSQL/domain/version overrides, source-build deployment, and manual compose behavior.
- Remove stale hardcoded production image tags from compose and make `deploy-prod.sh` resolve and persist `SERVER_IMAGE` / `WEB_IMAGE` from explicit image refs, release version inputs, versioned asset refs, or the latest GitHub Release.
- Clarify that Helm charts are maintained outside this application repository.

## Validation

- `make pr`
- `SKIP_ENT_CODEGEN_CHECK=1 make ci-governance`
- `make secrets-scan`
- `make public-hygiene-scan`
- `bash -n deploy/prod/deploy-prod.sh`
- `docker compose -f deploy/prod/docker-compose.prod.yml --env-file deploy/prod/.env.prod.example config` with explicit release image refs and required runtime env
- Release deployment script smoke checks for explicit images, versioned asset refs, explicit `SHEPHERD_VERSION`, and latest-release resolution using temporary deployment directories
- Public marker scan for internal registry/kubeconfig paths and stale prerelease image defaults
