### PR TITLE
ci(release): verify existing cosign signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,34 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
+          COSIGN_VERIFY_IDENTITY_REGEXP: ^https://github\.com/kv-shepherd/shepherd/\.github/workflows/release\.yml@refs/(heads/main|tags/v.*)$
+          COSIGN_VERIFY_OIDC_ISSUER: https://token.actions.githubusercontent.com
         run: |
+          sign_and_verify() {
+            local image_ref="$1"
+            local output
+
+            if output="$(cosign sign --yes "${image_ref}" 2>&1)"; then
+              printf '%s\n' "${output}"
+            else
+              printf '%s\n' "${output}" >&2
+              if ! grep -Eq "createLogEntryConflict|equivalent entry already exists" <<< "${output}"; then
+                return 1
+              fi
+              echo "Cosign transparency log entry already exists for ${image_ref}; verifying existing signature."
+            fi
+
+            cosign verify "${image_ref}" \
+              --certificate-identity-regexp="${COSIGN_VERIFY_IDENTITY_REGEXP}" \
+              --certificate-oidc-issuer="${COSIGN_VERIFY_OIDC_ISSUER}" \
+              >/dev/null
+          }
+
           while IFS= read -r tag; do
-            echo "Signing ${tag}@${DIGEST}"
-            cosign sign --yes "${tag}@${DIGEST}"
+            [[ -z "${tag}" ]] && continue
+            image_ref="${tag}@${DIGEST}"
+            echo "Signing ${image_ref}"
+            sign_and_verify "${image_ref}"
           done <<< "${TAGS}"
 
   # ── Attach assets to GitHub Release (created by release-please) ──


### PR DESCRIPTION
## Description

Fix the release artifact workflow after v0.1.1-alpha.9 hit a Cosign/Rekor idempotency failure while signing the server image:

- keep signing image references by digest
- verify each signed image with the GitHub Actions OIDC issuer and release workflow identity regex
- treat Rekor `createLogEntryConflict` / equivalent-entry conflicts as recoverable only when `cosign verify` succeeds

This keeps real signing failures blocking while allowing already-recorded transparency log entries to pass verification.

## Related Issue

- Refs N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [ ] I have run `golangci-lint run` and fixed all issues
- [ ] I have run `go test -race ./...` and all tests pass
- [ ] I have added tests that prove my fix/feature works

### Documentation
- [ ] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] Breaking changes are documented with migration guides

### Architecture
- [x] My changes comply with existing ADRs
- [ ] If this introduces a new architectural decision, I have created an ADR

### CI Checks
- [x] No forbidden imports (GORM, Redis, Wire, naked goroutines)
- [x] Transaction boundaries are respected
- [x] K8s calls are outside DB transactions

## Screenshots (if applicable)

N/A

## Labels

- [x] `kind/bug`
- [x] `area/core`
- [x] `priority/high`

## Additional Notes

Local validation:

- `git diff --check`
- YAML parse via Ruby
- `make ci-governance` (includes actionlint/workflow parity, governance checks, hygiene, gitleaks, KubeVirt schema check)

Context7/Sigstore docs confirm keyless signing should verify with the GitHub Actions OIDC issuer and expected workflow identity.

Issue: N/A
release impact: fixes v0.1.1-alpha.9 artifact publishing after release PR #694

By submitting this pull request, I confirm that:
- My contribution is made under the Apache 2.0 license
- All commits are signed off (DCO)