### PR TITLE
ci(e2e): add live evidence workflow

### DIFF
--- a/.github/workflows/live-e2e-evidence.yml
+++ b/.github/workflows/live-e2e-evidence.yml
@@ -1,0 +1,117 @@
+# KubeVirt Shepherd live E2E evidence runner
+# ADR-0058: Manual release evidence outside required GitHub CI.
+# ADR-0029: Pin actions to commit SHA, use specific runner version.
+name: Live E2E Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run preflight readiness only or full live E2E evidence"
+        required: true
+        default: "full"
+        type: choice
+        options:
+          - full
+          - preflight
+      namespace:
+        description: "Disposable namespace used by the live E2E run"
+        required: true
+        default: "e2e-live"
+        type: string
+      cleanup_namespace_vms:
+        description: "Delete live E2E VMs from the namespace on exit"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  live-e2e:
+    name: Live E2E Evidence
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: shepherd
+          POSTGRES_PASSWORD: shepherd
+          POSTGRES_DB: shepherd_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://shepherd:shepherd@localhost:5432/shepherd_test?sslmode=disable
+      E2E_KUBECONFIG_B64: ${{ secrets.E2E_KUBECONFIG_B64 }}
+      E2E_NAMESPACE: ${{ inputs.namespace }}
+      E2E_CLEANUP_NAMESPACE_VMS: ${{ inputs.cleanup_namespace_vms && '1' || '0' }}
+      E2E_ADMIN_USERNAME: ${{ secrets.E2E_ADMIN_USERNAME }}
+      E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+      E2E_NEW_PASSWORD: ${{ secrets.E2E_NEW_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
+
+      - name: Install runner tools
+        run: sudo apt-get update && sudo apt-get install -y curl ripgrep
+
+      - name: Check live E2E inputs
+        run: test -n "${E2E_KUBECONFIG_B64:-}" || { echo "::error ::E2E_KUBECONFIG_B64 secret is required for live E2E evidence"; exit 1; }
+
+      - name: Check kubectl
+        run: command -v kubectl >/dev/null || { echo "::error ::kubectl is required on the live E2E runner"; exit 1; }
+
+      - name: Install Atlas CLI
+        run: make live-e2e-install-atlas
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix web
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: web
+
+      - name: Validate evidence fixture contract
+        run: make ci-live-e2e-evidence
+
+      - name: Run live E2E preflight
+        if: ${{ inputs.mode == 'preflight' }}
+        run: bash scripts/run_e2e_live.sh --preflight-only --no-db-wrapper
+
+      - name: Run full live E2E
+        if: ${{ inputs.mode == 'full' }}
+        run: bash scripts/run_e2e_live.sh --foreground --no-db-wrapper
+
+      - name: Validate latest full evidence
+        if: ${{ inputs.mode == 'full' && success() }}
+        run: make ci-live-e2e-latest-evidence
+
+      - name: Upload live E2E evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: live-e2e-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .run/live-e2e/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 14
+          compression-level: 6

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # KubeVirt Shepherd Makefile
 # ADR-0016: Module path kv-shepherd.io/shepherd
 
-.PHONY: all build test lint lint-arch lint-version-check build-shepherd-lint shepherd-lint test-shepherd-linter clean run seed docker help generate api-gen api-generate ent-gen sqlc-gen master-flow-strict master-flow-completion project-completion-readiness test-backend-docker-pg master-flow-strict-docker-pg live-e2e-readiness ci-live-e2e-evidence ci-live-e2e-latest-evidence postgres-ops-check postgres-ops-apply pr pr-ci pr-sequential ci-checks ci-prep ci-governance ci-ent-generated-sync ci-backend ci-frontend ci-api-sync ci-api-sync-local ci-e2e-smoke ci-go-lint ci-go-build ci-go-test ci-master-flow-backend ci-frontend-deadcode ci-frontend-unit ci-frontend-unit-local ci-api-lint ci-api-breaking ci-api-generated-sync ci-api-generated-sync-local ci-api-generated-sync-check ci-api-contract ci-prometheus-config ci-prometheus-alert-runbooks ci-prometheus-operator-rule-parity ci-prometheus-rules ci-grafana-dashboard-promql ci-monitoring-assets govulncheck frontend-deadcode-scan frontend-security-audit secrets-scan public-hygiene-scan supplemental-scans kubevirt-schema-check kubevirt-schema-upgrade kubevirt-schema-report authproviderplugin-sdk-smoke ci-parity dco-check api-changelog-comment
+.PHONY: all build test lint lint-arch lint-version-check build-shepherd-lint shepherd-lint test-shepherd-linter clean run seed docker help generate api-gen api-generate ent-gen sqlc-gen master-flow-strict master-flow-completion project-completion-readiness test-backend-docker-pg master-flow-strict-docker-pg live-e2e-readiness live-e2e-install-atlas ci-live-e2e-evidence ci-live-e2e-latest-evidence postgres-ops-check postgres-ops-apply pr pr-ci pr-sequential ci-checks ci-prep ci-governance ci-ent-generated-sync ci-backend ci-frontend ci-api-sync ci-api-sync-local ci-e2e-smoke ci-go-lint ci-go-build ci-go-test ci-master-flow-backend ci-frontend-deadcode ci-frontend-unit ci-frontend-unit-local ci-api-lint ci-api-breaking ci-api-generated-sync ci-api-generated-sync-local ci-api-generated-sync-check ci-api-contract ci-prometheus-config ci-prometheus-alert-runbooks ci-prometheus-operator-rule-parity ci-prometheus-rules ci-grafana-dashboard-promql ci-monitoring-assets govulncheck frontend-deadcode-scan frontend-security-audit secrets-scan public-hygiene-scan supplemental-scans kubevirt-schema-check kubevirt-schema-upgrade kubevirt-schema-report authproviderplugin-sdk-smoke ci-parity dco-check api-changelog-comment
 
 # Go parameters
 GO_TOOLCHAIN_VERSION?=go1.25.11
@@ -276,6 +276,20 @@ ci-e2e-smoke:
 ## live-e2e-readiness: Validate live E2E prerequisites without starting services. Set LIVE_E2E_PREFLIGHT_ARGS='--no-db-wrapper' when DATABASE_URL is already provided.
 live-e2e-readiness:
 	@bash scripts/run_e2e_live.sh --preflight-only $(LIVE_E2E_PREFLIGHT_ARGS)
+
+## live-e2e-install-atlas: Install the go.mod-pinned Atlas CLI into .run/tools/atlas.
+live-e2e-install-atlas:
+	@set -e; \
+	atlas_version="$$(go list -m -f '{{ .Version }}' ariga.io/atlas)"; \
+	atlas_image="arigaio/atlas:$${atlas_version#v}"; \
+	atlas_container="atlas-install-$$(date +%s)-$$$$"; \
+	mkdir -p .run/tools; \
+	docker rm -f "$${atlas_container}" >/dev/null 2>&1 || true; \
+	docker create --name "$${atlas_container}" "$${atlas_image}" >/dev/null; \
+	trap 'docker rm -f "$${atlas_container}" >/dev/null 2>&1 || true' EXIT; \
+	docker cp "$${atlas_container}:/atlas" .run/tools/atlas; \
+	chmod 0755 .run/tools/atlas; \
+	.run/tools/atlas version
 
 ## ci-live-e2e-evidence: Validate ADR-0058 live E2E evidence manifest fixtures. Set LIVE_E2E_EVIDENCE_FILE to validate a real manifest.
 ci-live-e2e-evidence:

--- a/docs/operations/live-e2e-validation.md
+++ b/docs/operations/live-e2e-validation.md
@@ -28,7 +28,7 @@ stateful resources.
 | KubeVirt-capable cluster | Yes | The cluster must support the provider operations under test |
 | Kubeconfig | Yes | Set `E2E_KUBECONFIG_B64` or place `k8s-admin.yaml` at the repository root |
 | `kubectl` | Yes | Required to resolve context, probe the Kubernetes API server, and prove KubeVirt API discovery |
-| Atlas CLI | Yes | Required for startup migrations; set `ATLAS_EXEC_PATH` or install `atlas` |
+| Atlas CLI | Yes | Required for startup migrations; set `ATLAS_EXEC_PATH`, install `atlas`, or run `make live-e2e-install-atlas` |
 | Node dependencies | Yes | `npm ci --prefix web` |
 | Playwright Chromium | Yes | `cd web && npx playwright install chromium` |
 | Admin bootstrap password | Defaulted | Runner uses `admin/admin` then `E2E_NEW_PASSWORD=admin123` unless overridden |
@@ -106,6 +106,46 @@ bash scripts/run_e2e_live.sh --foreground --no-db-wrapper
 
 The runner builds and starts a local backend server, seeds baseline data, seeds
 API-managed live fixtures, runs low-level E2E fixtures, then starts Playwright.
+
+## Manual GitHub Workflow
+
+After the workflow file is present on the default branch, maintainers can use
+the manual **Live E2E Evidence** GitHub Actions workflow for operator-controlled
+release evidence. It is a `workflow_dispatch` workflow only; it is not required
+CI and does not run for pull requests or normal pushes.
+
+Configure repository or organization secrets before dispatching the workflow:
+
+| Secret | Required | Notes |
+|--------|----------|-------|
+| `E2E_KUBECONFIG_B64` | Yes | Base64-encoded kubeconfig for the disposable validation cluster |
+| `E2E_ADMIN_USERNAME` | No | Overrides the default admin username |
+| `E2E_ADMIN_PASSWORD` | No | Overrides the default initial admin password |
+| `E2E_NEW_PASSWORD` | No | Overrides the default forced-change password |
+
+The workflow inputs are:
+
+| Input | Default | Notes |
+|-------|---------|-------|
+| `mode` | `full` | Use `preflight` for readiness only; use `full` for release evidence |
+| `namespace` | `e2e-live` | Disposable namespace used by the run |
+| `cleanup_namespace_vms` | `true` | Sets `E2E_CLEANUP_NAMESPACE_VMS` to clean up VMs on exit |
+
+The workflow provisions PostgreSQL as a GitHub Actions service, installs the
+go.mod-pinned Atlas CLI version with `make live-e2e-install-atlas`, installs
+frontend dependencies and Playwright Chromium, then runs:
+
+```bash
+bash scripts/run_e2e_live.sh --preflight-only --no-db-wrapper
+# or, for full release evidence:
+bash scripts/run_e2e_live.sh --foreground --no-db-wrapper
+make ci-live-e2e-latest-evidence
+```
+
+It uploads `.run/live-e2e/**` as a workflow artifact with hidden paths enabled
+because the evidence directory is under `.run/`. Use a disposable validation
+cluster and do not target an environment whose logs, resource names, or evidence
+bundle metadata cannot be retained in GitHub Actions artifacts.
 
 ## Targeted Runs
 


### PR DESCRIPTION
## Summary

- Add a manual `workflow_dispatch` workflow for live E2E evidence collection.
- Install the go.mod-pinned Atlas CLI through `make live-e2e-install-atlas` and run live E2E against a PostgreSQL service with operator-provided kubeconfig secrets.
- Document the workflow inputs, required secrets, artifact retention, and the fact that full real-cluster evidence is still required.

## Validation

- `make live-e2e-install-atlas`
- `make ci-parity`
- `make ci-governance`
- `make ci-live-e2e-evidence`
- `make secrets-scan`
- `make pr`

## Issue

Refs #715

This PR does not close #715. The issue should remain open until a `mode=full` live E2E run against a real KubeVirt-capable cluster passes and its evidence bundle is validated.