### PR TITLE
fix(instance-size): preserve marker empty objects

### DIFF
--- a/web/src/features/admin-instance-sizes/specOverrides.test.ts
+++ b/web/src/features/admin-instance-sizes/specOverrides.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+
+import { CURATED_INSTANCE_SIZE_PRESET_ITEMS } from '@/presets/catalog/curatedCatalog';
+
+import { stripIndexedSpecOverridePaths } from './specOverrides';
+
+/**
+ * Pulls a parsed `spec_text` JSON tree from a curated InstanceSize preset.
+ *
+ * The curated catalog persists `spec_text` as a stringified KubeVirt VM spec,
+ * which is the canonical input shape that `stripIndexedSpecOverridePaths`
+ * receives at the form -> API data boundary in
+ * `useAdminInstanceSizesController.formToPayload`.
+ */
+function getPresetSpec(key: string): Record<string, unknown> {
+    const preset = CURATED_INSTANCE_SIZE_PRESET_ITEMS.find((item) => item.key === key);
+    if (!preset) {
+        throw new Error(`curated preset "${key}" not found`);
+    }
+    return JSON.parse(preset.values.spec_text) as Record<string, unknown>;
+}
+
+describe('stripIndexedSpecOverridePaths', () => {
+    /**
+     * a. Core mixed-tree case: prove pruning bubbles only along the unset path
+     *    and never inspects sibling branches. The "cpu pruned + devices.rng
+     *    untouched" pair is the golden combination — it is the most direct
+     *    evidence that the cleanup runs along `domain.cpu.*` only.
+     */
+    it('prunes only along the unset path and keeps sibling KubeVirt marker empty objects intact', () => {
+        const spec = {
+            spec: {
+                template: {
+                    spec: {
+                        domain: {
+                            cpu: {
+                                cores: 4,
+                                dedicatedCpuPlacement: true,
+                            },
+                            devices: {
+                                rng: {},
+                                interfaces: [
+                                    { bridge: {}, name: 'default', model: 'virtio' },
+                                ],
+                            },
+                        },
+                        livenessProbe: {
+                            guestAgentPing: {},
+                            initialDelaySeconds: 120,
+                        },
+                        networks: [{ name: 'default', pod: {} }],
+                    },
+                },
+            },
+        };
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        // (1) indexed-column fields are removed and the now-empty `cpu` parent
+        //     is pruned along the unset path; `domain` retains its other
+        //     children (devices) so it is *not* pruned.
+        expect(cleaned).not.toHaveProperty('spec.template.spec.domain.cpu');
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.devices');
+
+        // (2) every sibling marker empty object survives untouched.
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.devices.rng', {});
+        expect(cleaned).toHaveProperty(
+            'spec.template.spec.domain.devices.interfaces.0.bridge',
+            {},
+        );
+        expect(cleaned).toHaveProperty('spec.template.spec.livenessProbe.guestAgentPing', {});
+        expect(cleaned).toHaveProperty('spec.template.spec.networks.0.pod', {});
+    });
+
+    /**
+     * b. When every descendant of an ancestor chain is owned by indexed
+     *    columns, the entire chain collapses upward to the root.
+     */
+    it('prunes the full ancestor chain when every leaf is owned by indexed columns', () => {
+        const spec = {
+            spec: {
+                template: {
+                    spec: {
+                        domain: {
+                            cpu: { cores: 4, dedicatedCpuPlacement: true },
+                        },
+                    },
+                },
+            },
+        };
+
+        const cleaned = stripIndexedSpecOverridePaths(spec);
+
+        expect(cleaned).toEqual({});
+    });
+
+    /**
+     * c. Pruning must stop at the first non-empty ancestor — siblings that
+     *    are unrelated to indexed columns continue to live in the tree.
+     */
+    it('keeps non-empty ancestors intact when only some leaves are pruned', () => {
+        const spec = {
+            spec: {
+                template: {
+                    spec: {
+                        domain: {
+                            cpu: { cores: 4, model: 'host-passthrough' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.cpu', {
+            model: 'host-passthrough',
+        });
+    });
+
+    /**
+     * d. Top-level dot-notation keys (legacy raw-JSON shape) keep being
+     *    deleted via the existing `delete cleaned[path]` branch.
+     */
+    it('removes flat dot-notation top-level keys without touching unrelated entries', () => {
+        const spec = {
+            'spec.template.spec.domain.cpu.cores': 4,
+            'spec.template.spec.domain.cpu.dedicatedCpuPlacement': true,
+            'spec.template.spec.domain.devices.rng': {},
+        };
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        expect(cleaned['spec.template.spec.domain.cpu.cores']).toBeUndefined();
+        expect(cleaned['spec.template.spec.domain.cpu.dedicatedCpuPlacement']).toBeUndefined();
+        expect(cleaned['spec.template.spec.domain.devices.rng']).toEqual({});
+    });
+
+    /**
+     * d2. Legacy nested form (`spec.domain.*`) is also stripped along the
+     *     LEGACY_INDEXED_SPEC_OVERRIDE_PATHS list. Without this regression
+     *     a future refactor of the legacy-prefix derivation could silently
+     *     re-introduce phantom indexed-column values from old DB rows.
+     */
+    it('strips legacy nested spec.domain.* paths and prunes their ancestors', () => {
+        const spec = {
+            spec: {
+                domain: {
+                    cpu: { cores: 4, dedicatedCpuPlacement: true },
+                    devices: { rng: {} },
+                },
+            },
+        };
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        // Indexed-column leaves are removed and the now-empty `cpu` parent is
+        // pruned along the unset path.
+        expect(cleaned).not.toHaveProperty('spec.domain.cpu');
+        // Sibling marker empty object on the legacy branch survives.
+        expect(cleaned).toHaveProperty('spec.domain.devices.rng', {});
+    });
+
+    /**
+     * d3. The function must stay side-effect free: the caller's tree is
+     *     never mutated, even though the internal pruner calls `delete`
+     *     on descendants. Guards against a regression where a future
+     *     refactor reverts the deep clone to a shallow `{ ...spec }`.
+     */
+    it('does not mutate the input spec', () => {
+        const spec = {
+            spec: {
+                template: {
+                    spec: {
+                        domain: {
+                            cpu: { cores: 4, dedicatedCpuPlacement: true },
+                            devices: { rng: {} },
+                        },
+                        livenessProbe: { guestAgentPing: {} },
+                    },
+                },
+            },
+        };
+        const before = JSON.stringify(spec);
+
+        stripIndexedSpecOverridePaths(spec);
+
+        expect(JSON.stringify(spec)).toBe(before);
+    });
+
+    /**
+     * e1. Precise regression for the production incident: the curated
+     *     `linux-prod` preset must keep `livenessProbe.guestAgentPing: {}`
+     *     after the boundary cleanse, otherwise the KubeVirt admission
+     *     webhook rejects the dry-run with
+     *     "either ...livenessProbe.tcpSocket, .exec or .httpGet must be set".
+     */
+    it('linux-prod preset retains livenessProbe.guestAgentPing as {} after strip', () => {
+        const spec = getPresetSpec('linux-prod');
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        expect(cleaned).toHaveProperty('spec.template.spec.livenessProbe.guestAgentPing', {});
+    });
+
+    /**
+     * e2. The Windows curated preset has no livenessProbe, so we exercise
+     *     the regression on its other KubeVirt marker empty objects:
+     *     devices.rng, interfaces[0].bridge, networks[0].pod, plus the
+     *     Windows-specific clock.utc and clock.timer.hyperv.
+     */
+    it('windows-prod preset retains every KubeVirt marker empty object after strip', () => {
+        const spec = getPresetSpec('windows-prod');
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.devices.rng', {});
+        expect(cleaned).toHaveProperty(
+            'spec.template.spec.domain.devices.interfaces.0.bridge',
+            {},
+        );
+        expect(cleaned).toHaveProperty('spec.template.spec.networks.0.pod', {});
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.clock.utc', {});
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.clock.timer.hyperv', {});
+    });
+
+    /**
+     * f. Leaf-exists guard: an ancestor that was *already* empty before the
+     *    strip call must not be pruned. Without the guard, the pruner would
+     *    misattribute pre-existing emptiness to "this unset" and erase
+     *    KubeVirt marker objects placed by the operator on purpose.
+     */
+    it('leaves ancestors that were already empty before the strip untouched', () => {
+        const spec = {
+            spec: {
+                template: {
+                    spec: {
+                        domain: {
+                            // `cpu` is already `{}` and `cpu.cores` does not exist;
+                            // the guard must skip pruning so an operator's deliberate
+                            // marker empty object survives.
+                            cpu: {},
+                        },
+                    },
+                },
+            },
+        };
+
+        const cleaned = stripIndexedSpecOverridePaths(spec) as Record<string, unknown>;
+
+        expect(cleaned).toHaveProperty('spec.template.spec.domain.cpu', {});
+    });
+});

--- a/web/src/features/admin-instance-sizes/specOverrides.ts
+++ b/web/src/features/admin-instance-sizes/specOverrides.ts
@@ -127,8 +127,20 @@ const LEGACY_INDEXED_SPEC_OVERRIDE_PATHS = INDEXED_SPEC_OVERRIDE_PATHS.map(
  * value propagation, avoiding double-source-of-truth races.
  *
  * Returns a shallow clone with both the flat dot-notation keys and the
- * matching nested branches removed; orphan empty parents are pruned so the
- * resulting spec_overrides is canonical and round-trippable.
+ * matching nested branches removed; ancestors emptied **by this unset** are
+ * pruned along the unset path only.
+ *
+ * Pruning semantics align with Lodash `_.unset` (which by design retains an
+ * empty parent object after removing a leaf, e.g. `_.unset({a:[{b:{c:7}}]},
+ * 'a[0].b.c')` -> `{a:[{b:{}}]}`) and never touch sibling branches. KubeVirt
+ * relies on "marker" empty objects such as `livenessProbe.guestAgentPing: {}`,
+ * `devices.rng: {}`, `interfaces[*].bridge: {}`, `networks[*].pod: {}` and
+ * `clock.utc: {}` as legitimate leaf values (see the `// Empty map = leaf
+ * value` invariant in internal/provider/vm_renderer.go). A naive whole-tree
+ * prune would silently strip those markers and the KubeVirt admission webhook
+ * would reject the resulting VM spec ("either ...livenessProbe.tcpSocket,
+ * .exec or .httpGet must be set"), so cleanup is restricted to the ADR-0036
+ * ancestor chain only.
  */
 export function stripIndexedSpecOverridePaths(
     spec: Record<string, unknown> | undefined,
@@ -136,23 +148,67 @@ export function stripIndexedSpecOverridePaths(
     if (!spec) {
         return spec;
     }
-    const cleaned: Record<string, unknown> = { ...spec };
+    // Deep clone before mutating: `unsetAndPruneAncestors` calls `delete` on
+    // descendants, so a shallow `{ ...spec }` would leak writes into the
+    // caller's tree. Today both call sites in `useAdminInstanceSizesController`
+    // happen to feed us a normalized (already cloned) tree, but this is an
+    // exported public API and must stay side-effect free regardless of caller.
+    // `cloneSpecOverrides` uses the structuredClone deep-copy best practice
+    // (MDN; falls back to JSON for older runtimes), which is safe here because
+    // spec_overrides is by contract pure JSON.
+    const cleaned = cloneSpecOverrides(spec);
     for (const path of [...INDEXED_SPEC_OVERRIDE_PATHS, ...LEGACY_INDEXED_SPEC_OVERRIDE_PATHS]) {
         delete cleaned[path];
-        deleteNestedValue(cleaned, path);
+        unsetAndPruneAncestors(cleaned, path);
     }
-    pruneEmptyBranches(cleaned);
     return cleaned;
 }
 
-function pruneEmptyBranches(target: Record<string, unknown>) {
-    for (const [key, value] of Object.entries(target)) {
-        if (!isRecord(value)) {
-            continue;
+/**
+ * Removes the leaf at `path` and bubbles up to prune ancestors that became
+ * empty **as a direct result of this unset**. Sibling branches are never
+ * inspected, so KubeVirt marker empty objects (e.g. `guestAgentPing: {}`,
+ * `rng: {}`, `bridge: {}`, `pod: {}`) survive untouched.
+ *
+ * Aligns with Lodash `_.unset` (path-targeted, retains empty parents) and
+ * adds one ADR-0036 boundary-cleanup rule: when the leaf removal genuinely
+ * empties the parent chain, those empty ancestors are pruned upward until
+ * either a non-empty ancestor is reached or the tree root is hit.
+ *
+ * The leaf-exists guard is required: an absent leaf cannot have been
+ * "emptied by this unset", so we must not prune ancestors that were already
+ * empty before the call (they encode their own KubeVirt marker semantics).
+ */
+function unsetAndPruneAncestors(
+    target: Record<string, unknown>,
+    path: string,
+): void {
+    const segments = path.split('.').filter(Boolean);
+    if (segments.length === 0) {
+        return;
+    }
+    const ancestors: Array<{ parent: Record<string, unknown>; key: string }> = [];
+    let current: Record<string, unknown> = target;
+    for (let index = 0; index < segments.length - 1; index += 1) {
+        const next = current[segments[index]];
+        if (!isRecord(next)) {
+            return;
         }
-        pruneEmptyBranches(value);
-        if (Object.keys(value).length === 0) {
-            delete target[key];
+        ancestors.push({ parent: current, key: segments[index] });
+        current = next;
+    }
+    const leafKey = segments[segments.length - 1];
+    if (!Object.prototype.hasOwnProperty.call(current, leafKey)) {
+        return;
+    }
+    delete current[leafKey];
+    for (let index = ancestors.length - 1; index >= 0; index -= 1) {
+        const { parent, key } = ancestors[index];
+        const value = parent[key];
+        if (isRecord(value) && Object.keys(value).length === 0) {
+            delete parent[key];
+        } else {
+            break;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix the boundary cleanup in `stripIndexedSpecOverridePaths` so that legitimate KubeVirt **marker empty objects** survive the cleanse. Without this fix, administrator approval of a VM request whose InstanceSize relies on those markers (curated `linux-prod`, or any operator-authored spec) is rejected by the cluster:

```
admission webhook "virtualmachine-validator.kubevirt.io" denied the request:
either spec.template.spec.livenessProbe.tcpSocket, .exec or .httpGet must be set
if a spec.template.spec.livenessProbe is specified
```

Closes #692

## Root Cause

The previous helper recursively pruned every empty object in the `spec_overrides` tree. KubeVirt uses several empty leaves as semantic markers (`livenessProbe.guestAgentPing: {}`, `devices.rng: {}`, `interfaces[*].bridge: {}`, `networks[*].pod: {}`, `clock.utc: {}`, `clock.timer.hyperv: {}`); a whole-tree prune erased them, leaving an outer `livenessProbe: { initialDelaySeconds: 120 }` with no handler.

The backend purposely keeps `spec_overrides` opaque (`internal/provider/vm_renderer.go` carries the `// Empty map = leaf value` invariant) and relies on KubeVirt's SSA dry-run for semantic validation; the defect was 100% owned by the frontend boundary cleanse.

## Fix

Replace whole-tree pruning with `unsetAndPruneAncestors`, which follows Lodash `_.unset` semantics:

- removes only the explicitly unset leaf,
- bubbles up to prune ancestors emptied **by that unset** (and stops at the first non-empty ancestor),
- never inspects sibling branches.

Additional hardening of the cleanse contract:
- Deep-clone the input via `cloneSpecOverrides` (`structuredClone`-first per MDN best practice, JSON fallback) so the exported helper is side-effect free.
- Leaf-exists guard via `Object.prototype.hasOwnProperty.call` so ancestors that were already empty before the call are not misattributed to “this unset.”

## Tests (9 cases in `specOverrides.test.ts`)

| ID | Scenario |
|----|----------|
| a  | Mixed-tree pruning + sibling marker survival (golden combination: `cpu` pruned, `devices.rng` / `interfaces[0].bridge` / `livenessProbe.guestAgentPing` / `networks[0].pod` intact) |
| b  | Full-chain collapse to `{}` when every leaf is owned by indexed columns |
| c  | Non-empty ancestor retention (`cpu: { model: 'host-passthrough' }` survives) |
| d  | Flat dot-notation top-level key deletion |
| d2 | Legacy nested `spec.domain.*` path stripping |
| d3 | Input immutability (no caller-tree mutation) |
| e1 | `linux-prod` curated preset retains `livenessProbe.guestAgentPing: {}` |
| e2 | `windows-prod` curated preset retains `rng/bridge/pod/clock.utc/clock.timer.hyperv` |
| f  | Leaf-exists guard against pre-existing empty objects |

## Scope

- **Frontend only**: `web/src/features/admin-instance-sizes/specOverrides.ts` (+68/-12) + new test file
- **No backend / API contract change** (validation stays delegated to KubeVirt SSA dry-run)
- **No preset payload change** (presets are correct; cleanse must respect them)

## Stale-Data Remediation (Required)

> ⚠️ Pre-existing rows whose `spec_overrides` were already stripped by the previous logic **will not be auto-restored** by this fix. Hydrate + save in the admin UI only re-writes the still-broken value back to KubeVirt and the webhook will still reject it. Affected rows must be repaired via **one** of the following:
>
> 1. **Re-apply preset** (recommended): in admin UI, click “Reset to preset” on the affected InstanceSize, then save – reseeds the complete `livenessProbe` handler.
> 2. **Manual repair**: in the admin raw-JSON editor, re-add the missing handler (e.g. `livenessProbe.guestAgentPing: {}`) and save.
> 3. **Ops direct JSONB patch**: DBA runs `UPDATE instance_sizes SET spec_overrides = jsonb_set(…)` to re-insert the marker leaf.
>
> Diagnostic SQL to find affected rows:
>
> ```sql
> SELECT id, name FROM instance_sizes
> WHERE spec_overrides->'spec'->'template'->'spec' ? 'livenessProbe'
>   AND NOT (
>     spec_overrides->'spec'->'template'->'spec'->'livenessProbe'
>       ?| array['guestAgentPing','tcpSocket','httpGet','exec']
>   );
> ```

## Workflow-Equivalent Validation

Local `make pr` passed on this PR branch:

| Lane | Time | Result |
|------|------|--------|
| backend     | 1m20s | ✅ PASS |
| governance  | 0m21s | ✅ PASS |
| frontend    | 7m18s | ✅ PASS |
| e2e-smoke   | 1m52s | ✅ PASS |

Frontend unit tests: **86 files / 430 cases all green** (including the 9 new `specOverrides.test.ts` cases). `make secrets-scan` clean.

## ADR Alignment

- ADR-0018 §4 / ADR-0036: indexed columns remain SOT; the cleanse is the symmetric frontend counterpart to the backend `HasDedicatedCPUInSpecOverrides` / `DetectSpecOverridesConflicts` guards.
- Backend keeps the `// Empty map = leaf value` invariant; this PR brings the frontend boundary into compliance.

release impact: bugfix/patch
