### PR TITLE
docs: unify project links to canonical kv-shepherd.io

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,6 +2,9 @@
 
 KubeVirt Shepherd is an open-source project maintained by the CloudPasture community.
 
+- **Website**: https://kv-shepherd.io
+- **Source**: https://github.com/kv-shepherd/shepherd
+
 ## How to Support
 
 If you find this project useful, please consider:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Official Website
+    url: https://kv-shepherd.io
+    about: Project homepage, feature overview, and deployment options
   - name: GitHub Discussions
-    url: https://github.com/CloudPasture/kubevirt-shepherd/discussions
+    url: https://github.com/kv-shepherd/shepherd/discussions
     about: Please use GitHub Discussions for questions and general discussions
   - name: Security Vulnerabilities
-    url: https://github.com/CloudPasture/kubevirt-shepherd/security/policy
+    url: https://github.com/kv-shepherd/shepherd/security/policy
     about: Please report security vulnerabilities following our security policy

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/kv-shepherd/shepherd)](go.mod)
 [![CI](https://github.com/kv-shepherd/shepherd/actions/workflows/ci.yml/badge.svg)](https://github.com/kv-shepherd/shepherd/actions/workflows/ci.yml)
 
-**[Website](https://www.kv-shepherd.io)** ·
+**[Website](https://kv-shepherd.io)** ·
 **[Online Demo](https://demo.kv-shepherd.io)** ·
 **[Documentation](docs/README.md)**
 
@@ -95,7 +95,15 @@ kubectl -n shepherd port-forward svc/shepherd-edge 3443:443
 
 Open `https://127.0.0.1:3443`. See the chart repository for NodePort/IP access,
 Ingress with TLS, persistent PostgreSQL, external database values, and
-managed-cluster RBAC examples.
+managed-cluster RBAC examples. Clusters that run Prometheus Operator can also
+enable chart-managed monitoring resources:
+
+```bash
+helm upgrade --install shepherd shepherd/shepherd \
+  --namespace shepherd --create-namespace \
+  --set observability.serviceMonitor.enabled=true \
+  --set observability.prometheusRule.enabled=true
+```
 
 ### Docker Compose From Release Images
 
@@ -121,7 +129,7 @@ before `bash`.
 
 See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for external PostgreSQL 18,
 domain/TLS configuration, image version pinning, manual compose commands, and
-the security checklist.
+the optional Prometheus/Grafana monitoring overlay, and the security checklist.
 
 ### Local Development
 
@@ -176,6 +184,7 @@ configuration reference, security checklist, and VPS experience seed setup.
 Feedback from real environments is especially useful while the project is in
 Alpha.
 
+- [Official Website](https://kv-shepherd.io) - Project homepage and feature overview
 - [Discord](https://discord.gg/9P2wtpPMUe) - Chat with the community
 - [GitHub Issues][issues] - Bug reports and feature requests
 - [GitHub Discussions](https://github.com/kv-shepherd/shepherd/discussions) - Questions and ideas

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # KubeVirt Shepherd Documentation
 
+> **[kv-shepherd.io](https://kv-shepherd.io)** · **[Online Demo](https://demo.kv-shepherd.io)** · **[Deployment Guide](./DEPLOYMENT.md)**
+>
 > This directory contains all project documentation organized following open source best practices.
 
 ---
@@ -164,6 +166,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidelines.
 
 | Document | Purpose |
 |----------|---------|
+| [kv-shepherd.io](https://kv-shepherd.io) | Official project website |
 | [DEPLOYMENT.md](./DEPLOYMENT.md) | Production deployment guide and configuration reference |
 | [RELEASE.md](./RELEASE.md) | Release process and versioning |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Contribution guidelines |


### PR DESCRIPTION
## Description

Standardize all repository entry points to use the canonical `https://kv-shepherd.io` URL (without `www` prefix), matching the website sitemap and hreflang configuration deployed in d5ae286.

This improves search engine signal consistency between the GitHub repository and the official website.

## Changes

- **README.md**: fix Website link to canonical URL; add Official Website to Community section
- **docs/README.md**: add project links bar at top; add website row to Related Documents table
- **.github/ISSUE_TEMPLATE/config.yml**: fix stale CloudPasture org URLs; add Official Website contact link
- **.github/FUNDING.yml**: add Website and Source links

## Type of Change

- [x] 📚 Documentation update

## Checklist

### Documentation
- [x] I have updated relevant documentation
- [x] No breaking changes

Issue: N/A (follow-up to d5ae286 SEO metadata commit)

---

By submitting this pull request, I confirm that:
- My contribution is made under the Apache 2.0 license
- All commits are signed off (DCO)