### PR TITLE
chore(ops): add postgres river validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # KubeVirt Shepherd Makefile
 # ADR-0016: Module path kv-shepherd.io/shepherd
 
-.PHONY: all build test lint lint-arch lint-version-check build-shepherd-lint shepherd-lint test-shepherd-linter clean run seed docker help generate api-gen api-generate ent-gen sqlc-gen master-flow-strict master-flow-completion project-completion-readiness test-backend-docker-pg master-flow-strict-docker-pg live-e2e-readiness ci-live-e2e-evidence ci-live-e2e-latest-evidence pr pr-ci pr-sequential ci-checks ci-prep ci-governance ci-ent-generated-sync ci-backend ci-frontend ci-api-sync ci-api-sync-local ci-e2e-smoke ci-go-lint ci-go-build ci-go-test ci-master-flow-backend ci-frontend-deadcode ci-frontend-unit ci-frontend-unit-local ci-api-lint ci-api-breaking ci-api-generated-sync ci-api-generated-sync-local ci-api-generated-sync-check ci-api-contract ci-prometheus-config ci-prometheus-alert-runbooks ci-prometheus-operator-rule-parity ci-prometheus-rules ci-grafana-dashboard-promql ci-monitoring-assets govulncheck frontend-deadcode-scan frontend-security-audit secrets-scan public-hygiene-scan supplemental-scans kubevirt-schema-check kubevirt-schema-upgrade kubevirt-schema-report authproviderplugin-sdk-smoke ci-parity dco-check api-changelog-comment
+.PHONY: all build test lint lint-arch lint-version-check build-shepherd-lint shepherd-lint test-shepherd-linter clean run seed docker help generate api-gen api-generate ent-gen sqlc-gen master-flow-strict master-flow-completion project-completion-readiness test-backend-docker-pg master-flow-strict-docker-pg live-e2e-readiness ci-live-e2e-evidence ci-live-e2e-latest-evidence postgres-ops-check postgres-ops-apply pr pr-ci pr-sequential ci-checks ci-prep ci-governance ci-ent-generated-sync ci-backend ci-frontend ci-api-sync ci-api-sync-local ci-e2e-smoke ci-go-lint ci-go-build ci-go-test ci-master-flow-backend ci-frontend-deadcode ci-frontend-unit ci-frontend-unit-local ci-api-lint ci-api-breaking ci-api-generated-sync ci-api-generated-sync-local ci-api-generated-sync-check ci-api-contract ci-prometheus-config ci-prometheus-alert-runbooks ci-prometheus-operator-rule-parity ci-prometheus-rules ci-grafana-dashboard-promql ci-monitoring-assets govulncheck frontend-deadcode-scan frontend-security-audit secrets-scan public-hygiene-scan supplemental-scans kubevirt-schema-check kubevirt-schema-upgrade kubevirt-schema-report authproviderplugin-sdk-smoke ci-parity dco-check api-changelog-comment
 
 # Go parameters
 GO_TOOLCHAIN_VERSION?=go1.25.11
@@ -292,6 +292,14 @@ ci-live-e2e-latest-evidence:
 	@set -e; \
 	manifest="$$(node docs/design/ci/scripts/find_latest_live_e2e_full_evidence.mjs .run/live-e2e)"; \
 	bash docs/design/ci/scripts/check_live_e2e_evidence_manifest.sh --require-full-pass --require-existing-artifacts "$${manifest}"
+
+## postgres-ops-check: Validate production PostgreSQL/River autovacuum settings. Requires DATABASE_URL or POSTGRES_OPS_DATABASE_URL.
+postgres-ops-check:
+	@DATABASE_URL="$${POSTGRES_OPS_DATABASE_URL:-$${DATABASE_URL:-}}" bash scripts/check_postgres_ops.sh
+
+## postgres-ops-apply: Apply and validate production PostgreSQL/River autovacuum settings. Requires DATABASE_URL or POSTGRES_OPS_DATABASE_URL.
+postgres-ops-apply:
+	@DATABASE_URL="$${POSTGRES_OPS_DATABASE_URL:-$${DATABASE_URL:-}}" bash scripts/check_postgres_ops.sh --apply-autovacuum
 
 ## ci-go-lint: Run the Go lint target set used by the required CI Lint job
 ci-go-lint: lint-version-check

