### PR TITLE
docs(deploy): clarify deployment modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,29 @@ See [CHANGELOG.md](CHANGELOG.md) for release details and
 
 ## Quick Start
 
-### Deploy From Release Images
+### Helm Deployment
+
+Use this path for Kubernetes-native installs. Helm charts are maintained
+separately in [kv-shepherd/helm-charts](https://github.com/kv-shepherd/helm-charts),
+and the published chart uses public Docker Hub images by default.
+
+Demo install without an Ingress controller or persistent database storage:
+
+```bash
+helm repo add shepherd https://kv-shepherd.github.io/helm-charts
+helm repo update
+helm upgrade --install shepherd shepherd/shepherd \
+  --namespace shepherd --create-namespace \
+  --set postgresql.persistence.enabled=false
+
+kubectl -n shepherd port-forward svc/shepherd-edge 3443:443
+```
+
+Open `https://127.0.0.1:3443`. See the chart repository for NodePort/IP access,
+Ingress with TLS, persistent PostgreSQL, external database values, and
+managed-cluster RBAC examples.
+
+### Docker Compose From Release Images
 
 Use this path for production or VPS installs. It uses GHCR release images and
 does not require a git checkout on the target host.
@@ -85,7 +107,8 @@ GitHub release assets.
 
 ```bash
 mkdir -p shepherd-deploy && cd shepherd-deploy
-curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  bash -s -- --release-images --with-seed
 ```
 
 This starts the latest published GHCR images with bundled PostgreSQL 18 and a
@@ -121,7 +144,7 @@ Default local endpoints:
 - HTTPS dev ingress: `https://localhost:3443`
 - API: `http://localhost:3000/api/v1`
 
-### Source Build Deployment
+### Docker Compose From Source Build
 
 Use source-build deployment only when you intentionally want the target host to
 build local backend and frontend images from a checkout.
@@ -130,33 +153,14 @@ build local backend and frontend images from a checkout.
 git clone https://github.com/kv-shepherd/shepherd.git
 cd shepherd
 git pull --ff-only origin main
-bash deploy/prod/deploy-prod.sh --with-seed
+bash deploy/prod/deploy-prod.sh --source-build --with-seed
 ```
 
-See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full deployment guide,
+Both Docker Compose paths use `deploy-prod.sh`, but the mode flag is deliberate:
+`--release-images` runs published images and can be used from `curl`; `--source-build`
+requires a git checkout and builds local images before starting the stack. See
+[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full deployment guide,
 configuration reference, security checklist, and VPS experience seed setup.
-
-### Helm Deployment
-
-Helm charts are maintained separately in
-[kv-shepherd/helm-charts](https://github.com/kv-shepherd/helm-charts). The
-published chart uses public Docker Hub images by default.
-
-Demo install without an Ingress controller or persistent database storage:
-
-```bash
-helm repo add shepherd https://kv-shepherd.github.io/helm-charts
-helm repo update
-helm upgrade --install shepherd shepherd/shepherd \
-  --namespace shepherd --create-namespace \
-  --set postgresql.persistence.enabled=false
-
-kubectl -n shepherd port-forward svc/shepherd-edge 3443:443
-```
-
-Open `https://127.0.0.1:3443`. See the chart repository for NodePort/IP access,
-Ingress with TLS, persistent PostgreSQL, external database values, and
-managed-cluster RBAC examples.
 
 ## Documentation
 

--- a/deploy/prod/deploy-prod.sh
+++ b/deploy/prod/deploy-prod.sh
@@ -3,9 +3,13 @@
 # KubeVirt Shepherd — Production Deployment Script
 # =============================================================================
 # Usage:
-#   bash deploy/prod/deploy-prod.sh                    # Public deploy (no bootstrap seed)
-#   bash deploy/prod/deploy-prod.sh --with-seed        # Public deploy + bootstrap seed
-#   bash deploy/prod/deploy-prod.sh --with-seed --with-experience-seed
+#   bash deploy/prod/deploy-prod.sh --release-images
+#                                                # Public deploy from published images
+#   bash deploy/prod/deploy-prod.sh --release-images --with-seed
+#                                                # Public deploy + bootstrap seed
+#   bash deploy/prod/deploy-prod.sh --source-build --with-seed
+#                                                # Build local images from a checkout
+#   bash deploy/prod/deploy-prod.sh --release-images --with-seed --with-experience-seed
 #                                                 # Public deploy + baseline seed + experience fixtures
 #   bash deploy/prod/deploy-prod.sh --enterprise       # Enterprise edition
 #   bash deploy/prod/deploy-prod.sh --build-only       # Build images only
@@ -41,6 +45,7 @@ DEPLOY_ASSET_REF="${DEPLOY_ASSET_REF:-main}"
 DEPLOY_RAW_BASE="${DEPLOY_RAW_BASE:-https://raw.githubusercontent.com/kv-shepherd/shepherd/${DEPLOY_ASSET_REF}}"
 DEPLOY_RELEASE_VERSION="${DEPLOY_RELEASE_VERSION:-${SHEPHERD_VERSION:-}}"
 RESOLVED_RELEASE_VERSION=""
+DEPLOY_IMAGE_MODE="${DEPLOY_IMAGE_MODE:-auto}"
 
 strip_release_prefix() {
     local version="$1"
@@ -93,18 +98,52 @@ resolve_image_defaults() {
         release_version_requested=1
     fi
 
-    if [[ "${SOURCE_TREE_AVAILABLE}" == "1" && "${release_version_requested}" == "0" ]]; then
-        SERVER_IMAGE="${SERVER_IMAGE:-shepherd-server:latest}"
-        WEB_IMAGE="${WEB_IMAGE:-shepherd-web:latest}"
+    local use_source_build=0
+    local force_release_images=0
+    case "${DEPLOY_IMAGE_MODE}" in
+        source-build)
+            ensure_source_tree_for_build
+            use_source_build=1
+            ;;
+        release-images)
+            force_release_images=1
+            use_source_build=0
+            ;;
+        auto|"")
+            if [[ "${SOURCE_TREE_AVAILABLE}" == "1" && "${release_version_requested}" == "0" ]]; then
+                use_source_build=1
+            fi
+            ;;
+        *)
+            echo "ERROR: DEPLOY_IMAGE_MODE must be one of: auto, release-images, source-build" >&2
+            exit 1
+            ;;
+    esac
+
+    if [[ "${use_source_build}" == "1" ]]; then
+        if [[ -z "${CONFIG_ENV_OVERRIDES[SERVER_IMAGE]+x}" ]]; then
+            SERVER_IMAGE="shepherd-server:latest"
+        else
+            SERVER_IMAGE="${CONFIG_ENV_OVERRIDES[SERVER_IMAGE]}"
+        fi
+        if [[ -z "${CONFIG_ENV_OVERRIDES[WEB_IMAGE]+x}" ]]; then
+            WEB_IMAGE="shepherd-web:latest"
+        else
+            WEB_IMAGE="${CONFIG_ENV_OVERRIDES[WEB_IMAGE]}"
+        fi
     else
         local need_server_image=0
         local need_web_image=0
         local version=""
 
