### PR TITLE
fix(dev): use public origin for redirects

### DIFF
--- a/deploy/dev/start-dev.sh
+++ b/deploy/dev/start-dev.sh
@@ -486,6 +486,7 @@ start_host_frontend() {
             NEXT_PUBLIC_DEV_BROWSER_LOG_BRIDGE="1" \
             NEXT_PUBLIC_DEV_SECURE_ORIGIN="${DEV_PUBLIC_BASE_URL}" \
             NEXT_PUBLIC_DEV_HTTP_INGRESS_PORT="${DEV_INGRESS_PORT}" \
+            SHEPHERD_PUBLIC_BASE_URL="${DEV_PUBLIC_BASE_URL}" \
             INTERNAL_API_URL="http://localhost:8080" \
             NEXT_DIST_DIR="${DEV_FRONTEND_PROD_DIST_DIR}" \
             NODE_OPTIONS="${node_options}" \
@@ -504,6 +505,9 @@ start_host_frontend() {
             cd "${ROOT_DIR}/web"
             NEXT_PUBLIC_API_URL="/api/v1" \
             NEXT_PUBLIC_DEV_BROWSER_LOG_BRIDGE="1" \
+            NEXT_PUBLIC_DEV_SECURE_ORIGIN="${DEV_PUBLIC_BASE_URL}" \
+            NEXT_PUBLIC_DEV_HTTP_INGRESS_PORT="${DEV_INGRESS_PORT}" \
+            SHEPHERD_PUBLIC_BASE_URL="${DEV_PUBLIC_BASE_URL}" \
             INTERNAL_API_URL="http://localhost:8080" \
             NEXT_DIST_DIR="${DEV_FRONTEND_PROD_DIST_DIR}" \
             NODE_OPTIONS="${node_options}" \
@@ -545,6 +549,7 @@ start_host_frontend() {
         NEXT_PUBLIC_DEV_BROWSER_LOG_BRIDGE="1" \
         NEXT_PUBLIC_DEV_SECURE_ORIGIN="${DEV_PUBLIC_BASE_URL}" \
         NEXT_PUBLIC_DEV_HTTP_INGRESS_PORT="${DEV_INGRESS_PORT}" \
+        SHEPHERD_PUBLIC_BASE_URL="${DEV_PUBLIC_BASE_URL}" \
         INTERNAL_API_URL="http://localhost:8080" \
         WATCHPACK_POLLING="$([[ "${watch_mode}" == "polling" ]] && echo true || echo false)" \
         CHOKIDAR_USEPOLLING="$([[ "${watch_mode}" == "polling" ]] && echo 1 || echo 0)" \

--- a/web/src/proxy.test.ts
+++ b/web/src/proxy.test.ts
@@ -189,6 +189,23 @@ describe("proxy", () => {
     expect(response.headers.get("location")).toBe("https://shepherd.example.com/login");
   });
 
+  it("uses the dev public origin for local reverse-proxy redirects", () => {
+    vi.stubEnv("NEXT_PUBLIC_DEV_SECURE_ORIGIN", "https://test-shepherd.example.com");
+    process.env.NEXT_PUBLIC_LOGIN_ENTRY_PATH = "/enterprise-login";
+
+    const response = proxy(
+      makeRequest("https://test-shepherd.example.com:3101/admin/approval-tasks", undefined, {
+        host: "test-shepherd.example.com:3101",
+        "x-forwarded-proto": "https",
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://test-shepherd.example.com/enterprise-login",
+    );
+  });
+
   it("forwards only allow-listed request headers plus CSP nonce", () => {
     const forwarded = buildForwardedRequestHeaders(
       new Headers({

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -54,6 +54,16 @@ function parseBooleanEnv(value: string | undefined): boolean | undefined {
   }
 }
 
+function resolveRawPublicBaseURL(): string {
+  return (
+    process.env.SHEPHERD_PUBLIC_BASE_URL ||
+    process.env.SERVER_PUBLIC_BASE_URL ||
+    process.env.DEV_PUBLIC_BASE_URL ||
+    process.env.NEXT_PUBLIC_DEV_SECURE_ORIGIN ||
+    ""
+  ).trim();
+}
+
 export function shouldSendHTTPSOnlyHeaders(): boolean {
   const isProduction = process.env.NODE_ENV === "production";
   if (!isProduction) {
@@ -65,11 +75,7 @@ export function shouldSendHTTPSOnlyHeaders(): boolean {
     return explicit;
   }
 
-  const rawPublicBaseURL = (
-    process.env.SHEPHERD_PUBLIC_BASE_URL ||
-    process.env.SERVER_PUBLIC_BASE_URL ||
-    ""
-  ).trim();
+  const rawPublicBaseURL = resolveRawPublicBaseURL();
   if (!rawPublicBaseURL) {
     return true;
   }
@@ -82,11 +88,7 @@ export function shouldSendHTTPSOnlyHeaders(): boolean {
 }
 
 function resolveConfiguredPublicURL(protocol?: "http" | "https"): URL | undefined {
-  const rawPublicBaseURL = (
-    process.env.SHEPHERD_PUBLIC_BASE_URL ||
-    process.env.SERVER_PUBLIC_BASE_URL ||
-    ""
-  ).trim();
+  const rawPublicBaseURL = resolveRawPublicBaseURL();
   if (!rawPublicBaseURL) {
     return undefined;
   }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -38,7 +38,8 @@
     ".next-e2e/types/**/*.ts",
     ".next-e2e/**/types/**/*.ts",
     ".next-prod/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-prod/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary

- Pass the computed dev public base URL into the host Next.js runtime in build, start, and dev modes.
- Centralize frontend proxy public base URL resolution across production and dev runtime variables.
- Add regression coverage for local reverse-proxy login redirects and include `.next-prod/dev/types` in TypeScript checks.

## Validation

- Context7: checked official Next.js guidance for Proxy redirects with `NextResponse.redirect(new URL(...))` and server-side environment variable access.
- `npm --prefix web run test:run -- src/proxy.test.ts`
- `npm --prefix web run typecheck`
- `make secrets-scan`
- `npm --prefix web run lint`
- `npm --prefix web run test:run`
- `make pr` on the candidate PR branch

## Issue

Closes #710

## Release impact

bugfix/patch