--- a/docs/operations/database-operations.md
+++ b/docs/operations/database-operations.md
@@ -38,6 +38,24 @@ ALTER TABLE domain_events SET (
 );
 ```
 
+The repository also provides a guarded operational helper. By default it is
+read-only and fails when required table reloptions are missing or mismatched:
+
+```bash
+DATABASE_URL='postgres://shepherd:<password>@<host>:5432/shepherd_db?sslmode=require' \
+  make postgres-ops-check
+```
+
+To apply the required reloptions and then verify them:
+
+```bash
+DATABASE_URL='postgres://shepherd:<password>@<host>:5432/shepherd_db?sslmode=require' \
+  make postgres-ops-apply
+```
+
+Use `POSTGRES_OPS_DATABASE_URL` instead of `DATABASE_URL` when the application
+runtime environment should not be reused by the operator shell.
+
 ### Verification Query
 
 Run this query periodically to check table health:

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -74,7 +74,12 @@ cluster kubeconfigs and console bootstrap material.
    [platform-admin-sop.md](./platform-admin-sop.md).
 
 6. Apply and verify PostgreSQL/River autovacuum tuning using
-   [database-operations.md](./database-operations.md).
+   [database-operations.md](./database-operations.md):
+
+   ```bash
+   DATABASE_URL='postgres://shepherd:<password>@<host>:5432/shepherd_db?sslmode=require' \
+     make postgres-ops-apply
+   ```
 
 ## Optional Monitoring Overlay
 
@@ -172,6 +177,7 @@ Before declaring a production deployment ready:
    ```bash
    bash docs/design/ci/scripts/check_prometheus_config.sh
    make ci-monitoring-assets
+   make postgres-ops-check
    bash docs/design/ci/scripts/check_design_doc_governance.sh
    bash scripts/run_e2e_live.sh --preflight-only
    bash docs/design/ci/scripts/check_live_e2e_no_mock.sh

--- a/scripts/check_postgres_ops.sh
+++ b/scripts/check_postgres_ops.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Validate and optionally apply PostgreSQL/River production table maintenance
+# settings from docs/operations/database-operations.md.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/check_postgres_ops.sh [--apply-autovacuum] [--database-url URL]
+
+Environment:
+  DATABASE_URL    PostgreSQL connection URI when --database-url is omitted.
+
+Options:
+  --apply-autovacuum  Apply the required table autovacuum reloptions before checking.
+  --database-url URL  PostgreSQL connection URI. The value is never echoed.
+  -h, --help          Show this help.
+
+The default mode is read-only. It checks that autovacuum is enabled and that
+river_job, audit_logs, and domain_events have the required table reloptions.
+EOF
+}
+
+apply_autovacuum=false
+database_url="${DATABASE_URL:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply-autovacuum)
+      apply_autovacuum=true
+      shift
+      ;;
+    --database-url)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --database-url requires a non-empty value" >&2
+        exit 2
+      fi
+      database_url="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${database_url}" ]]; then
+  echo "ERROR: DATABASE_URL or --database-url is required" >&2
+  exit 2
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql is required for PostgreSQL operations validation" >&2
+  exit 2
+fi
+
+psql_cmd=(psql -X -v ON_ERROR_STOP=1 -d "${database_url}")
+
+run_psql() {
+  "${psql_cmd[@]}" "$@"
+}
+
+run_psql_tsv() {
+  "${psql_cmd[@]}" -A -t -F $'\t' "$@"
+}
+
+if [[ "${apply_autovacuum}" == "true" ]]; then
+  echo "Applying required PostgreSQL/River autovacuum reloptions..."
+  run_psql -q <<'SQL'
+ALTER TABLE river_job SET (
+  autovacuum_vacuum_scale_factor = 0.01,
+  autovacuum_vacuum_threshold = 1000,
+  autovacuum_analyze_scale_factor = 0.01,
+  autovacuum_analyze_threshold = 500
+);
+
+ALTER TABLE audit_logs SET (
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_vacuum_threshold = 5000
+);
+
+ALTER TABLE domain_events SET (
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_vacuum_threshold = 2000
+);
+SQL
+fi
+
+autovacuum_setting="$(run_psql_tsv -c "SHOW autovacuum;")"
+if [[ "${autovacuum_setting}" != "on" ]]; then
+  echo "FAIL: PostgreSQL autovacuum is ${autovacuum_setting}; expected on" >&2
+  exit 1
+fi
+
+echo "OK: PostgreSQL autovacuum is enabled"
+
+failures=0
+reloptions_rows="$(mktemp)"
+cleanup() {
+  rm -f "${reloptions_rows}"
+}
+trap cleanup EXIT
+
+run_psql_tsv >"${reloptions_rows}" <<'SQL'
+WITH expected(table_name, option_name, expected_value) AS (
+  VALUES
+    ('river_job', 'autovacuum_vacuum_scale_factor', '0.01'),
+    ('river_job', 'autovacuum_vacuum_threshold', '1000'),
+    ('river_job', 'autovacuum_analyze_scale_factor', '0.01'),
+    ('river_job', 'autovacuum_analyze_threshold', '500'),
+    ('audit_logs', 'autovacuum_vacuum_scale_factor', '0.02'),
+    ('audit_logs', 'autovacuum_vacuum_threshold', '5000'),
+    ('domain_events', 'autovacuum_vacuum_scale_factor', '0.02'),
+    ('domain_events', 'autovacuum_vacuum_threshold', '2000')
+),
+actual AS (
+  SELECT
+    e.table_name,
+    e.option_name,
+    e.expected_value,
+    o.option_value AS actual_value,
+    CASE
+      WHEN c.oid IS NULL THEN 'missing_table'
+      WHEN o.option_value = e.expected_value THEN 'ok'
+      ELSE 'mismatch'
+    END AS status
+  FROM expected e
+  LEFT JOIN pg_class c ON c.oid = to_regclass(e.table_name)
+  LEFT JOIN LATERAL pg_options_to_table(c.reloptions) AS o(option_name, option_value)
+    ON o.option_name = e.option_name
+)
+SELECT table_name, option_name, expected_value, COALESCE(actual_value, '<unset>'), status
+FROM actual
+ORDER BY table_name, option_name;
+SQL
+
+while IFS=$'\t' read -r table_name option_name expected_value actual_value status; do
+  [[ -n "${table_name}" ]] || continue
+  case "${status}" in
+    ok)
+      printf 'OK: %s %s=%s\n' "${table_name}" "${option_name}" "${actual_value}"
+      ;;
+    missing_table)
+      printf 'FAIL: table %s is missing from the configured database/search_path\n' "${table_name}" >&2
+      failures=$((failures + 1))
+      ;;
+    *)
+      printf 'FAIL: %s %s expected %s, got %s\n' \
+        "${table_name}" "${option_name}" "${expected_value}" "${actual_value:-<unset>}" >&2
+      failures=$((failures + 1))
+      ;;
+  esac
+done <"${reloptions_rows}"
+
+echo
+echo "PostgreSQL/River table health:"
+run_psql <<'SQL'
+SELECT
+  relname AS table_name,
+  n_dead_tup,
+  n_live_tup,
+  round(100.0 * n_dead_tup / nullif(n_live_tup + n_dead_tup, 0), 2) AS dead_ratio_percent,
+  last_autovacuum,
+  last_autoanalyze
+FROM pg_stat_user_tables
+WHERE relname IN ('river_job', 'audit_logs', 'domain_events')
+ORDER BY dead_ratio_percent DESC NULLS LAST, relname;
+SQL
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "FAIL: PostgreSQL/River operations validation found ${failures} issue(s)" >&2
+  exit 1
+fi
+
+echo "OK: PostgreSQL/River operations validation passed"