-        if [[ -z "${SERVER_IMAGE:-}" ]] || { [[ "${release_version_requested}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[SERVER_IMAGE]+x}" ]]; }; then
+        if [[ -z "${SERVER_IMAGE:-}" ]] \
+            || { [[ "${force_release_images}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[SERVER_IMAGE]+x}" ]]; } \
+            || { [[ "${release_version_requested}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[SERVER_IMAGE]+x}" ]]; }; then
             need_server_image=1
         fi
-        if [[ -z "${WEB_IMAGE:-}" ]] || { [[ "${release_version_requested}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[WEB_IMAGE]+x}" ]]; }; then
+        if [[ -z "${WEB_IMAGE:-}" ]] \
+            || { [[ "${force_release_images}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[WEB_IMAGE]+x}" ]]; } \
+            || { [[ "${release_version_requested}" == "1" ]] && [[ -z "${CONFIG_ENV_OVERRIDES[WEB_IMAGE]+x}" ]]; }; then
             need_web_image=1
         fi
 
@@ -179,6 +218,10 @@ usage() {
 Usage: deploy-prod.sh [options]
 
 Options:
+  --release-images Deploy published GHCR release images. Use this for curl/wget
+                   installs and normal single-host/VPS production deployments.
+  --source-build   Build server and web images from the local repository
+                   checkout. Requires the full source tree.
   --enterprise     Deploy enterprise edition (requires private repo)
   --build-only     Build images only, do not start services
   --with-seed      Run bootstrap seed after startup (roles + default admin)
@@ -192,8 +235,9 @@ Options:
 Environment overrides:
   DEPLOY_ENV_FILE              Alternate .env.prod path
   DEPLOY_DIR                   Directory used when running this script via stdin
+  DEPLOY_IMAGE_MODE            auto, release-images, or source-build
   DEPLOY_ASSET_REF             Git ref used for auto-downloaded deploy assets
-  SHEPHERD_VERSION             GHCR release image version for stdin/raw deploys.
+  SHEPHERD_VERSION             GHCR release image version for --release-images.
                                If unset, deploy-prod.sh resolves the latest
                                GitHub Release tag.
   DEPLOY_TLS_DIR               Alternate TLS cert/key directory
@@ -579,6 +623,22 @@ resolve_bundled_postgres_mode() {
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --release-images)
+            if [[ "${DEPLOY_IMAGE_MODE}" == "source-build" ]]; then
+                echo "ERROR: --release-images and --source-build are mutually exclusive"
+                exit 1
+            fi
+            DEPLOY_IMAGE_MODE="release-images"
+            shift
+            ;;
+        --source-build)
+            if [[ "${DEPLOY_IMAGE_MODE}" == "release-images" ]]; then
+                echo "ERROR: --source-build and --release-images are mutually exclusive"
+                exit 1
+            fi
+            DEPLOY_IMAGE_MODE="source-build"
+            shift
+            ;;
         --enterprise)
             ENTERPRISE_MODE=1
             shift
