### PR TITLE
fix: package atlas binary in release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     timeout-minutes: 15
     needs: [preflight]
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, arm64]
     steps:
@@ -96,7 +97,7 @@ jobs:
             "${ATLAS_IMAGE}"
           docker cp "${atlas_container}:/atlas" dist/atlas
           docker rm -f "${atlas_container}" >/dev/null
-          chmod +x dist/atlas
+          chmod 0755 dist/atlas
           mkdir -p dist/share/shepherd/migrations
           cp -R migrations/atlas dist/share/shepherd/migrations/atlas
 


### PR DESCRIPTION
## Summary
- set release archive matrix fail-fast to false so one architecture does not cancel the other
- normalize the copied Atlas binary to 0755 before creating release tarballs

## Verification
- reproduced the arm64 Atlas copy permission as execute-only
- verified tar packaging succeeds after chmod 0755
- git diff --check