### PR DESCRIPTION
## Summary

- Add `scripts/check_postgres_ops.sh` to validate production PostgreSQL/River autovacuum requirements.
- Expose `make postgres-ops-check` for read-only validation and `make postgres-ops-apply` for apply+validate.
- Update production deployment and database operations docs to use the executable workflow.

## Context7

- Checked official PostgreSQL docs for table storage parameters/reloptions, `pg_options_to_table`, `pg_stat_user_tables`, and script-friendly `psql -X --set ON_ERROR_STOP=on` usage before coding.

## Validation

- `bash -n scripts/check_postgres_ops.sh`
- `scripts/check_postgres_ops.sh --help`
- Docker PostgreSQL 18 end-to-end check:
  - check fails before reloptions are applied
  - `scripts/check_postgres_ops.sh --apply-autovacuum` applies and validates
  - follow-up `scripts/check_postgres_ops.sh` passes
- `make secrets-scan`
- `make ci-governance`
  - passed; emitted existing KubeVirt schema drift warning: embedded `v1.8.2`, upstream `v1.8.4`
- `make project-completion-readiness`
- `make live-e2e-readiness`
  - expected local failure: no real kubeconfig available (`E2E_KUBECONFIG_B64` or `k8s-admin.yaml`)
  - preflight evidence emitted under `.run/live-e2e/preflight/...`
- `make pr`
  - preflight, backend, governance, and frontend lanes passed locally
  - interrupted before e2e-smoke lane after frontend completed; e2e smoke was run separately
- `PW_USE_EXISTING_BUILD=1 make ci-e2e-smoke`
  - 40 passed

## Follow-up

- Opened #715 to track the environment-bound full real-cluster live E2E release evidence.

## Issue

Closes #714

## Release impact

none/operator tooling only