@@ -704,8 +764,12 @@ elif [[ "${SKIP_BUILD}" == "1" ]]; then
         echo "  - ${NGINX_IMAGE:-nginx:1.30.1-alpine}"
         exit 0
     fi
-elif [[ "${SOURCE_TREE_AVAILABLE}" != "1" ]]; then
-    echo "Skipping build phase (release-image deployment; no source tree found)."
+elif [[ "${DEPLOY_IMAGE_MODE}" == "release-images" || "${SOURCE_TREE_AVAILABLE}" != "1" ]]; then
+    if [[ "${DEPLOY_IMAGE_MODE}" == "release-images" ]]; then
+        echo "Skipping build phase (--release-images)."
+    else
+        echo "Skipping build phase (release-image deployment; no source tree found)."
+    fi
     if [[ "${BUILD_ONLY}" == "1" ]]; then
         echo ""
         echo "Release images selected:"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,10 +1,37 @@
 # Production Deployment
 
-Shepherd ships with a Docker Compose-based production topology built around
-`server`, `web`, and `nginx`, with an optional bundled PostgreSQL service when
-you do not point `DATABASE_URL` at an external database.
+Shepherd supports two public deployment paths:
 
-## Service Architecture
+- Helm for Kubernetes-native installs.
+- Docker Compose for single-host, VPS, or source-build installs.
+
+## Helm Deployment
+
+Use this path when deploying Shepherd into Kubernetes. Helm charts are maintained
+separately in [kv-shepherd/helm-charts](https://github.com/kv-shepherd/helm-charts).
+The published chart uses public Docker Hub images by default.
+
+Demo install without an Ingress controller or persistent database storage:
+
+```bash
+helm repo add shepherd https://kv-shepherd.github.io/helm-charts
+helm repo update
+helm upgrade --install shepherd shepherd/shepherd \
+  --namespace shepherd --create-namespace \
+  --set postgresql.persistence.enabled=false
+
+kubectl -n shepherd port-forward svc/shepherd-edge 3443:443
+```
+
+Open `https://127.0.0.1:3443`. See the chart repository for NodePort/IP access,
+Ingress with TLS, persistent PostgreSQL, external database values, and
+managed-cluster RBAC examples.
+
+## Docker Compose Service Architecture
+
+The Docker Compose topology is built around `server`, `web`, and `nginx`, with
+an optional bundled PostgreSQL service when you do not point `DATABASE_URL` at
+an external database.
 
 | Service | Image | Role |
 |---------|-------|------|
@@ -13,7 +40,7 @@ you do not point `DATABASE_URL` at an external database.
 | **web** | `ghcr.io/kv-shepherd/shepherd-web` by default | Next.js SSR frontend |
 | **nginx** | `nginx:1.30.1-alpine` by default | TLS termination, reverse proxy, rate limiting |
 
-## Deploying from Release Images
+## Docker Compose from Release Images
 
 Use this path for production or VPS hosts that should run published GHCR images
 without a git checkout.
@@ -29,13 +56,15 @@ a generated self-signed TLS certificate:
 
 ```bash
 mkdir -p shepherd-deploy && cd shepherd-deploy
-curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
+curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  bash -s -- --release-images --with-seed
 ```
 
 `wget` works too:
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | bash -s -- --with-seed
+wget -qO- https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
+  bash -s -- --release-images --with-seed
 ```
 
 All runtime inputs are optional. Pass them before `bash` only when you need to
@@ -43,13 +72,13 @@ override the default topology:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
-  SERVER_PUBLIC_BASE_URL=https://shepherd.example.com bash -s -- --with-seed
+  SERVER_PUBLIC_BASE_URL=https://shepherd.example.com bash -s -- --release-images --with-seed
 
 curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
-  DATABASE_URL='<postgres-18-dsn>' DEPLOY_BUNDLED_POSTGRES=false bash -s -- --with-seed
+  DATABASE_URL='<postgres-18-dsn>' DEPLOY_BUNDLED_POSTGRES=false bash -s -- --release-images --with-seed
 
 curl -fsSL https://raw.githubusercontent.com/kv-shepherd/shepherd/main/deploy/prod/deploy-prod.sh | \
-  SHEPHERD_VERSION='vX.Y.Z' bash -s -- --with-seed
+  SHEPHERD_VERSION='vX.Y.Z' bash -s -- --release-images --with-seed
 ```
 
 Use PostgreSQL 18 for external databases. The bundled `postgres:18` container
@@ -73,7 +102,7 @@ For private or offline registries, set `SERVER_IMAGE`, `WEB_IMAGE`, and
 optionally `POSTGRES_IMAGE` or `NGINX_IMAGE` to full image references before
 running the script.
 
-## Deploying from Source Build
+## Docker Compose from Source Build
 
 Use source-build deployment only when you intentionally want the target host to
 build local backend and frontend images from a checkout.
@@ -82,11 +111,16 @@ build local backend and frontend images from a checkout.
 git clone https://github.com/kv-shepherd/shepherd.git
 cd shepherd
 git pull --ff-only origin main
-bash deploy/prod/deploy-prod.sh --with-seed
+bash deploy/prod/deploy-prod.sh --source-build --with-seed
 ```
 
 For source builds, `deploy-prod.sh` uses local image tags by default unless you
-set `SHEPHERD_VERSION`, `SERVER_IMAGE`, or `WEB_IMAGE`.
+set `SERVER_IMAGE` or `WEB_IMAGE`.
+
+Both Docker Compose paths use `deploy-prod.sh`, but the mode flag is deliberate:
+`--release-images` runs published images and can be used from `curl` or `wget`;
+`--source-build` requires a git checkout and builds local images before
+starting the stack.
 
 ## Deployment Script Behavior
 
@@ -104,10 +138,11 @@ On the default bundled PostgreSQL path, `deploy-prod.sh` will automatically:
 Additional script entry points:
 
 ```bash
-bash deploy-prod.sh              # deploy using release images
-bash deploy-prod.sh --with-seed  # first deploy/bootstrap
-bash deploy-prod.sh --with-seed --with-experience-seed
-bash deploy-prod.sh --help       # all options
+bash deploy-prod.sh --release-images
+bash deploy-prod.sh --release-images --with-seed
+bash deploy-prod.sh --release-images --with-seed --with-experience-seed
+bash deploy-prod.sh --source-build --with-seed
+bash deploy-prod.sh --help
 ```
 
 ### Manual Docker Compose Path
@@ -153,7 +188,7 @@ production deployment topology and add the extended experience seed instead of
 using a separate demo mode:
 
 ```bash
-bash deploy/prod/deploy-prod.sh --with-seed --with-experience-seed
+bash deploy/prod/deploy-prod.sh --source-build --with-seed --with-experience-seed
 ```
 
 This keeps the normal `server` + `web` + `nginx` + PostgreSQL deployment path


### PR DESCRIPTION
## Summary

- put Helm first in the README quick start and add Helm near the top of the production deployment guide
- make Docker Compose examples use explicit mode flags: `--release-images` for curl/wget published-image installs and `--source-build` for checkout-based local image builds
- add mutually exclusive `deploy-prod.sh` mode flags so the two documented paths no longer rely on implicit source-tree detection
- make explicit mode selection override stale `.env.prod` image tags unless `SERVER_IMAGE` / `WEB_IMAGE` are passed for the current run

## Validation

- `bash -n deploy/prod/deploy-prod.sh`
- `bash deploy/prod/deploy-prod.sh --help`
- `bash deploy/prod/deploy-prod.sh --release-images --source-build --help` exits with the expected mutual-exclusion error
- `DEPLOY_ENV_FILE=$(mktemp -d)/.env.prod DEPLOY_TLS_DIR=$(mktemp -d)/tls bash deploy/prod/deploy-prod.sh --release-images --build-only`
- `DEPLOY_ENV_FILE=$(mktemp -d)/.env.prod DEPLOY_TLS_DIR=$(mktemp -d)/tls bash deploy/prod/deploy-prod.sh --source-build --build-only`
- `git diff --check`
- `go run docs/design/ci/scripts/check_markdown_links.go`
- `go run docs/design/ci/scripts/check_doc_claims_consistency.go`
- `make public-hygiene-scan`
- `make secrets-scan`

Closes #686