### PR TITLE
fix(vm): align resource approval requests

### DIFF
--- a/internal/api/handlers/server_vm_modify.go
+++ b/internal/api/handlers/server_vm_modify.go
@@ -337,6 +337,7 @@ func (s *Server) buildVMModifyPayload(
 		CurrentDiskGB:          liveVM.Spec.DiskGB,
 		CurrentCPURequest:      liveVM.Spec.CPURequest,
 		CurrentMemoryRequestGi: liveVM.Spec.MemoryRequestGi,
+		HugepagesPageSize:      liveVM.Spec.HugepagesPageSize,
 		TargetCPUCores:         targetCPU,
 		TargetMemoryGi:         targetMemory,
 		TargetDiskGB:           targetDisk,

--- a/internal/api/handlers/server_vm_modify_test.go
+++ b/internal/api/handlers/server_vm_modify_test.go
@@ -129,6 +129,46 @@ func TestCreateVMModifyRequest_CreatesPendingModifyTicket(t *testing.T) {
 	}
 }
 
+func TestCreateVMModifyRequest_PreservesHugepagesContext(t *testing.T) {
+	t.Parallel()
+
+	srv, client, vmID := newVMModifyTestServerWithSpec(t, entvm.StatusRUNNING, domain.VMStatusRunning, func(spec *domain.VMSpec) {
+		spec.HugepagesPageSize = "2Mi"
+	})
+
+	body := mustJSON(t, generated.VMModifyRequest{
+		Reason:         "scale hugepages memory",
+		TargetMemoryGi: 8,
+	})
+	c, w := newAuthedGinContext(t, http.MethodPost, "/vms/"+vmID+"/modify-request", body, "owner-1", []string{"vm:operate", "platform:admin"})
+	srv.CreateVMModifyRequest(c, vmID)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d body=%s", w.Code, http.StatusAccepted, w.Body.String())
+	}
+
+	var resp generated.TicketResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	ticket, err := client.Ticket.Get(t.Context(), resp.TicketId)
+	if err != nil {
+		t.Fatalf("query ticket: %v", err)
+	}
+	event, err := client.DomainEvent.Get(t.Context(), ticket.EventID)
+	if err != nil {
+		t.Fatalf("query domain event: %v", err)
+	}
+
+	var payload domain.VMModifyPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("decode event payload: %v", err)
+	}
+	if payload.HugepagesPageSize != "2Mi" {
+		t.Fatalf("payload.HugepagesPageSize = %q, want 2Mi", payload.HugepagesPageSize)
+	}
+}
+
 func TestCreateVMModifyRequest_AllowsRunningShrinkAndMarksRestartRequired(t *testing.T) {
 	t.Parallel()
 
@@ -206,6 +246,15 @@ func newVMModifyTestServer(t *testing.T) (*Server, *ent.Client, string) {
 }
 
 func newVMModifyTestServerWithStatus(t *testing.T, dbStatus entvm.Status, liveStatus domain.VMStatus) (*Server, *ent.Client, string) {
+	return newVMModifyTestServerWithSpec(t, dbStatus, liveStatus, nil)
+}
+
+func newVMModifyTestServerWithSpec(
+	t *testing.T,
+	dbStatus entvm.Status,
+	liveStatus domain.VMStatus,
+	mutateSpec func(*domain.VMSpec),
+) (*Server, *ent.Client, string) {
 	t.Helper()
 
 	client := testutil.OpenEntPostgres(t, "server_vm_modify")
@@ -245,23 +294,28 @@ func newVMModifyTestServerWithStatus(t *testing.T, dbStatus entvm.Status, liveSt
 		t.Fatalf("create vm: %v", err)
 	}
 
+	liveSpec := domain.VMSpec{
+		CPU:                      2,
+		MemoryGi:                 4,
+		DiskGB:                   20,
+		RootDataVolumeName:       "rootdisk",
+		DiskHotplugSupported:     true,
+		CurrentCPUSockets:        1,
+		CurrentCPUCoresPerSocket: 2,
+		CurrentCPUThreads:        1,
+	}
+	if mutateSpec != nil {
+		mutateSpec(&liveSpec)
+	}
+
 	mock := provider.NewMockProvider()
 	mock.Seed([]*domain.VM{{
-		ID:        vmID,
-		Name:      vmName,
-		Namespace: "prod-ns",
-		Cluster:   clusterID,
-		Status:    liveStatus,
-		Spec: domain.VMSpec{
-			CPU:                      2,
-			MemoryGi:                 4,
-			DiskGB:                   20,
-			RootDataVolumeName:       "rootdisk",
-			DiskHotplugSupported:     true,
-			CurrentCPUSockets:        1,
-			CurrentCPUCoresPerSocket: 2,
-			CurrentCPUThreads:        1,
-		},
+		ID:              vmID,
+		Name:            vmName,
+		Namespace:       "prod-ns",
+		Cluster:         clusterID,
+		Status:          liveStatus,
+		Spec:            liveSpec,
 		ResourceVersion: "rv-modify-1",
 	}})
 

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -223,6 +223,7 @@ type VMModifyPayload struct {
 	CurrentDiskGB          int     `json:"current_disk_gb,omitempty"`
 	CurrentCPURequest      float64 `json:"current_cpu_request,omitempty"`
 	CurrentMemoryRequestGi float64 `json:"current_memory_request_gi,omitempty"`
+	HugepagesPageSize      string  `json:"hugepages_page_size,omitempty"`
 
 	TargetCPUCores  *float64 `json:"target_cpu_cores,omitempty"`
 	TargetMemoryGi  *float64 `json:"target_memory_gi,omitempty"`

--- a/internal/domain/vm.go
+++ b/internal/domain/vm.go
@@ -48,6 +48,8 @@ type VMSpec struct {
 	// MemoryRequestGi is the K8s memory request in Gi (overcommit: request ≤ limit/MemoryGi).
 	// Zero means "use MemoryGi" (no overcommit). Set via admin resource override (Stage 5.B).
 	MemoryRequestGi float64 `json:"memory_request_gi,omitempty"`
+	// HugepagesPageSize is set when the VM uses hugepages-backed memory.
+	HugepagesPageSize string `json:"hugepages_page_size,omitempty"`
 
 	// SpecOverrides carries advanced KubeVirt spec path/value overrides (ADR-0018 Hybrid Model).
 	// Merge order: Template.spec_overrides → InstanceSize.spec_overrides → approval modified_spec.

--- a/internal/domain/vm_test.go
+++ b/internal/domain/vm_test.go
@@ -29,6 +29,25 @@ func TestVMSpecJSON_ExposeRootVolumeDVFields(t *testing.T) {
 	}
 }
 
+func TestVMSpecJSON_ExposesHugepagesPageSize(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(VMSpec{
+		Name:              "vm-hugepages",
+		CPU:               4,
+		MemoryGi:          8,
+		HugepagesPageSize: "2Mi",
+	})
+	if err != nil {
+		t.Fatalf("Marshal(VMSpec) error = %v", err)
+	}
+
+	body := string(raw)
+	if !strings.Contains(body, `"hugepages_page_size":"2Mi"`) {
+		t.Fatalf("Marshal(VMSpec) = %s, want hugepages_page_size", body)
+	}
+}
+
 func TestVMSpecJSON_HidesLiveUpdateInternalFields(t *testing.T) {
 	t.Parallel()
 
@@ -69,17 +88,18 @@ func TestVMModifyPayloadJSON_PreservesTargetResources(t *testing.T) {
 	targetDisk := 40
 
 	raw, err := json.Marshal(VMModifyPayload{
-		VMID:            "vm-1",
-		VMName:          "vm-one",
-		ClusterID:       "cluster-a",
-		Namespace:       "prod-ns",
-		Actor:           "owner-1",
-		CurrentCPUCores: 2,
-		CurrentMemoryGi: 4,
-		CurrentDiskGB:   20,
-		TargetCPUCores:  &targetCPU,
-		TargetMemoryGi:  &targetMemory,
-		TargetDiskGB:    &targetDisk,
+		VMID:              "vm-1",
+		VMName:            "vm-one",
+		ClusterID:         "cluster-a",
+		Namespace:         "prod-ns",
+		Actor:             "owner-1",
+		CurrentCPUCores:   2,
+		CurrentMemoryGi:   4,
+		CurrentDiskGB:     20,
+		HugepagesPageSize: "2Mi",
+		TargetCPUCores:    &targetCPU,
+		TargetMemoryGi:    &targetMemory,
+		TargetDiskGB:      &targetDisk,
 	})
 	if err != nil {
 		t.Fatalf("Marshal(VMModifyPayload) error = %v", err)
@@ -90,6 +110,7 @@ func TestVMModifyPayloadJSON_PreservesTargetResources(t *testing.T) {
 		`"target_cpu_cores":4`,
 		`"target_memory_gi":8`,
 		`"target_disk_gb":40`,
+		`"hugepages_page_size":"2Mi"`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("Marshal(VMModifyPayload) = %s, want %s", body, want)

--- a/internal/governance/ticketing/service.go
+++ b/internal/governance/ticketing/service.go
@@ -250,6 +250,9 @@ func (g *Service) approveCreateWithConfig(
 	if err != nil {
 		return fmt.Errorf("get instance size %s for ticket %s: %w", effectiveInstanceSizeID, ticketID, err)
 	}
+	if validationErr := validateCreateHugepagesApprovalOverride(payload, instanceSizeEntity, opts); validationErr != nil {
+		return validationErr
+	}
 
 	var placementEvaluation map[string]interface{}
 	if g.validator != nil {
@@ -769,10 +772,6 @@ func (g *Service) prepareModifyApproval(
 	if err := json.Unmarshal(event.Payload, &payload); err != nil {
 		return nil, fmt.Errorf("parse modify event payload: %w", err)
 	}
-	overrideCPURequest, overrideMemoryRequest, modifySpec, validationErr := buildModifyApprovalSpec(&payload, opts)
-	if validationErr != nil {
-		return nil, validationErr
-	}
 
 	if g.vmService == nil {
 		return nil, apperrors.New(
@@ -791,6 +790,14 @@ func (g *Service) prepareModifyApproval(
 	}
 	if liveVM == nil {
 		return nil, fmt.Errorf("live vm is unavailable for modify approval %s", ticketID)
+	}
+	usesHugepages, err := g.modifyPayloadUsesHugepages(ctx, &payload, liveVM)
+	if err != nil {
+		return nil, err
+	}
+	overrideCPURequest, overrideMemoryRequest, modifySpec, validationErr := buildModifyApprovalSpec(&payload, opts, usesHugepages)
+	if validationErr != nil {
+		return nil, validationErr
 	}
 
 	plan, err := vmmutationplan.PlanVMResourceUpdatePatch(payload.Namespace, liveVM, vmmutationplan.VMLiveUpdateTargets{
@@ -849,6 +856,7 @@ func isNonConsumingApprovalError(err error) bool {
 func buildModifyApprovalSpec(
 	payload *domain.VMModifyPayload,
 	opts ExecutionOptions,
+	usesHugepages bool,
 ) (overrideCPURequest, overrideMemoryRequest *float64, modifiedSpec map[string]interface{}, err error) {
 	if payload == nil {
 		return nil, nil, nil, fmt.Errorf("modify payload is required")
@@ -878,6 +886,16 @@ func buildModifyApprovalSpec(
 			effectiveMemoryRequest = opts.MemoryRequestGi
 			overrideMemoryRequest = &effectiveMemoryRequest
 			modifiedSpec["memory_request_gi"] = opts.MemoryRequestGi
+		}
+	}
+	if usesHugepages {
+		if opts.EnableOverride && opts.MemoryRequestGi > 0 && !float64Equal(opts.MemoryRequestGi, targetMemoryLimitGi) {
+			return nil, nil, nil, hugepagesMemoryRequestAlignmentError(opts.MemoryRequestGi, targetMemoryLimitGi)
+		}
+		if targetMemoryLimitGi > 0 {
+			effectiveMemoryRequest = targetMemoryLimitGi
+			overrideMemoryRequest = &effectiveMemoryRequest
+			modifiedSpec["memory_request_gi"] = targetMemoryLimitGi
 		}
 	}
 
@@ -912,6 +930,74 @@ func buildModifyApprovalSpec(
 		return nil, nil, nil, nil
 	}
 	return overrideCPURequest, overrideMemoryRequest, modifiedSpec, nil
+}
+
+func (g *Service) modifyPayloadUsesHugepages(ctx context.Context, payload *domain.VMModifyPayload, liveVM *domain.VM) (bool, error) {
+	if liveVM != nil && strings.TrimSpace(liveVM.Spec.HugepagesPageSize) != "" {
+		return true, nil
+	}
+	if payload != nil && strings.TrimSpace(payload.HugepagesPageSize) != "" {
+		return true, nil
+	}
+	if payload == nil || strings.TrimSpace(payload.InstanceSizeID) == "" {
+		return false, nil
+	}
+	size, err := g.client.InstanceSize.Get(ctx, strings.TrimSpace(payload.InstanceSizeID))
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get instance size %s for modify approval: %w", payload.InstanceSizeID, err)
+	}
+	return instanceSizeUsesHugepages(size), nil
+}
+
+func validateCreateHugepagesApprovalOverride(payload *vmCreatePayload, size *ent.InstanceSize, opts ExecutionOptions) error {
+	if !instanceSizeUsesHugepages(size) || !opts.EnableOverride || opts.MemoryRequestGi <= 0 {
+		return nil
+	}
+	resolved := resolveCreateRequestTargets(payload, size)
+	targetMemoryLimitGi := resolved.MemoryLimitGi
+	if opts.MemoryLimitGi > 0 {
+		targetMemoryLimitGi = opts.MemoryLimitGi
+	}
+	if targetMemoryLimitGi <= 0 || float64Equal(opts.MemoryRequestGi, targetMemoryLimitGi) {
+		return nil
+	}
+	return hugepagesMemoryRequestAlignmentError(opts.MemoryRequestGi, targetMemoryLimitGi)
+}
+
+func instanceSizeUsesHugepages(size *ent.InstanceSize) bool {
+	if size == nil {
+		return false
+	}
+	for _, capability := range service.ExtractRequiredCapabilities(size) {
+		if capability == "hugepages" || strings.HasPrefix(capability, "hugepages:") {
+			return true
+		}
+	}
+	return false
+}
+
+func hugepagesMemoryRequestAlignmentError(request, limit float64) error {
+	return apperrors.BadRequest(
+		"HUGEPAGES_MEMORY_REQUEST_ALIGNMENT_REQUIRED",
+		"hugepages-backed memory requires memory request to equal memory limit",
+	).WithParams(map[string]interface{}{
+		"memory_request_gi": request,
+		"memory_limit_gi":   limit,
+	}).WithFieldErrors([]apperrors.FieldError{{
+		Field:   "memory_request_gi",
+		Code:    "HUGEPAGES_REQUIRES_LIMIT_ALIGNMENT",
+		Message: "hugepages-backed memory requires memory request to equal memory limit",
+	}})
+}
+
+func float64Equal(a, b float64) bool {
+	if a > b {
+		return a-b < 1e-9
+	}
+	return b-a < 1e-9
 }
 
 func withApprovedVMMutation(modifiedSpec map[string]interface{}, plan *vmmutationplan.VMResourceUpdatePlan) map[string]interface{} {
@@ -1790,6 +1876,9 @@ func (g *Service) buildDryRunSpec(
 	} else if opts.DiskGB > 0 {
 		spec.DiskGB = opts.DiskGB
 	}
+	if instanceSizeUsesHugepages(size) && spec.MemoryGi > 0 {
+		spec.MemoryRequestGi = spec.MemoryGi
+	}
 
 	return spec, nil
 }
@@ -1798,7 +1887,7 @@ func resolveCreateRequestTargets(
 	payload *vmCreatePayload,
 	size *ent.InstanceSize,
 ) service.ResolvedVMRequestTargets {
-	return service.ResolveVMRequestTargets(
+	resolved := service.ResolveVMRequestTargets(
 		size.CPUCores,
 		size.CPURequest,
 		size.MemoryGi,
@@ -1810,6 +1899,13 @@ func resolveCreateRequestTargets(
 			TargetDiskGB:   payload.TargetDiskGB,
 		},
 	)
+	if instanceSizeUsesHugepages(size) &&
+		resolved.MemoryLimitGi > 0 &&
+		!float64Equal(resolved.MemoryRequestGi, resolved.MemoryLimitGi) {
+		resolved.MemoryRequestGi = resolved.MemoryLimitGi
+		resolved.AdjustedMemoryGiReq = true
+	}
+	return resolved
 }
 
 func buildCreateApprovalOverride(
@@ -1843,6 +1939,9 @@ func buildCreateApprovalOverride(
 		}
 	} else if opts.DiskGB > 0 {
 		override.DiskGB = opts.DiskGB
+	}
+	if instanceSizeUsesHugepages(size) && override.MemoryLimitGi > 0 {
+		override.MemoryRequestGi = override.MemoryLimitGi
 	}
 	return &override
 }

--- a/internal/governance/ticketing/service_behavior_test.go
+++ b/internal/governance/ticketing/service_behavior_test.go
@@ -235,6 +235,53 @@ func ptrFloat64(v float64) *float64 {
 	return &v
 }
 
+func TestResolveCreateRequestTargets_HugepagesAlignsMemoryRequestToLimit(t *testing.T) {
+	t.Parallel()
+
+	resolved := resolveCreateRequestTargets(&vmCreatePayload{}, &ent.InstanceSize{
+		CPUCores:          4,
+		CPURequest:        2,
+		MemoryGi:          16,
+		MemoryRequestGi:   8,
+		DiskGB:            80,
+		RequiresHugepages: true,
+		HugepagesSize:     "2Mi",
+	})
+
+	if resolved.MemoryRequestGi != 16 {
+		t.Fatalf("MemoryRequestGi = %v, want 16", resolved.MemoryRequestGi)
+	}
+	if !resolved.AdjustedMemoryGiReq {
+		t.Fatalf("AdjustedMemoryGiReq = false, want true: %+v", resolved)
+	}
+}
+
+func TestValidateCreateHugepagesApprovalOverride_RejectsExplicitMismatch(t *testing.T) {
+	t.Parallel()
+
+	err := validateCreateHugepagesApprovalOverride(&vmCreatePayload{}, &ent.InstanceSize{
+		CPUCores:          4,
+		MemoryGi:          16,
+		DiskGB:            80,
+		RequiresHugepages: true,
+		HugepagesSize:     "2Mi",
+	}, ExecutionOptions{
+		EnableOverride:  true,
+		MemoryLimitGi:   16,
+		MemoryRequestGi: 8,
+	})
+	if err == nil {
+		t.Fatal("validateCreateHugepagesApprovalOverride() error = nil, want mismatch error")
+	}
+	appErr, ok := apperrors.IsAppError(err)
+	if !ok {
+		t.Fatalf("validateCreateHugepagesApprovalOverride() err = %v, want AppError", err)
+	}
+	if appErr.Code != "HUGEPAGES_MEMORY_REQUEST_ALIGNMENT_REQUIRED" {
+		t.Fatalf("appErr.Code = %q, want HUGEPAGES_MEMORY_REQUEST_ALIGNMENT_REQUIRED", appErr.Code)
+	}
+}
+
 func TestServiceApproveCreate_CallsAtomicWriterWithResolvedIDs(t *testing.T) {
 	t.Parallel()
 
@@ -341,7 +388,7 @@ func TestBuildModifyApprovalSpec_RequiresRequestReviewWhenLimitDropsBelowCurrent
 		CurrentMemoryRequestGi: 8,
 		TargetCPUCores:         ptrFloat64(4),
 		TargetMemoryGi:         ptrFloat64(4),
-	}, ExecutionOptions{})
+	}, ExecutionOptions{}, false)
 	if err == nil {
 		t.Fatal("buildModifyApprovalSpec() error = nil, want validation error")
 	}
@@ -371,7 +418,7 @@ func TestBuildModifyApprovalSpec_StoresApprovedRequestOverrides(t *testing.T) {
 		EnableOverride:  true,
 		CPURequest:      4,
 		MemoryRequestGi: 4,
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("buildModifyApprovalSpec() error = %v", err)
 	}
@@ -389,6 +436,66 @@ func TestBuildModifyApprovalSpec_StoresApprovedRequestOverrides(t *testing.T) {
 	}
 	if got, ok := modifiedSpec["memory_request_gi"].(float64); !ok || got != 4 {
 		t.Fatalf("modifiedSpec[memory_request_gi] = %v, want 4", modifiedSpec["memory_request_gi"])
+	}
+}
+
+func TestBuildModifyApprovalSpec_HugepagesAlignsMemoryRequestToLimit(t *testing.T) {
+	t.Parallel()
+
+	_, memoryRequest, modifiedSpec, err := buildModifyApprovalSpec(&domain.VMModifyPayload{
+		CurrentCPUCores:        4,
+		CurrentMemoryGi:        8,
+		CurrentCPURequest:      2,
+		CurrentMemoryRequestGi: 4,
+		TargetMemoryGi:         ptrFloat64(16),
+	}, ExecutionOptions{}, true)
+	if err != nil {
+		t.Fatalf("buildModifyApprovalSpec() error = %v", err)
+	}
+	if memoryRequest == nil || *memoryRequest != 16 {
+		t.Fatalf("memoryRequest = %v, want 16", memoryRequest)
+	}
+	if got, ok := modifiedSpec["memory_request_gi"].(float64); !ok || got != 16 {
+		t.Fatalf("modifiedSpec[memory_request_gi] = %v, want 16", modifiedSpec["memory_request_gi"])
+	}
+}
+
+func TestBuildModifyApprovalSpec_HugepagesRejectsExplicitMemoryRequestMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := buildModifyApprovalSpec(&domain.VMModifyPayload{
+		CurrentCPUCores:        4,
+		CurrentMemoryGi:        8,
+		CurrentCPURequest:      2,
+		CurrentMemoryRequestGi: 8,
+		TargetMemoryGi:         ptrFloat64(16),
+	}, ExecutionOptions{
+		EnableOverride:  true,
+		MemoryRequestGi: 8,
+	}, true)
+	if err == nil {
+		t.Fatal("buildModifyApprovalSpec() error = nil, want hugepages alignment error")
+	}
+	appErr, ok := apperrors.IsAppError(err)
+	if !ok {
+		t.Fatalf("buildModifyApprovalSpec() err = %v, want AppError", err)
+	}
+	if appErr.Code != "HUGEPAGES_MEMORY_REQUEST_ALIGNMENT_REQUIRED" {
+		t.Fatalf("appErr.Code = %q, want HUGEPAGES_MEMORY_REQUEST_ALIGNMENT_REQUIRED", appErr.Code)
+	}
+}
+
+func TestModifyPayloadUsesHugepages_UsesPayloadFallback(t *testing.T) {
+	t.Parallel()
+
+	got, err := (&Service{}).modifyPayloadUsesHugepages(context.Background(), &domain.VMModifyPayload{
+		HugepagesPageSize: "2Mi",
+	}, &domain.VM{})
+	if err != nil {
+		t.Fatalf("modifyPayloadUsesHugepages() error = %v", err)
+	}
+	if !got {
+		t.Fatal("modifyPayloadUsesHugepages() = false, want true")
 	}
 }
 
@@ -525,6 +632,96 @@ func TestServiceApproveModify_DryRunsExactMutationAndStoresApprovedSnapshot(t *t
 	}
 	if !bytes.Equal(restored.Payload, stub.lastMutation.Payload) {
 		t.Fatalf("stored mutation payload = %q, want %q", restored.Payload, stub.lastMutation.Payload)
+	}
+}
+
+func TestServiceApproveModify_HugepagesAlignsMemoryRequestInApprovedMutation(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.OpenEntPostgres(t, "gateway_modify_hugepages_align")
+	ctx := context.Background()
+
+	eventID := "event-modify-hugepages-align"
+	ticketID := "ticket-modify-hugepages-align"
+	payload, err := domain.VMModifyPayload{
+		VMID:                   "vm-1",
+		VMName:                 "vm-1",
+		ClusterID:              "cluster-1",
+		Namespace:              "team-a",
+		Actor:                  "user-1",
+		CurrentCPUCores:        4,
+		CurrentMemoryGi:        8,
+		CurrentCPURequest:      2,
+		CurrentMemoryRequestGi: 4,
+		HugepagesPageSize:      "2Mi",
+		TargetMemoryGi:         ptrFloat64(16),
+	}.ToJSON()
+	if err != nil {
+		t.Fatalf("marshal modify payload: %v", err)
+	}
+	if _, err = client.DomainEvent.Create().
+		SetID(eventID).
+		SetEventType(string(domain.EventVMModifyRequested)).
+		SetAggregateType("vm").
+		SetAggregateID("vm-1").
+		SetPayload(payload).
+		SetCreatedBy("user-1").
+		Save(ctx); err != nil {
+		t.Fatalf("create domain event: %v", err)
+	}
+	if _, err = client.Ticket.Create().
+		SetID(ticketID).
+		SetEventID(eventID).
+		SetRequester("user-1").
+		SetStatus(entticket.StatusPENDING).
+		SetOperationType(entticket.OperationTypeMODIFY).
+		Save(ctx); err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+
+	writer := &fakeAtomicWriter{}
+	stub := newMutationDryRunProviderStub(nil)
+	stub.Seed([]*domain.VM{{
+		ID:        "vm-1",
+		Name:      "vm-1",
+		Namespace: "team-a",
+		Cluster:   "cluster-1",
+		Status:    domain.VMStatusRunning,
+		Spec: domain.VMSpec{
+			CPU:                      4,
+			CPURequest:               2,
+			MemoryGi:                 8,
+			MemoryRequestGi:          4,
+			HugepagesPageSize:        "2Mi",
+			CurrentCPUSockets:        1,
+			CurrentCPUCoresPerSocket: 4,
+			CurrentCPUThreads:        1,
+		},
+	}})
+
+	gw := NewService(client, nil, writer)
+	gw.SetVMService(service.NewVMService(stub))
+
+	if approveErr := gw.Approve(ctx, ticketID, "admin-1", ExecutionOptions{}); approveErr != nil {
+		t.Fatalf("Approve() error = %v", approveErr)
+	}
+	if !writer.modifyCalled {
+		t.Fatal("atomic modify writer was not called")
+	}
+	if got, ok := writer.modifiedSpec["memory_request_gi"].(float64); !ok || got != 16 {
+		t.Fatalf("writer.modifiedSpec[memory_request_gi] = %v, want 16", writer.modifiedSpec["memory_request_gi"])
+	}
+	if stub.lastMutation == nil {
+		t.Fatal("DryRunVMMutation mutation = nil, want exact mutation")
+	}
+	for _, want := range []string{
+		`"guest":"16Gi"`,
+		`"limits":{"memory":"16Gi"}`,
+		`"requests":{"memory":"16Gi"}`,
+	} {
+		if !strings.Contains(string(stub.lastMutation.Payload), want) {
+			t.Fatalf("DryRunVMMutation payload missing %s:\n%s", want, string(stub.lastMutation.Payload))
+		}
 	}
 }
 
@@ -2546,6 +2743,32 @@ func TestBuildDryRunSpec_AppliesOverrideValues(t *testing.T) {
 		}
 		if spec.DiskGB != 200 {
 			t.Errorf("spec.DiskGB = %d, want 200 (override)", spec.DiskGB)
+		}
+	})
+
+	t.Run("hugepages_memory_limit_override_aligns_request", func(t *testing.T) {
+		t.Parallel()
+		hugepagesSize := &ent.InstanceSize{
+			ID:                "size-hugepages",
+			CPUCores:          2.0,
+			MemoryGi:          4.0,
+			MemoryRequestGi:   4.0,
+			DiskGB:            50,
+			RequiresHugepages: true,
+			HugepagesSize:     "2Mi",
+		}
+		spec, err := gw.buildDryRunSpec(payload, tmpl, hugepagesSize, ExecutionOptions{
+			EnableOverride: true,
+			MemoryLimitGi:  16.0,
+		})
+		if err != nil {
+			t.Fatalf("buildDryRunSpec() hugepages override error = %v", err)
+		}
+		if spec.MemoryGi != 16.0 {
+			t.Errorf("spec.MemoryGi = %f, want 16.0", spec.MemoryGi)
+		}
+		if spec.MemoryRequestGi != 16.0 {
+			t.Errorf("spec.MemoryRequestGi = %f, want 16.0", spec.MemoryRequestGi)
 		}
 	})
 

--- a/internal/provider/mapper.go
+++ b/internal/provider/mapper.go
@@ -298,6 +298,9 @@ func mapVMSpec(vm *kubevirtv1.VirtualMachine) domain.VMSpec {
 	} else if limit, ok := domainRes.Limits[corev1.ResourceMemory]; ok {
 		spec.MemoryGi = float64(limit.Value()) / (1024 * 1024 * 1024)
 	}
+	if domainSpec.Memory != nil && domainSpec.Memory.Hugepages != nil {
+		spec.HugepagesPageSize = strings.TrimSpace(domainSpec.Memory.Hugepages.PageSize)
+	}
 
 	mapVMLiveDiskSpec(vm, &spec)
 

--- a/internal/provider/mapper_test.go
+++ b/internal/provider/mapper_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 )
@@ -115,5 +116,40 @@ func TestKubeVirtMapper_MapVM_MapsConsoleCapabilityDefaultsAndOverrides(t *testi
 	}
 	if !defaultGot.Spec.AutoattachSerialConsole {
 		t.Fatal("default AutoattachSerialConsole = false, want true")
+	}
+}
+
+func TestKubeVirtMapper_MapVM_MapsHugepagesPageSize(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewKubeVirtMapper()
+	guest := resource.MustParse("8Gi")
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "vm-hugepages",
+			Namespace: "team-a",
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Memory: &kubevirtv1.Memory{
+							Guest: &guest,
+							Hugepages: &kubevirtv1.Hugepages{
+								PageSize: "2Mi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := mapper.MapVM(vm, nil)
+	if err != nil {
+		t.Fatalf("MapVM() error = %v", err)
+	}
+	if got.Spec.HugepagesPageSize != "2Mi" {
+		t.Fatalf("HugepagesPageSize = %q, want 2Mi", got.Spec.HugepagesPageSize)
 	}
 }

--- a/internal/provider/vm_live_update_patch.go
+++ b/internal/provider/vm_live_update_patch.go
@@ -8,11 +8,12 @@ import (
 	"kv-shepherd.io/shepherd/internal/domain"
 )
 
-// VMLiveUpdateTargets carries the requested online resource expansions.
+// VMLiveUpdateTargets carries requested VM resource changes.
 //
 // Scope:
-//   - CPU: integer total vCPU expansion only, mapped to KubeVirt socket hotplug
-//   - Memory: 0.5 Gi steps via memory.guest + requests/limits
+//   - CPU: integer total vCPU values; running VM plans stage topology changes
+//     for restart instead of applying socket hotplug.
+//   - Memory: 0.5 Gi steps via memory.guest + requests/limits.
 //   - Disk: integer Gi expansion of the root DataVolume request
 type VMLiveUpdateTargets struct {
 	CPUCores        *float64
@@ -31,8 +32,10 @@ type VMResourceUpdatePlan struct {
 // RenderVMResourceUpdatePatch renders a VM resource patch using the safest
 // supported path for the current VM state.
 //
-// Running VMs use the strict live-update path. Stopped VMs can accept broader
-// CPU/memory reconfiguration while disk remains expansion-only.
+// Running VMs use the strict live-update path for memory/disk changes. CPU
+// topology changes are staged through PlanVMResourceUpdatePatch when restart is
+// required. Stopped VMs can accept broader CPU/memory reconfiguration while disk
+// remains expansion-only.
 func RenderVMResourceUpdatePatch(namespace string, current *domain.VM, target VMLiveUpdateTargets) (*domain.VMMutation, error) {
 	if current == nil {
 		return nil, fmt.Errorf("render vm resource update patch: current vm is nil")
@@ -56,6 +59,18 @@ func PlanVMResourceUpdatePatch(namespace string, current *domain.VM, target VMLi
 			Mutation:        rendered,
 			RequiresRestart: false,
 			ApplyMode:       "offline",
+		}, nil
+	}
+
+	if target.CPUCores != nil {
+		rendered, err := renderVMOfflineResourcePatch(namespace, current, target)
+		if err != nil {
+			return nil, err
+		}
+		return &VMResourceUpdatePlan{
+			Mutation:        rendered,
+			RequiresRestart: true,
+			ApplyMode:       "restart_required",
 		}, nil
 	}
 
@@ -365,19 +380,11 @@ func resolveOfflineCPUAllocation(current *domain.VM, targetTotal float64) (socke
 	if currentThreads <= 0 {
 		currentThreads = 1
 	}
-	currentCoresPerSocket := current.Spec.CurrentCPUCoresPerSocket
-	if currentCoresPerSocket <= 0 {
-		currentCoresPerSocket = 1
-	}
 
-	switch {
-	case target%(currentCoresPerSocket*currentThreads) == 0:
-		return target / (currentCoresPerSocket * currentThreads), currentCoresPerSocket, currentThreads, target, nil
-	case target%currentThreads == 0:
+	if target%currentThreads == 0 {
 		return 1, target / currentThreads, currentThreads, target, nil
-	default:
-		return target, 1, 1, target, nil
 	}
+	return target, 1, 1, target, nil
 }
 
 func newMergePatchMutation(specPatch map[string]interface{}) (*domain.VMMutation, error) {

--- a/internal/provider/vm_live_update_patch_test.go
+++ b/internal/provider/vm_live_update_patch_test.go
@@ -181,3 +181,47 @@ func TestPlanVMResourceUpdatePatch_RunningShrinkFallsBackToRestartRequired(t *te
 		t.Fatalf("plan.Mutation.Payload unexpectedly includes requests block:\n%s", string(plan.Mutation.Payload))
 	}
 }
+
+func TestPlanVMResourceUpdatePatch_RunningCPUResizePatchesCoresAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	targetCPU := 8.0
+
+	plan, err := PlanVMResourceUpdatePatch("prod-ns", &domain.VM{
+		Name:      "vm-a",
+		Namespace: "prod-ns",
+		Status:    domain.VMStatusRunning,
+		Spec: domain.VMSpec{
+			CPU:                      4,
+			MemoryGi:                 8,
+			CurrentCPUSockets:        1,
+			CurrentCPUCoresPerSocket: 4,
+			CurrentCPUThreads:        1,
+		},
+	}, VMLiveUpdateTargets{
+		CPUCores: &targetCPU,
+	})
+	if err != nil {
+		t.Fatalf("PlanVMResourceUpdatePatch returned error: %v", err)
+	}
+	if !plan.RequiresRestart {
+		t.Fatal("plan.RequiresRestart = false, want true")
+	}
+	if plan.ApplyMode != "restart_required" {
+		t.Fatalf("plan.ApplyMode = %q, want restart_required", plan.ApplyMode)
+	}
+	patchPayload := string(plan.Mutation.Payload)
+	for _, want := range []string{
+		"\"sockets\":1",
+		"\"cores\":8",
+		"\"threads\":1",
+		"\"cpu\":\"8\"",
+	} {
+		if !strings.Contains(patchPayload, want) {
+			t.Fatalf("plan.Mutation.Payload missing %q:\n%s", want, patchPayload)
+		}
+	}
+	if strings.Contains(patchPayload, "\"sockets\":2") {
+		t.Fatalf("plan.Mutation.Payload used socket hotplug topology unexpectedly:\n%s", patchPayload)
+	}
+}

--- a/internal/service/approval_validator.go
+++ b/internal/service/approval_validator.go
@@ -210,6 +210,9 @@ func (v *ApprovalValidator) ValidateApproval(
 				memoryRequestGi = input.Override.MemoryRequestGi
 			}
 		}
+		if instanceSizeUsesHugepages(size) && memoryGi > 0 {
+			memoryRequestGi = memoryGi
+		}
 		if err := ValidateOvercommit(cpuCores, cpuRequest, memoryGi, memoryRequestGi, effectiveDedicatedCPU); err != nil {
 			return err
 		}
@@ -478,6 +481,9 @@ func (v *ApprovalValidator) resolveValidationContext(
 			if input.Override.MemoryRequestGi > 0 {
 				resolved.memoryRequestGi = input.Override.MemoryRequestGi
 			}
+		}
+		if instanceSizeUsesHugepages(size) && resolved.memoryGi > 0 {
+			resolved.memoryRequestGi = resolved.memoryGi
 		}
 		if err := ValidateOvercommit(
 			resolved.cpuCores,
@@ -761,6 +767,17 @@ func ExtractRequiredCapabilities(size *ent.InstanceSize) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func instanceSizeUsesHugepages(size *ent.InstanceSize) bool {
+	if size == nil {
+		return false
+	}
+	hugepagesSize := normalizeHugepagesSize(size.HugepagesSize)
+	if hugepagesSize == "" {
+		hugepagesSize = normalizeHugepagesSize(extractHugepagesSize(size.SpecOverrides))
+	}
+	return size.RequiresHugepages || hugepagesSize != ""
 }
 
 // MissingCapabilities returns capabilities required by InstanceSize but unavailable on cluster.

--- a/internal/service/approval_validator_test.go
+++ b/internal/service/approval_validator_test.go
@@ -70,6 +70,45 @@ func TestExtractRequiredCapabilities_FromSpecOverrides(t *testing.T) {
 	require.ElementsMatch(t, []string{"gpu", "sriov", "hugepages", "hugepages:1gi"}, caps)
 }
 
+func TestInstanceSizeUsesHugepages(t *testing.T) {
+	testCases := []struct {
+		name string
+		size *ent.InstanceSize
+		want bool
+	}{
+		{
+			name: "flag",
+			size: &ent.InstanceSize{RequiresHugepages: true},
+			want: true,
+		},
+		{
+			name: "page size",
+			size: &ent.InstanceSize{HugepagesSize: "2Mi"},
+			want: true,
+		},
+		{
+			name: "spec override",
+			size: &ent.InstanceSize{
+				SpecOverrides: map[string]interface{}{
+					"spec.template.spec.domain.memory.hugepages.pageSize": "1Gi",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "absent",
+			size: &ent.InstanceSize{},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, instanceSizeUsesHugepages(tc.size))
+		})
+	}
+}
+
 func TestMissingCapabilities(t *testing.T) {
 	clusterCaps := buildClusterCapabilitySet([]string{
 		"nvidia.com/GA102GL_A10",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -567,7 +567,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -910,7 +909,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -959,7 +957,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -990,7 +987,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2724,7 +2720,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -3172,6 +3167,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -3679,6 +3697,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3768,7 +3787,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3856,7 +3876,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3866,7 +3885,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3877,7 +3895,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3933,7 +3950,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4454,7 +4470,6 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -4614,7 +4629,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4702,6 +4716,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4727,7 +4742,6 @@
       "resolved": "https://registry.npmjs.org/antd/-/antd-5.29.3.tgz",
       "integrity": "sha512-3DdbGCa9tWAJGcCJ6rzR8EJFsv2CtyEbkVabZE14pfgUHfCicWCj0/QzQVLDYg8CPfQk9BH7fHCoTXHTy7MP/A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^7.2.1",
         "@ant-design/cssinjs": "^1.23.0",
@@ -5127,7 +5141,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5663,7 +5676,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5934,7 +5948,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6120,7 +6133,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7059,7 +7071,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -7766,7 +7777,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8349,6 +8359,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9385,7 +9396,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -10044,6 +10054,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10059,6 +10070,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10071,7 +10083,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10228,7 +10241,6 @@
       "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.1.tgz",
       "integrity": "sha512-vKeSifSJ6HoLaAB+B8aq/Qgm8a3dyxROzCtKNCsBQgiverpc4kWDQihoUwzUj+zNWJOykwSY4dNX3QrGwtVb9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "@rc-component/async-validator": "^5.0.3",
@@ -10743,7 +10755,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10753,7 +10764,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11854,7 +11864,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12099,7 +12108,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12384,7 +12392,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12476,7 +12483,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -12857,7 +12863,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,19 +42,19 @@
         "@types/node": "^20.19.37",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19",
-        "@vitest/coverage-v8": "^4.1.1",
+        "@vitest/coverage-v8": "^4.1.9",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.3",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "jsdom": "^28.1.0",
         "knip": "^6.0.5",
         "openapi-typescript": "^7.13.0",
         "postcss": "^8.5.10",
         "tailwindcss": "^4.2.2",
         "typescript": "^5",
-        "vitest": "^4.1.1"
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1042,21 +1042,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1064,9 +1064,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1790,99 +1790,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1931,25 +1838,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mswjs/interceptors": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2162,34 +2050,6 @@
       "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.6.0.tgz",
       "integrity": "sha512-CJrmdSe9Yt2ZbLsJpVFoVkEu0KICEvnr3njW25Nz0jodaiFJtg8AYLGZogRYy0/N5HUWkGUsCmegKXYBSqwygw==",
       "license": "MPL-2.0"
-    },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.120.0",
@@ -3092,9 +2952,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -3109,9 +2969,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -3126,9 +2986,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -3143,9 +3003,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -3160,9 +3020,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -3177,9 +3037,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -3194,9 +3054,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -3211,9 +3071,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -3228,9 +3088,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -3245,9 +3105,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -3262,9 +3122,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -3279,9 +3139,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -3296,9 +3156,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -3306,33 +3166,48 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -3347,9 +3222,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -3364,9 +3239,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3878,9 +3753,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4006,14 +3881,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4582,14 +4449,15 @@
       ]
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.1.tgz",
-      "integrity": "sha512-nZ4RWwGCoGOQRMmU/Q9wlUY540RVRxJZ9lxFsFfy0QV7Zmo5VVBhB6Sl9Xa0KIp2iIs3zWfPlo9LcY1iqbpzCw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.1",
+        "@vitest/utils": "4.1.9",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -4597,14 +4465,14 @@
         "magicast": "^0.5.2",
         "obug": "^2.1.1",
         "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.1",
-        "vitest": "4.1.1"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4613,31 +4481,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
-      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.1",
-        "@vitest/utils": "4.1.1",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
-      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.1",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4658,26 +4526,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
-      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
-      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.1",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4685,14 +4553,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
-      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.1",
-        "@vitest/utils": "4.1.1",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4701,9 +4569,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
-      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4711,15 +4579,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
-      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.1",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5444,57 +5312,11 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5552,21 +5374,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -6032,9 +5839,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6867,17 +6674,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7010,17 +6806,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -7170,14 +6955,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -7603,17 +7380,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -7682,14 +7448,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7980,10 +7738,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9571,71 +9339,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/msw": {
-      "version": "2.12.14",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.14.tgz",
-      "integrity": "sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.41.2",
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@types/statuses": "^2.0.6",
-        "cookie": "^1.0.2",
-        "graphql": "^16.12.0",
-        "headers-polyfill": "^4.0.2",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "path-to-regexp": "^6.3.0",
-        "picocolors": "^1.1.1",
-        "rettime": "^0.10.1",
-        "statuses": "^2.0.2",
-        "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.0",
-        "type-fest": "^5.2.0",
-        "until-async": "^3.0.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/msw/node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -9885,15 +9588,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/openapi-fetch": {
       "version": "0.16.0",
@@ -9961,14 +9667,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -11276,17 +10974,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -11344,14 +11031,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/rettime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
-      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -11364,14 +11043,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -11380,27 +11059,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -11752,20 +11431,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -11812,21 +11477,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11844,43 +11498,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
       "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -12007,20 +11629,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -12152,20 +11760,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -12210,9 +11804,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12220,14 +11814,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12419,23 +12013,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -12723,17 +12300,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
-    "node_modules/until-async": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/kettanaito"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -12813,18 +12379,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -12840,7 +12406,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -12905,20 +12471,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
-      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vitest/expect": "4.1.1",
-        "@vitest/mocker": "4.1.1",
-        "@vitest/pretty-format": "4.1.1",
-        "@vitest/runner": "4.1.1",
-        "@vitest/snapshot": "4.1.1",
-        "@vitest/spy": "4.1.1",
-        "@vitest/utils": "4.1.1",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -12929,7 +12495,7 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
+        "tinyrainbow": "^3.1.0",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
@@ -12946,10 +12512,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.1",
-        "@vitest/browser-preview": "4.1.1",
-        "@vitest/browser-webdriverio": "4.1.1",
-        "@vitest/ui": "4.1.1",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -12971,6 +12539,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -13208,22 +12782,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -13240,17 +12798,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -13282,26 +12829,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -13320,20 +12847,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/web/package.json
+++ b/web/package.json
@@ -57,22 +57,22 @@
     "@types/node": "^20.19.37",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19",
-    "@vitest/coverage-v8": "^4.1.1",
+    "@vitest/coverage-v8": "^4.1.9",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.3",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "jsdom": "^28.1.0",
     "knip": "^6.0.5",
     "openapi-typescript": "^7.13.0",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "typescript": "^5",
-    "vitest": "^4.1.1"
+    "vitest": "^4.1.9"
   },
   "overrides": {
-    "vite": "8.0.5",
+    "vite": "8.0.16",
     "flatted": "^3.4.2",
     "@ant-design/pro-layout": {
       "path-to-regexp": "8.4.0"

--- a/web/src/features/admin-approvals/components/AdminApprovalsContent.test.tsx
+++ b/web/src/features/admin-approvals/components/AdminApprovalsContent.test.tsx
@@ -689,6 +689,31 @@ describe("AdminApprovalsContent", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("warns before approving production modify requests with overcommit", () => {
+    controllerState.overrides = {
+      approveModal: {
+        id: "ticket-modify-prod",
+        event_id: "event-modify-prod",
+        status: "PENDING",
+        operation_type: "MODIFY",
+        requester: "alice",
+        ticket_payload: {
+          current_cpu_request: 2,
+          current_memory_request_gi: 4,
+          target_cpu_cores: 4,
+          target_memory_gi: 8,
+          cluster_environment: "prod",
+        },
+      },
+    };
+
+    render(<AdminApprovalsContent />);
+
+    expect(
+      screen.getByText("Production request review recommended"),
+    ).toBeInTheDocument();
+  });
+
   it("shows cluster compatibility query errors instead of silently rendering an empty list", () => {
     controllerState.overrides = {
       clusterQueryError: {

--- a/web/src/features/admin-approvals/components/AdminApprovalsContent.tsx
+++ b/web/src/features/admin-approvals/components/AdminApprovalsContent.tsx
@@ -646,6 +646,19 @@ export function AdminApprovalsContent() {
   const modifyTargetMemoryLimitGi =
     approvals.approveModal?.summary?.target_memory_gi ??
     payloadNumber(approveModalPayload?.target_memory_gi);
+  const modifyHugepagesPageSize =
+    typeof approveModalPayload?.hugepages_page_size === "string"
+      ? approveModalPayload.hugepages_page_size.trim()
+      : "";
+  const modifyUsesHugepages =
+    modifyHugepagesPageSize !== "" ||
+    payloadBool(approveModalPayload?.requires_hugepages) === true;
+  const modifyClusterEnvironment =
+    typeof approvals.approveModal?.summary?.cluster_environment === "string"
+      ? approvals.approveModal.summary.cluster_environment
+      : typeof approveModalPayload?.cluster_environment === "string"
+        ? approveModalPayload.cluster_environment
+        : "";
   const modifyCPURequestNeedsReview =
     typeof modifyCurrentCPURequest === "number" &&
     typeof modifyTargetCPULimit === "number" &&
@@ -654,6 +667,15 @@ export function AdminApprovalsContent() {
     typeof modifyCurrentMemoryRequestGi === "number" &&
     typeof modifyTargetMemoryLimitGi === "number" &&
     modifyCurrentMemoryRequestGi > modifyTargetMemoryLimitGi;
+  const modifyProductionRequestWarning =
+    !modifyUsesHugepages &&
+    modifyClusterEnvironment.trim().toLowerCase() === "prod" &&
+    ((typeof modifyCurrentCPURequest === "number" &&
+      typeof modifyTargetCPULimit === "number" &&
+      modifyCurrentCPURequest !== modifyTargetCPULimit) ||
+      (typeof modifyCurrentMemoryRequestGi === "number" &&
+        typeof modifyTargetMemoryLimitGi === "number" &&
+        modifyCurrentMemoryRequestGi !== modifyTargetMemoryLimitGi));
 
   // Removed legacy columns definition to use custom List rendering
 
@@ -1592,7 +1614,8 @@ export function AdminApprovalsContent() {
                 <Alert
                   type={
                     modifyCPURequestNeedsReview ||
-                    modifyMemoryRequestNeedsReview
+                    modifyMemoryRequestNeedsReview ||
+                    modifyUsesHugepages
                       ? "warning"
                       : "info"
                   }
@@ -1616,6 +1639,21 @@ export function AdminApprovalsContent() {
                     },
                   )}
                 />
+                {modifyProductionRequestWarning && (
+                  <Alert
+                    type="warning"
+                    showIcon
+                    style={{ marginBottom: 16 }}
+                    message={t(
+                      "approve_modal.modify_prod_request_warning_title",
+                      "Production request review recommended",
+                    )}
+                    description={t(
+                      "approve_modal.modify_prod_request_warning_description",
+                      "This production VM can run with request values below limits, but keeping requests aligned with approved limits is recommended unless overcommit is intentional.",
+                    )}
+                  />
+                )}
                 <Form.Item
                   name="enable_override"
                   valuePropName="checked"

--- a/web/src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx
+++ b/web/src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx
@@ -1468,8 +1468,33 @@ describe("useAdminApprovalsController", () => {
 
     expect(approveFormState.setFieldsValue).toHaveBeenCalledWith({
       enable_override: true,
-      cpu_request: 8,
-      memory_request_gi: 8,
+      cpu_request: 4,
+      memory_request_gi: 4,
+    });
+  });
+
+  it("prefills modify memory request to target limit when hugepages are enabled", () => {
+    const { result } = renderHook(() => useAdminApprovalsController({ t }));
+
+    act(() => {
+      result.current.openApproveModal({
+        id: "ticket-modify-hugepages",
+        operation_type: "MODIFY",
+        status: "PENDING",
+        requester: "alice",
+        ticket_payload: {
+          current_memory_gi: 8,
+          current_memory_request_gi: 4,
+          target_memory_gi: 16,
+          hugepages_page_size: "2Mi",
+        },
+      } as never);
+    });
+
+    expect(approveFormState.setFieldsValue).toHaveBeenCalledWith({
+      enable_override: true,
+      cpu_request: undefined,
+      memory_request_gi: 16,
     });
   });
 

--- a/web/src/features/admin-approvals/hooks/useAdminApprovalsController.ts
+++ b/web/src/features/admin-approvals/hooks/useAdminApprovalsController.ts
@@ -788,17 +788,35 @@ export function useAdminApprovalsController({
       );
       const targetCPULimit = payloadNumber(payload?.target_cpu_cores);
       const targetMemoryLimitGi = payloadNumber(payload?.target_memory_gi);
+      const effectiveMemoryLimitGi =
+        targetMemoryLimitGi ?? payloadNumber(payload?.current_memory_gi);
+      const usesHugepages =
+        normalizeOptionalString(payload?.hugepages_page_size) !== "" ||
+        payload?.requires_hugepages === true;
       const requestReviewRequired =
         (typeof currentCPURequest === "number" &&
           typeof targetCPULimit === "number" &&
           currentCPURequest > targetCPULimit) ||
         (typeof currentMemoryRequestGi === "number" &&
           typeof targetMemoryLimitGi === "number" &&
-          currentMemoryRequestGi > targetMemoryLimitGi);
+          currentMemoryRequestGi > targetMemoryLimitGi) ||
+        usesHugepages;
       approveForm.setFieldsValue({
         enable_override: requestReviewRequired,
-        cpu_request: currentCPURequest,
-        memory_request_gi: currentMemoryRequestGi,
+        cpu_request:
+          typeof currentCPURequest === "number" &&
+          typeof targetCPULimit === "number" &&
+          currentCPURequest > targetCPULimit
+            ? targetCPULimit
+            : currentCPURequest,
+        memory_request_gi:
+          usesHugepages && typeof effectiveMemoryLimitGi === "number"
+            ? effectiveMemoryLimitGi
+            : typeof currentMemoryRequestGi === "number" &&
+                typeof targetMemoryLimitGi === "number" &&
+                currentMemoryRequestGi > targetMemoryLimitGi
+              ? targetMemoryLimitGi
+              : currentMemoryRequestGi,
       });
     }
   };


### PR DESCRIPTION
## Summary

- Preserve hugepages context on live VM specs and modify approval payloads.
- Align hugepages-backed memory requests to the effective memory limit across create dry-run, placement validation, modify approval dry-run, and stored approval snapshots.
- Stage running CPU topology changes as restart-required patches instead of treating them as live socket hotplug execution.
- Prefill and warn in admin approval review when request values need alignment or production review.
- Refresh frontend test dependencies and the Vite override to clear the high-severity audit gate.
- Sync the frontend lockfile with npm 10.9.8 so GitHub Actions can run `npm ci` on the same dependency graph.

## Validation

- Context7: checked official Kubernetes guidance that hugepages cannot be overcommitted and requests must equal limits.
- Context7: checked official KubeVirt guidance that running CPU hotplug is socket-based, while this PR intentionally stages CPU topology changes as restart-required.
- `go test ./internal/api/handlers ./internal/domain ./internal/governance/ticketing ./internal/provider ./internal/service`
- `npm --prefix web run test:run -- src/features/admin-approvals/hooks/useAdminApprovalsController.test.tsx src/features/admin-approvals/components/AdminApprovalsContent.test.tsx`
- `npm --prefix web run typecheck`
- `npm --prefix web audit --audit-level=high`
- `npx npm@10.9.8 ci --prefix web`
- `make secrets-scan`
- `make ci-go-lint`
- `make ci-governance`
- `make pr`

## Issue

Closes #712

## Release impact

bugfix/patch